### PR TITLE
Add parameter sweeps and multiple experiments to demo scripts

### DIFF
--- a/catastrophic_forgetting.py
+++ b/catastrophic_forgetting.py
@@ -127,23 +127,28 @@ for (name, p), g in zip(model_ewc.named_parameters(), grads):
 anchor = {n: p.detach().clone() for n, p in model_ewc.named_parameters()}
 
 # EWC penalty: λ/2 · Σ Fisher_i · (θ_i - θ_i*)²
-LAMBDA = 5000.0
+
+for LAMBDA in [0.0, 100.0, 1000.0, 5000.0, 10000.0]:
+    print(f"\n  --- LAMBDA = {LAMBDA} ---")
+
+    # We must reset the model to the exact anchor state before training Task B
+    model_ewc_clone = make_model()
+    model_ewc_clone.load_state_dict(anchor)
+
+    def ewc_penalty(model):
+        loss = torch.tensor(0.0)
+        for name, p in model.named_parameters():
+            loss = loss + (fisher[name] * (p - anchor[name]) ** 2).sum()
+        return (LAMBDA / 2) * loss
 
 
-def ewc_penalty(model):
-    loss = torch.tensor(0.0)
-    for name, p in model.named_parameters():
-        loss = loss + (fisher[name] * (p - anchor[name]) ** 2).sum()
-    return (LAMBDA / 2) * loss
-
-
-train(model_ewc, task_B_X, task_B_y, ewc_penalty=ewc_penalty)
-acc_A_after_B = accuracy(model_ewc, task_A_X, task_A_y)
-acc_B_after_B = accuracy(model_ewc, task_B_X, task_B_y)
-print(f"  After Task B (with EWC):  acc(A) = {acc_A_after_B:.3f}   "
-      f"acc(B) = {acc_B_after_B:.3f}")
-print(f"  ==> Task A accuracy retained at {acc_A_after_B:.3f} "
-      f"(EWC prevents forgetting)")
+    train(model_ewc_clone, task_B_X, task_B_y, ewc_penalty=ewc_penalty)
+    acc_A_after_B = accuracy(model_ewc_clone, task_A_X, task_A_y)
+    acc_B_after_B = accuracy(model_ewc_clone, task_B_X, task_B_y)
+    print(f"  After Task B (with EWC):  acc(A) = {acc_A_after_B:.3f}   "
+          f"acc(B) = {acc_B_after_B:.3f}")
+    print(f"  ==> Task A accuracy retained at {acc_A_after_B:.3f} "
+          f"(EWC prevents forgetting)")
 
 
 # ============================================================

--- a/joint_lm_kg.py
+++ b/joint_lm_kg.py
@@ -147,76 +147,83 @@ def kg_rule_loss(model, T):
     pred = torch.sigmoid(scores / T)
     return F.binary_cross_entropy(pred.clamp(1e-6, 1 - 1e-6), GP_true), pred
 
-# ============================================================
-# 5. Train
-# ============================================================
-model = EinsumTransformer()
-opt = torch.optim.Adam(model.parameters(), lr=3e-3)
+def run_experiment(BETA):
+    print(f"\n======================================")
+    print(f"Experiment: BETA={BETA}")
+    print(f"======================================")
 
-ALPHA = 1.0   # weight on LM loss
-BETA = 1.0    # weight on KG rule loss
-N_STEPS = 600
+    # ============================================================
+    # 5. Train
+    # ============================================================
+    model = EinsumTransformer()
+    opt = torch.optim.Adam(model.parameters(), lr=3e-3)
 
-print("\nTraining (joint LM + KG, T annealed 1.0 -> 0.05)...")
-for step in range(N_STEPS):
-    # Anneal T
-    T = 1.0 * (0.05 / 1.0) ** (step / max(1, N_STEPS - 1))
+    ALPHA = 1.0   # weight on LM loss
+    N_STEPS = 600
 
-    # LM loss: predict next token
-    logits = model(train_tensor[:, :-1])
-    targets = train_tensor[:, 1:]
-    lm_loss = F.cross_entropy(
-        logits.reshape(-1, VOCAB), targets.reshape(-1), ignore_index=PAD
-    )
+    print("\nTraining (joint LM + KG, T annealed 1.0 -> 0.05)...")
+    for step in range(N_STEPS):
+        # Anneal T
+        T = 1.0 * (0.05 / 1.0) ** (step / max(1, N_STEPS - 1))
 
-    # KG rule loss
-    rule_loss, _ = kg_rule_loss(model, T)
+        # LM loss: predict next token
+        logits = model(train_tensor[:, :-1])
+        targets = train_tensor[:, 1:]
+        lm_loss = F.cross_entropy(
+            logits.reshape(-1, VOCAB), targets.reshape(-1), ignore_index=PAD
+        )
 
-    loss = ALPHA * lm_loss + BETA * rule_loss
-    opt.zero_grad()
-    loss.backward()
-    opt.step()
+        # KG rule loss
+        rule_loss, _ = kg_rule_loss(model, T)
 
-    if step % 100 == 0:
-        print(f"  step {step:3d}  T={T:.3f}  lm={lm_loss.item():.3f}  "
-              f"rule={rule_loss.item():.3f}")
+        loss = ALPHA * lm_loss + BETA * rule_loss
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
 
-# ============================================================
-# 6. Eval
-# ============================================================
-print("\n=== EVAL ===")
-model.eval()
-with torch.no_grad():
-    # 6a. LM-side: ask grandparent questions including HELD-OUT pairs
-    print("\nLM completion of '<gp> <of> z <is> ?' (greedy argmax over person tokens):")
-    for x, z in gp_pairs:
-        prompt = torch.tensor([[BOS, GP, OF, z, IS, PAD]])
-        logits = model(prompt)
-        # Restrict to person tokens (0..7)
-        person_logits = logits[0, -2, :N_PEOPLE]
-        pred = int(person_logits.argmax())
-        seen = "TRAIN" if (x, z) in train_gp else "HELD-OUT"
-        ok = "OK " if pred == x else "MISS"
-        print(f"  {ok} [{seen:8s}] grandparent of {z} -> pred={pred}  truth={x}")
+        if step % 100 == 0:
+            print(f"  step {step:3d}  T={T:.3f}  lm={lm_loss.item():.3f}  "
+                  f"rule={rule_loss.item():.3f}")
 
-    # 6b. KG-side: query in embedding space directly (no transformer)
-    print("\nKG embedding-space query (rule applied to learned emb, no LM):")
-    e = F.normalize(model.tok_emb[:N_PEOPLE], dim=1)
-    EmbP = torch.einsum("uv,ui,vj->ij", P_true, e, e)
-    EmbGP = EmbP @ EmbP
-    for x, z in gp_pairs:
-        # "who are grandparents of z?" -> contract second index with e[z]
-        q = torch.einsum("ij,j->i", EmbGP, e[z])
-        scores = e @ q
-        pred = int(scores.argmax())
-        ok = "OK " if pred == x else "MISS"
-        print(f"  {ok} grandparent of {z} -> pred={pred}  truth={x}")
+    # ============================================================
+    # 6. Eval
+    # ============================================================
+    print("\n=== EVAL ===")
+    model.eval()
+    with torch.no_grad():
+        # 6a. LM-side: ask grandparent questions including HELD-OUT pairs
+        print("\nLM completion of '<gp> <of> z <is> ?' (greedy argmax over person tokens):")
+        for x, z in gp_pairs:
+            prompt = torch.tensor([[BOS, GP, OF, z, IS, PAD]])
+            logits = model(prompt)
+            # Restrict to person tokens (0..7)
+            person_logits = logits[0, -2, :N_PEOPLE]
+            pred = int(person_logits.argmax())
+            seen = "TRAIN" if (x, z) in train_gp else "HELD-OUT"
+            ok = "OK " if pred == x else "MISS"
+            print(f"  {ok} [{seen:8s}] grandparent of {z} -> pred={pred}  truth={x}")
 
-    # 6c. Show the KG rule produces the right boolean matrix (T -> 0)
-    _, pred_GP = kg_rule_loss(model, T=0.05)
-    print("\nFinal predicted Grandparent matrix (threshold 0.5) vs truth:")
-    print((pred_GP > 0.5).int())
-    print("Truth:")
-    print(GP_true.int())
-    acc = ((pred_GP > 0.5).float() == GP_true).float().mean()
-    print(f"Cell-wise accuracy: {acc.item():.3f}")
+        # 6b. KG-side: query in embedding space directly (no transformer)
+        print("\nKG embedding-space query (rule applied to learned emb, no LM):")
+        e = F.normalize(model.tok_emb[:N_PEOPLE], dim=1)
+        EmbP = torch.einsum("uv,ui,vj->ij", P_true, e, e)
+        EmbGP = EmbP @ EmbP
+        for x, z in gp_pairs:
+            # "who are grandparents of z?" -> contract second index with e[z]
+            q = torch.einsum("ij,j->i", EmbGP, e[z])
+            scores = e @ q
+            pred = int(scores.argmax())
+            ok = "OK " if pred == x else "MISS"
+            print(f"  {ok} grandparent of {z} -> pred={pred}  truth={x}")
+
+        # 6c. Show the KG rule produces the right boolean matrix (T -> 0)
+        _, pred_GP = kg_rule_loss(model, T=0.05)
+        print("\nFinal predicted Grandparent matrix (threshold 0.5) vs truth:")
+        print((pred_GP > 0.5).int())
+        print("Truth:")
+        print(GP_true.int())
+        acc = ((pred_GP > 0.5).float() == GP_true).float().mean()
+        print(f"Cell-wise accuracy: {acc.item():.3f}")
+
+for BETA in [0.0, 1.0, 10.0]:
+    run_experiment(BETA)

--- a/throwing.py
+++ b/throwing.py
@@ -61,96 +61,104 @@ class ForwardModel(nn.Module):
         return self.net(force).squeeze(-1)
 
 
-# ============================================================
-# 3. Phase 1 — motor babbling: random throws, build dataset
-# ============================================================
-print("=== PHASE 1: Motor babbling (random throws) ===")
-torch.manual_seed(0)
+def run_experiment(num_trials):
+    print(f"\n======================================")
+    print(f"Experiment: num_trials={num_trials}")
+    print(f"======================================")
 
-dataset = []
-for trial in range(100):
-    f = float(torch.rand(1)) * 30  # forces from 0 to 30
-    d = world_throw(f)
-    dataset.append((f, d))
+    # ============================================================
+    # 3. Phase 1 — motor babbling: random throws, build dataset
+    # ============================================================
+    print("=== PHASE 1: Motor babbling (random throws) ===")
+    torch.manual_seed(0)
 
-forces = torch.tensor([f for f, _ in dataset]).unsqueeze(1)
-distances = torch.tensor([d for _, d in dataset])
-print(f"  Collected {len(dataset)} (force, distance) pairs")
-print(f"  Range: f ∈ [{forces.min():.1f}, {forces.max():.1f}]   "
-      f"d ∈ [{distances.min():.1f}, {distances.max():.1f}]")
+    dataset = []
+    for trial in range(num_trials):
+        f = float(torch.rand(1)) * 30  # forces from 0 to 30
+        d = world_throw(f)
+        dataset.append((f, d))
 
-
-# ============================================================
-# 4. Phase 2 — train the forward model on self-collected data
-# ============================================================
-print("\n=== PHASE 2: Fit forward model (learn 'force → distance') ===")
-model = ForwardModel()
-opt = torch.optim.Adam(model.parameters(), lr=5e-3)
-
-for step in range(800):
-    pred = model(forces)
-    loss = F.mse_loss(pred, distances)
-    opt.zero_grad()
-    loss.backward()
-    opt.step()
-    if step % 200 == 0:
-        print(f"  step {step:3d}  prediction MSE = {loss.item():.3f}")
-
-print(f"  Final MSE: {loss.item():.4f}")
+    forces = torch.tensor([f for f, _ in dataset]).unsqueeze(1)
+    distances = torch.tensor([d for _, d in dataset])
+    print(f"  Collected {len(dataset)} (force, distance) pairs")
+    print(f"  Range: f ∈ [{forces.min():.1f}, {forces.max():.1f}]   "
+          f"d ∈ [{distances.min():.1f}, {distances.max():.1f}]")
 
 
-# ============================================================
-# 5. Phase 3 — planning: 'how hard should I throw to hit target d?'
-#    The agent does NOT know the formula. It uses its learned model.
-#    Plan = gradient descent on force to minimize predicted-distance error.
-# ============================================================
-print("\n=== PHASE 3: Planning (use learned model to hit targets) ===")
+    # ============================================================
+    # 4. Phase 2 — train the forward model on self-collected data
+    # ============================================================
+    print("\n=== PHASE 2: Fit forward model (learn 'force → distance') ===")
+    model = ForwardModel()
+    opt = torch.optim.Adam(model.parameters(), lr=5e-3)
 
-def plan_throw(target_d, model, n_iters=200):
-    """Inverse the forward model via gradient descent on the action."""
-    f = torch.tensor([10.0], requires_grad=True)
-    inner_opt = torch.optim.Adam([f], lr=0.5)
-    for _ in range(n_iters):
-        pred = model(f.unsqueeze(0))
-        err = (pred - target_d) ** 2
-        inner_opt.zero_grad()
-        err.backward()
-        inner_opt.step()
-        with torch.no_grad():
-            f.clamp_(0, 50)  # physical bounds
-    return float(f.detach())
+    for step in range(800):
+        pred = model(forces)
+        loss = F.mse_loss(pred, distances)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        if step % 200 == 0:
+            print(f"  step {step:3d}  prediction MSE = {loss.item():.3f}")
+
+    print(f"  Final MSE: {loss.item():.4f}")
 
 
-# Test on targets the agent has never seen
-test_targets = [10.0, 25.0, 50.0, 75.0]
-print(f"  {'target':>10s}  {'planned f':>10s}  {'actual d':>10s}  {'error':>8s}")
-for target in test_targets:
-    planned_f = plan_throw(target, model)
-    actual_d = world_throw(planned_f)
-    err = abs(actual_d - target)
-    print(f"  {target:>10.1f}  {planned_f:>10.2f}  {actual_d:>10.2f}  {err:>8.2f}")
+    # ============================================================
+    # 5. Phase 3 — planning: 'how hard should I throw to hit target d?'
+    #    The agent does NOT know the formula. It uses its learned model.
+    #    Plan = gradient descent on force to minimize predicted-distance error.
+    # ============================================================
+    print("\n=== PHASE 3: Planning (use learned model to hit targets) ===")
+
+    def plan_throw(target_d, model, n_iters=200):
+        """Inverse the forward model via gradient descent on the action."""
+        f = torch.tensor([10.0], requires_grad=True)
+        inner_opt = torch.optim.Adam([f], lr=0.5)
+        for _ in range(n_iters):
+            pred = model(f.unsqueeze(0))
+            err = (pred - target_d) ** 2
+            inner_opt.zero_grad()
+            err.backward()
+            inner_opt.step()
+            with torch.no_grad():
+                f.clamp_(0, 50)  # physical bounds
+        return float(f.detach())
 
 
-# ============================================================
-# 6. Phase 4 — what concept did the model discover?
-#    Probe the model's internal representation. Is there a 'force-like' axis?
-# ============================================================
-print("\n=== PHASE 4: Probe the learned representation ===")
+    # Test on targets the agent has never seen
+    test_targets = [10.0, 25.0, 50.0, 75.0]
+    print(f"  {'target':>10s}  {'planned f':>10s}  {'actual d':>10s}  {'error':>8s}")
+    for target in test_targets:
+        planned_f = plan_throw(target, model)
+        actual_d = world_throw(planned_f)
+        err = abs(actual_d - target)
+        print(f"  {target:>10.1f}  {planned_f:>10.2f}  {actual_d:>10.2f}  {err:>8.2f}")
 
-# Run a sweep of forces through the first hidden layer
-test_forces = torch.linspace(0, 30, 50).unsqueeze(1)
-with torch.no_grad():
-    h1 = F.gelu(model.net[0](test_forces))   # [50, 32]
 
-# Find the hidden unit most correlated with force (the discovered "force" axis)
-correlations = torch.tensor([
-    float(torch.corrcoef(torch.stack([h1[:, k], test_forces.squeeze()]))[0, 1])
-    for k in range(h1.shape[1])
-])
-best_unit = int(correlations.abs().argmax())
-print(f"  Hidden unit {best_unit} has correlation {correlations[best_unit]:.3f} with input force.")
-print(f"  This unit is the model's emergent 'force magnitude' representation.")
-print(f"  (We never told it about force — it discovered the most predictive axis.)")
+    # ============================================================
+    # 6. Phase 4 — what concept did the model discover?
+    #    Probe the model's internal representation. Is there a 'force-like' axis?
+    # ============================================================
+    print("\n=== PHASE 4: Probe the learned representation ===")
+
+    # Run a sweep of forces through the first hidden layer
+    test_forces = torch.linspace(0, 30, 50).unsqueeze(1)
+    with torch.no_grad():
+        h1 = F.gelu(model.net[0](test_forces))   # [50, 32]
+
+    # Find the hidden unit most correlated with force (the discovered "force" axis)
+    correlations = torch.tensor([
+        float(torch.corrcoef(torch.stack([h1[:, k], test_forces.squeeze()]))[0, 1])
+        for k in range(h1.shape[1])
+    ])
+    best_unit = int(correlations.abs().argmax())
+    print(f"  Hidden unit {best_unit} has correlation {correlations[best_unit]:.3f} with input force.")
+    print(f"  This unit is the model's emergent 'force magnitude' representation.")
+    print(f"  (We never told it about force — it discovered the most predictive axis.)")
+
+for num_trials in [10, 50, 100, 500]:
+    run_experiment(num_trials)
 
 
 # ============================================================

--- a/train_kg.py
+++ b/train_kg.py
@@ -34,7 +34,6 @@ for i in range(N):
             print(f"  Grandparent({i}, {j})")
 
 # ---------- model ----------
-D = 16  # embedding dim
 
 class TensorLogicKG(torch.nn.Module):
     def __init__(self, n_objects, dim):
@@ -66,44 +65,52 @@ class TensorLogicKG(torch.nn.Module):
         # Apply temperature-controlled sigmoid (Section 5, eq. for σ(x,T))
         return torch.sigmoid(scores / T)
 
-model = TensorLogicKG(N, D)
-opt = torch.optim.Adam(model.parameters(), lr=0.05)
+def run_experiment(D, lr):
+    print(f"\n======================================")
+    print(f"Experiment: D={D}, lr={lr}")
+    print(f"======================================")
+    model = TensorLogicKG(N, D)
+    opt = torch.optim.Adam(model.parameters(), lr=lr)
 
-# ---------- training loop ----------
-print("\nTraining...")
-for step in range(400):
-    pred = model(P_true)
-    loss = F.binary_cross_entropy(pred.clamp(1e-6, 1 - 1e-6), GP_true)
-    opt.zero_grad()
-    loss.backward()
-    opt.step()
-    if step % 50 == 0:
-        with torch.no_grad():
-            acc = ((pred > 0.5).float() == GP_true).float().mean()
-            print(f"  step {step:3d}  loss={loss.item():.4f}  acc={acc.item():.3f}")
+    # ---------- training loop ----------
+    print("\nTraining...")
+    for step in range(400):
+        pred = model(P_true)
+        loss = F.binary_cross_entropy(pred.clamp(1e-6, 1 - 1e-6), GP_true)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        if step % 50 == 0:
+            with torch.no_grad():
+                acc = ((pred > 0.5).float() == GP_true).float().mean()
+                print(f"  step {step:3d}  loss={loss.item():.4f}  acc={acc.item():.3f}")
 
-# ---------- evaluate ----------
-print("\nFinal predictions (threshold 0.5):")
-with torch.no_grad():
-    pred = model(P_true)
-    for i in range(N):
-        for j in range(N):
-            p = pred[i, j].item()
-            t = GP_true[i, j].item()
-            if p > 0.5 or t > 0.5:
-                mark = "OK " if (p > 0.5) == (t > 0.5) else "MISS"
-                print(f"  {mark} ({i},{j})  pred={p:.2f}  true={int(t)}")
+    # ---------- evaluate ----------
+    print("\nFinal predictions (threshold 0.5):")
+    with torch.no_grad():
+        pred = model(P_true)
+        for i in range(N):
+            for j in range(N):
+                p = pred[i, j].item()
+                t = GP_true[i, j].item()
+                if p > 0.5 or t > 0.5:
+                    mark = "OK " if (p > 0.5) == (t > 0.5) else "MISS"
+                    print(f"  {mark} ({i},{j})  pred={p:.2f}  true={int(t)}")
 
-# ---------- the "reasoning in embedding space" test ----------
-# Ask: who are the grandparents of node 7?  (Truth: 2, since 2->5->7)
-# Do it WITHOUT touching the boolean tensors — only embeddings.
-print("\nQuery in embedding space: 'who are grandparents of 7?'")
-with torch.no_grad():
-    e = F.normalize(model.emb, dim=1)
-    EmbP = model.parent_relation_tensor(P_true)
-    EmbGP = EmbP @ EmbP
-    q = torch.einsum("ij,bj->bi", EmbGP, e[7:8])   # contract 'b' index with node 7
-    scores = (e @ q.T).squeeze()
-    for i, s in enumerate(scores.tolist()):
-        print(f"  candidate {i}: score={s:.3f}")
-    print(f"  argmax = {int(scores.argmax())}  (truth: 2)")
+    # ---------- the "reasoning in embedding space" test ----------
+    # Ask: who are the grandparents of node 7?  (Truth: 2, since 2->5->7)
+    # Do it WITHOUT touching the boolean tensors — only embeddings.
+    print("\nQuery in embedding space: 'who are grandparents of 7?'")
+    with torch.no_grad():
+        e = F.normalize(model.emb, dim=1)
+        EmbP = model.parent_relation_tensor(P_true)
+        EmbGP = EmbP @ EmbP
+        q = torch.einsum("ij,bj->bi", EmbGP, e[7:8])   # contract 'b' index with node 7
+        scores = (e @ q.T).squeeze()
+        for i, s in enumerate(scores.tolist()):
+            print(f"  candidate {i}: score={s:.3f}")
+        print(f"  argmax = {int(scores.argmax())}  (truth: 2)")
+
+for D in [4, 8, 16]:
+    for lr in [0.01, 0.05, 0.1]:
+        run_experiment(D, lr)

--- a/transitive_closure.py
+++ b/transitive_closure.py
@@ -42,10 +42,11 @@ print(deductive.int())
 
 # --- Mode 2: T>0, sigmoid => analogical / soft reasoning
 #     Same equation, just relaxed nonlinearity. Values become "belief strengths".
-print("\n=== Analogical (sigmoid, T=0.5) ===")
-T = 0.5
-analogical = closure(lambda x: torch.sigmoid(x / T))
-print(analogical.round(decimals=2))
+for T in [0.1, 0.5, 1.0, 2.0, 10.0]:
+    print(f"\n=== Analogical (sigmoid, T={T}) ===")
+    # Using default parameter binding in lambda to avoid late binding issue in loops
+    analogical = closure((lambda T_val: lambda x: torch.sigmoid(x / T_val))(T))
+    print(analogical.round(decimals=2))
 
 # --- Mode 3: embedding-space sanity check
 #     Represent each node as a unit vector. Edge becomes a superposition of


### PR DESCRIPTION
Updated `transitive_closure.py`, `train_kg.py`, `throwing.py`, `joint_lm_kg.py`, and `catastrophic_forgetting.py` to loop over key hyperparameters (temperature, embedding dimensions, learning rates, number of trials, lambda penalties) rather than using single hardcoded values. Wrapped logic in experiment functions to isolate state and prevent cross-contamination between test runs.

---
*PR created automatically by Jules for task [10948802165664485734](https://jules.google.com/task/10948802165664485734) started by @jwalin-shah*