### PR TITLE
Fix symmetric false positives in KG via M_compose

### DIFF
--- a/joint_lm_kg.py
+++ b/joint_lm_kg.py
@@ -88,6 +88,7 @@ class EinsumTransformer(torch.nn.Module):
         # KG object embedding for tokens 0..7.
         self.tok_emb = torch.nn.Parameter(torch.randn(VOCAB, D) * 0.1)
         self.pos_emb = torch.nn.Parameter(torch.randn(SEQ_LEN, D) * 0.1)
+        self.M_compose = torch.nn.Parameter(torch.eye(D) + torch.randn(D, D) * 0.1)
 
         self.Wq = torch.nn.Parameter(torch.randn(N_LAYERS, D, D) * 0.1)
         self.Wk = torch.nn.Parameter(torch.randn(N_LAYERS, D, D) * 0.1)
@@ -142,7 +143,7 @@ def kg_rule_loss(model, T):
     """
     e = F.normalize(model.tok_emb[:N_PEOPLE], dim=1)
     EmbP = torch.einsum("uv,ui,vj->ij", P_true, e, e)
-    EmbGP = EmbP @ EmbP
+    EmbGP = EmbP @ model.M_compose @ EmbP
     scores = torch.einsum("ij,ai,bj->ab", EmbGP, e, e)
     pred = torch.sigmoid(scores / T)
     return F.binary_cross_entropy(pred.clamp(1e-6, 1 - 1e-6), GP_true), pred
@@ -203,7 +204,7 @@ with torch.no_grad():
     print("\nKG embedding-space query (rule applied to learned emb, no LM):")
     e = F.normalize(model.tok_emb[:N_PEOPLE], dim=1)
     EmbP = torch.einsum("uv,ui,vj->ij", P_true, e, e)
-    EmbGP = EmbP @ EmbP
+    EmbGP = EmbP @ model.M_compose @ EmbP
     for x, z in gp_pairs:
         # "who are grandparents of z?" -> contract second index with e[z]
         q = torch.einsum("ij,j->i", EmbGP, e[z])

--- a/train_kg.py
+++ b/train_kg.py
@@ -41,6 +41,7 @@ class TensorLogicKG(torch.nn.Module):
         super().__init__()
         # Learnable per-object embeddings — the ONLY parameters.
         self.emb = torch.nn.Parameter(torch.randn(n_objects, dim) * 0.3)
+        self.M_compose = torch.nn.Parameter(torch.eye(dim) + torch.randn(dim, dim) * 0.1)
         # Embedded relation tensor for Parent (computed from facts each forward pass).
         # We could also make this a parameter; here we ground it in known facts.
 
@@ -57,7 +58,7 @@ class TensorLogicKG(torch.nn.Module):
         # Grandparent(x,z) :- Parent(x,y), Parent(y,z)
         # =>  EmbGP = einsum over shared y of (EmbP) ⋅ (EmbP)
         #     but in embedding space this is just EmbP @ EmbP  (chained einsum)
-        EmbGP = EmbP @ EmbP                                       # [D, D]
+        EmbGP = EmbP @ self.M_compose @ EmbP                      # [D, D]
 
         # Decode: score each (a, b) pair by querying EmbGP with their embeddings.
         # D_pred[a,b] ≈ Grandparent(a, b)
@@ -101,7 +102,7 @@ print("\nQuery in embedding space: 'who are grandparents of 7?'")
 with torch.no_grad():
     e = F.normalize(model.emb, dim=1)
     EmbP = model.parent_relation_tensor(P_true)
-    EmbGP = EmbP @ EmbP
+    EmbGP = EmbP @ model.M_compose @ EmbP
     q = torch.einsum("ij,bj->bi", EmbGP, e[7:8])   # contract 'b' index with node 7
     scores = (e @ q.T).squeeze()
     for i, s in enumerate(scores.tolist()):


### PR DESCRIPTION
This patch introduces a trainable `M_compose` matrix to correct the symmetric false-positives caused by `EmbP @ EmbP`. The update is applied to both `train_kg.py` and `joint_lm_kg.py` and allows the network to learn a better asymmetric composition mechanism for rule inference as noted in the session transcript.

---
*PR created automatically by Jules for task [15981851634872575654](https://jules.google.com/task/15981851634872575654) started by @jwalin-shah*