### PR TITLE
Add QuickSilver zero-knowledge proof system implementation

### DIFF
--- a/demos/lpn_vole_demo.py
+++ b/demos/lpn_vole_demo.py
@@ -1,0 +1,91 @@
+"""LPN-based VOLE extension demo.
+
+Replaces the trusted dealer in the main protocol with a pseudorandom
+correlation generator: a sparse base correlation gets locally
+expanded to a long pseudorandom one via a public LPN matrix.
+
+The output VOLE is a drop-in for ``trusted_dealer_setup`` -- the
+ZK proof code does not change.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import time
+
+from quicksilver.circuit import Circuit
+from quicksilver.field import F
+from quicksilver.lpn_vole import LpnParams, lpn_vole_extend
+from quicksilver.protocol import prove, verify
+
+
+def demo_drop_in_replacement() -> None:
+    print("=" * 64)
+    print("Demo: LPN-extended VOLE replaces the trusted dealer")
+    print("=" * 64)
+    # Same factorisation circuit as the original demo.
+    p, q = 1_000_003, 999_983
+    N = p * q
+    c = Circuit()
+    pw = c.input()
+    qw = c.input()
+    c.assert_eq(c.mul(pw, qw), N)
+    print(f"  circuit needs {c.vole_count()} VOLE elements")
+
+    params = LpnParams.default(n_out=c.vole_count())
+    print(f"  LPN params: k_base={params.k_base} (length of base correlation),")
+    print(f"              t={params.t_weight} (Hamming weight of base error)")
+    t0 = time.time()
+    p_share, v_share = lpn_vole_extend(params)
+    setup_dt = (time.time() - t0) * 1000
+    print(f"  LPN extension: {setup_dt:.1f} ms")
+
+    msg1, batched = prove(c, [p, q], p_share)
+    chi = F.rand_nonzero()
+    msg2 = batched(chi)
+    ok = verify(c, v_share, msg1, chi, msg2)
+    print(f"  verifier accepts: {ok}\n")
+    assert ok
+
+
+def demo_pseudorandomness() -> None:
+    print("=" * 64)
+    print("Demo: u_base is sparse; u_out is indistinguishable from random")
+    print("=" * 64)
+    n = 64
+    params = LpnParams.default(n_out=n)
+    p_share, _ = lpn_vole_extend(params)
+    # Base would have been H · sparse, but we never expose it; we can show
+    # the OUTPUT u looks unstructured.
+    zeros = sum(1 for x in p_share.u if x == 0)
+    small = sum(1 for x in p_share.u if x < (1 << 64))  # very biased towards small
+    print(f"  output u length:        {len(p_share.u)}")
+    print(f"  zeros in u:             {zeros}  (expect ~ 0)")
+    print(f"  values < 2^64 in u:     {small} of {n}  (expect ~ 0 by chance)")
+    print(f"  first u entries:        {[hex(x)[:18] for x in p_share.u[:3]]}")
+    print()
+
+
+def demo_scaling() -> None:
+    print("=" * 64)
+    print("Demo: setup time vs output VOLE length")
+    print("=" * 64)
+    print(f"  {'n_out':>8} {'k_base':>8} {'setup(ms)':>12}")
+    for n in (32, 128, 512, 2048):
+        params = LpnParams.default(n_out=n)
+        t0 = time.time()
+        lpn_vole_extend(params)
+        dt = (time.time() - t0) * 1000
+        print(f"  {n:>8} {params.k_base:>8} {dt:>12.1f}")
+    print()
+
+
+if __name__ == "__main__":
+    demo_drop_in_replacement()
+    demo_pseudorandomness()
+    demo_scaling()
+    print("All LPN-VOLE demos passed.")

--- a/demos/quicksilver_boolean_demo.py
+++ b/demos/quicksilver_boolean_demo.py
@@ -1,0 +1,167 @@
+"""Boolean QuickSilver demo.
+
+Same protocol as the prime-field version, but wires are bits and
+IT-MAC tags live in GF(2^128). Three vignettes:
+
+1. Knowledge of factors of a 16-bit number, computed bit-by-bit
+   inside a schoolbook 8x8 multiplier.
+2. Knowledge of an XOR-preimage: prove a SHA-like mixing function
+   maps a secret ``x`` to a public ``y``, with no information about
+   ``x`` revealed.
+3. Boolean-circuit scaling: doubles in cost per added bit of width.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import time
+from typing import List
+
+from quicksilver.boolean import BoolCircuit, run
+
+
+def _ripple_adder(c: BoolCircuit, a_bits, b_bits) -> List[int]:
+    """Bitwise ripple-carry adder. Output has len(a_bits)+1 bits."""
+    out = []
+    carry = c.const(0)
+    for a, b in zip(a_bits, b_bits):
+        axb = c.xor(a, b)
+        s = c.xor(axb, carry)
+        carry = c.or_(c.and_(a, b), c.and_(carry, axb))
+        out.append(s)
+    out.append(carry)
+    return out
+
+
+def _multiplier(c: BoolCircuit, x_bits, y_bits) -> List[int]:
+    """Schoolbook unsigned multiplier. Output is len(x)+len(y) bits."""
+    n_x, n_y = len(x_bits), len(y_bits)
+    columns: list[list[int]] = [[] for _ in range(n_x + n_y)]
+    for i, x in enumerate(x_bits):
+        for j, y in enumerate(y_bits):
+            columns[i + j].append(c.and_(x, y))
+    out_bits = []
+    for col in range(n_x + n_y):
+        bucket = columns[col]
+        if not bucket:
+            out_bits.append(c.const(0))
+            continue
+        acc = bucket[0]
+        for x in bucket[1:]:
+            s = c.xor(acc, x)
+            carry = c.and_(acc, x)
+            acc = s
+            if col + 1 < n_x + n_y:
+                columns[col + 1].append(carry)
+        out_bits.append(acc)
+    return out_bits
+
+
+def _bits_of(x: int, n: int) -> List[int]:
+    return [(x >> i) & 1 for i in range(n)]
+
+
+def _assert_eq_int(c: BoolCircuit, bits, expected: int) -> None:
+    for i, b in enumerate(bits):
+        c.assert_eq_const(b, (expected >> i) & 1)
+
+
+def demo_factorisation_8bit() -> None:
+    print("=" * 64)
+    print("Demo 1: knowledge of 8-bit factors, computed in a boolean multiplier")
+    print("=" * 64)
+    p, q = 13, 17
+    N = p * q
+    print(f"  Public N = {N} = {p} x {q}")
+    print(f"  Witness: bit decomposition of p and q (8 bits each)")
+
+    c = BoolCircuit()
+    p_bits = [c.input() for _ in range(8)]
+    q_bits = [c.input() for _ in range(8)]
+    out = _multiplier(c, p_bits, q_bits)
+    _assert_eq_int(c, out, N)
+
+    print(f"  circuit: {c.num_inputs} inputs, {c.num_ands} AND gates, "
+          f"{c.num_asserts} asserts")
+    print(f"  VOLE elements consumed: {c.vole_count()}")
+
+    witness = _bits_of(p, 8) + _bits_of(q, 8)
+    t0 = time.time()
+    ok = run(c, witness)
+    print(f"  verifier accepts: {ok}   (in {(time.time() - t0)*1000:.1f} ms)\n")
+    assert ok
+
+
+def demo_xor_preimage() -> None:
+    print("=" * 64)
+    print("Demo 2: knowledge of XOR-mixer preimage")
+    print("=" * 64)
+    # A toy mixing function: y = x XOR (x rotated left by 3) XOR constant.
+    # Prover knows x; verifier knows y.
+    n = 16
+    K = 0xA5A5
+    x = 0x4321
+    y = x ^ ((x << 3 | x >> (n - 3)) & ((1 << n) - 1)) ^ K
+    print(f"  Public y = 0x{y:04X}")
+    print(f"  Mixer: y = x XOR rot_left(x, 3) XOR 0x{K:04X}")
+    print(f"  (Secret x = 0x{x:04X})")
+
+    c = BoolCircuit()
+    x_bits = [c.input() for _ in range(n)]
+    rot_bits = [x_bits[(i - 3) % n] for i in range(n)]
+    out_bits = []
+    for i in range(n):
+        s = c.xor(x_bits[i], rot_bits[i])
+        s = c.xor_const(s, (K >> i) & 1)
+        out_bits.append(s)
+    _assert_eq_int(c, out_bits, y)
+
+    print(f"  circuit: {c.num_inputs} inputs, {c.num_ands} AND gates "
+          f"(all linear -> 0 ANDs)")
+
+    witness = _bits_of(x, n)
+    t0 = time.time()
+    ok = run(c, witness)
+    print(f"  verifier accepts: {ok}   (in {(time.time() - t0)*1000:.1f} ms)\n")
+    assert ok
+
+
+def demo_scaling() -> None:
+    print("=" * 64)
+    print("Demo 3: multiplier scaling -- (n_bit_factor, AND gates, time)")
+    print("=" * 64)
+    print(f"  {'bits':>5} {'inputs':>8} {'ANDs':>6} {'asserts':>8} {'time(ms)':>10}")
+    for nbits in (4, 6, 8, 10):
+        c = BoolCircuit()
+        p_bits = [c.input() for _ in range(nbits)]
+        q_bits = [c.input() for _ in range(nbits)]
+        out = _multiplier(c, p_bits, q_bits)
+        # Pick small primes that fit.
+        if nbits == 4:
+            P, Q = 3, 5
+        elif nbits == 6:
+            P, Q = 7, 11
+        elif nbits == 8:
+            P, Q = 13, 17
+        else:
+            P, Q = 31, 29
+        _assert_eq_int(c, out, P * Q)
+        witness = _bits_of(P, nbits) + _bits_of(Q, nbits)
+        t0 = time.time()
+        ok = run(c, witness)
+        dt = (time.time() - t0) * 1000
+        assert ok
+        print(f"  {nbits:>5} {c.num_inputs:>8} {c.num_ands:>6} "
+              f"{c.num_asserts:>8} {dt:>10.1f}")
+    print()
+
+
+if __name__ == "__main__":
+    demo_factorisation_8bit()
+    demo_xor_preimage()
+    demo_scaling()
+    print("All boolean QuickSilver demos passed.")

--- a/demos/quicksilver_demo.py
+++ b/demos/quicksilver_demo.py
@@ -1,0 +1,133 @@
+"""QuickSilver ZK demo.
+
+Three vignettes that exercise the full prover/verifier loop:
+
+1. Knowledge of factors: prover convinces verifier they know p, q with
+   p * q == N, without revealing p or q.
+2. Knowledge of a cubic root: x^3 + x + 5 == y for a specified y.
+3. Polynomial-extension demo: prove three quadratic constraints with a
+   single batched degree-2 check, no extra circuit wires.
+
+Run from the repo root:
+
+    python demos/quicksilver_demo.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import time
+
+from quicksilver.circuit import Circuit
+from quicksilver.field import F
+from quicksilver.itmac import prover_commit, verifier_receive
+from quicksilver.polynomial import Polynomial, run_poly_check
+from quicksilver.protocol import run
+from quicksilver.vole import trusted_dealer_setup
+
+
+def demo_factorisation() -> None:
+    print("=" * 60)
+    print("Demo 1: knowledge of factorisation")
+    print("=" * 60)
+    p, q = 1_000_003, 999_983  # both prime
+    N = p * q
+    print(f"  Public N = {N}")
+    print(f"  Prover claims to know p, q with p * q = N")
+    print(f"  (Secret witness: p={p}, q={q})\n")
+
+    c = Circuit()
+    pw = c.input()
+    qw = c.input()
+    prod = c.mul(pw, qw)
+    c.assert_eq(prod, N)
+
+    print(f"  Circuit: {len(c.gates)} gates, {c.num_inputs} inputs, "
+          f"{c.num_muls} mul gates, {c.num_asserts} asserts")
+    print(f"  VOLE elements consumed: {c.vole_count()}")
+
+    t0 = time.time()
+    ok = run(c, [p, q])
+    dt = (time.time() - t0) * 1000
+    print(f"\n  Verifier accepts: {ok}   (in {dt:.2f} ms)\n")
+    assert ok
+
+    # Soundness sanity: try to convince with wrong factors.
+    print("  Sanity: try the same with a wrong witness (p=2, q=3) ...")
+    try:
+        run(c, [2, 3])
+        print("    UNEXPECTED: ran to completion (should have failed!)")
+    except ValueError as e:
+        print(f"    rejected at assertion-zero check: {e}")
+    print()
+
+
+def demo_cubic_root() -> None:
+    print("=" * 60)
+    print("Demo 2: knowledge of x with x^3 + x + 5 = y")
+    print("=" * 60)
+    x = 17
+    y = (x ** 3 + x + 5) % F.p
+    print(f"  Public y = {y}")
+    print(f"  (Secret witness: x = {x})\n")
+
+    c = Circuit()
+    xw = c.input()
+    x2 = c.mul(xw, xw)
+    x3 = c.mul(x2, xw)
+    s = c.add(x3, xw)
+    s = c.add_const(s, 5)
+    c.assert_eq(s, y)
+
+    print(f"  Circuit: {c.num_muls} mul gates, {c.num_inputs} private inputs")
+    t0 = time.time()
+    ok = run(c, [x])
+    dt = (time.time() - t0) * 1000
+    print(f"  Verifier accepts: {ok}   (in {dt:.2f} ms)\n")
+    assert ok
+
+
+def demo_polynomial_extension() -> None:
+    print("=" * 60)
+    print("Demo 3: degree-d polynomial check (no extra mul gates)")
+    print("=" * 60)
+    # Prove three independent quadratic relations on three committed
+    # values, all batched into a single degree-2 polynomial check.
+    a, b, c = 5, 7, 11
+    polys = [
+        Polynomial(terms=((1, (0, 0)), (-(a * a), ()))),
+        Polynomial(terms=((1, (1, 1)), (-(b * b), ()))),
+        Polynomial(terms=((1, (2, 2)), (-(c * c), ()))),
+    ]
+    print(f"  Constraints (all on committed wires):")
+    for w, val in zip("abc", (a, b, c)):
+        print(f"    wire_{w}^2 == {val * val}")
+    print()
+
+    p_share, v_share = trusted_dealer_setup(3)
+    delta = v_share.delta
+    pwires, vwires = {}, {}
+    for i, val in enumerate((a, b, c)):
+        pw, d = prover_commit(val, p_share.u[i], p_share.v[i])
+        vw = verifier_receive(d, v_share.w[i], delta)
+        pwires[i] = pw
+        vwires[i] = vw
+
+    t0 = time.time()
+    ok = run_poly_check(polys, pwires, vwires, delta)
+    dt = (time.time() - t0) * 1000
+    print(f"  Batched check accepts: {ok}   (in {dt:.2f} ms)")
+    print(f"  Communication: d = 2 field elements, regardless of how many\n"
+          f"  constraints share that degree.\n")
+    assert ok
+
+
+if __name__ == "__main__":
+    demo_factorisation()
+    demo_cubic_root()
+    demo_polynomial_extension()
+    print("All demos passed.")

--- a/demos/zk_einsum.py
+++ b/demos/zk_einsum.py
@@ -1,0 +1,146 @@
+"""ZK proofs of tensor-logic einsum identities.
+
+The same einsum-as-rule-head story behind ``transitive_closure.py`` and
+``train_kg.py`` becomes a ZK frontend: any rule head expressible as an
+einsum is automatically a QuickSilver circuit. This demo covers the
+three canonical shapes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import time
+
+from quicksilver.circuit import Circuit
+from quicksilver.einsum import (
+    alloc_constant_tensor,
+    alloc_input_tensor,
+    assert_einsum_equals,
+    evaluate_einsum,
+    flatten_row_major,
+)
+from quicksilver.protocol import run as run_protocol
+
+
+def _prove(circuit, witness, tag):
+    t0 = time.time()
+    ok = run_protocol(circuit, witness)
+    dt = (time.time() - t0) * 1000
+    print(f"  {tag}: verifier accepts: {ok}   ({dt:.1f} ms)")
+    print(f"  circuit: {circuit.num_inputs} inputs, "
+          f"{circuit.num_muls} muls, {circuit.num_asserts} asserts")
+    assert ok
+
+
+def demo_matmul() -> None:
+    print("=" * 64)
+    print("Demo 1: prove A @ B = C with A and B private")
+    print("=" * 64)
+    A = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    B = [[9, 8, 7], [6, 5, 4], [3, 2, 1]]
+    C = evaluate_einsum("ij,jk->ik", [A, B])
+    print(f"  3x3 matmul; public output:")
+    for i in range(3):
+        print(f"    {C[i*3:(i+1)*3]}")
+    c = Circuit()
+    Aw = alloc_input_tensor(c, (3, 3))
+    Bw = alloc_input_tensor(c, (3, 3))
+    assert_einsum_equals(c, "ij,jk->ik", [Aw, Bw], [(3, 3), (3, 3)], C)
+    witness = flatten_row_major(A) + flatten_row_major(B)
+    _prove(c, witness, "matmul")
+    print()
+
+
+def demo_grandparent_rule() -> None:
+    print("=" * 64)
+    print("Demo 2: Datalog rule  Grandparent(x, z) :- Parent(x, y), Parent(y, z)")
+    print("        compiled directly from the einsum 'xy,yz->xz'")
+    print("=" * 64)
+    # Family tree: 0 is parent of 1 and 3; 1 of 2; 3 of 2.
+    # So 0 is grandparent of 2 (twice, via 1 and via 3).
+    P = [
+        [0, 1, 0, 1],
+        [0, 0, 1, 0],
+        [0, 0, 0, 0],
+        [0, 0, 1, 0],
+    ]
+    G = evaluate_einsum("xy,yz->xz", [P, P])
+    print(f"  4-person Parent matrix is private to the prover")
+    print(f"  public Grandparent matrix:")
+    for i in range(4):
+        print(f"    {G[i*4:(i+1)*4]}")
+    print(f"  (G[0][2] = {G[2]} -> two paths from 0 to 2)")
+    c = Circuit()
+    Pw1 = alloc_input_tensor(c, (4, 4))
+    Pw2 = alloc_input_tensor(c, (4, 4))
+    # Same tensor used twice; we force the prover to commit twice and
+    # the verifier doesn't know they're the same. To prove they really
+    # are the same matrix, add equality assertions.
+    assert_einsum_equals(c, "xy,yz->xz", [Pw1, Pw2], [(4, 4), (4, 4)], G)
+    for w1, w2 in zip(Pw1, Pw2):
+        c.assert_zero(c.sub(w1, w2))
+    witness = flatten_row_major(P) + flatten_row_major(P)
+    _prove(c, witness, "grandparent")
+    print()
+
+
+def demo_one_step_closure() -> None:
+    print("=" * 64)
+    print("Demo 3: one step of  Path = step(Edge + einsum('xy,yz->xz', Path, Edge))")
+    print("=" * 64)
+    # Reachability after exactly two hops on a 5-node graph.
+    Edge = [
+        [0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 1],
+        [0, 0, 0, 1, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+    ]
+    # After one step, Path = Edge.
+    Path1 = Edge
+    # After two steps (no step nonlinearity, integer counting):
+    # Path2 = Edge + Path1 @ Edge
+    PathEdge = evaluate_einsum("xy,yz->xz", [Path1, Edge])
+    Edge_flat = flatten_row_major(Edge)
+    Path2 = [e + pe for e, pe in zip(Edge_flat, PathEdge)]
+    print("  Edge (private to prover):")
+    for i in range(5):
+        print(f"    {Edge[i]}")
+    print("  Public claim: Path after 2 hops =")
+    for i in range(5):
+        print(f"    {Path2[i*5:(i+1)*5]}")
+
+    c = Circuit()
+    Ew1 = alloc_input_tensor(c, (5, 5))
+    Ew2 = alloc_input_tensor(c, (5, 5))
+    # Compile the matmul piece into the circuit; result is wires
+    # accessible by output multi-index.
+    from quicksilver.einsum import compile_einsum
+
+    matmul_out = compile_einsum(
+        c, "xy,yz->xz", [Ew1, Ew2], [(5, 5), (5, 5)]
+    )
+    # Add the elementwise sum  Path2[x][z] = Edge[x][z] + matmul[x][z]
+    # and assert against public Path2.
+    for (x, z), wid in matmul_out.items():
+        flat = x * 5 + z
+        edge_w = Ew1[flat]  # Edge appears twice; constrain Ew1 == Ew2 elementwise
+        sum_w = c.add(edge_w, wid)
+        c.assert_eq(sum_w, int(Path2[flat]))
+    for w1, w2 in zip(Ew1, Ew2):
+        c.assert_zero(c.sub(w1, w2))
+
+    witness = flatten_row_major(Edge) * 2
+    _prove(c, witness, "one closure step")
+    print()
+
+
+if __name__ == "__main__":
+    demo_matmul()
+    demo_grandparent_rule()
+    demo_one_step_closure()
+    print("All einsum-ZK demos passed.")

--- a/demos/zk_graph_reachability.py
+++ b/demos/zk_graph_reachability.py
@@ -1,0 +1,201 @@
+"""Zero-knowledge proof of graph reachability via the tensor-logic einsum.
+
+Bridges ``transitive_closure.py`` (the boolean closure recurrence
+``Path = step(Edge + Path @ Edge)``) and ``quicksilver/`` (VOLE-based
+ZK proofs). The same einsum that defines the transitive closure
+becomes the constraint that the prover satisfies inside QuickSilver.
+
+Statement proved:
+
+    "I know an n-vertex graph G and a length-k walk through G from
+     public source s to public target t."
+
+Verifier learns nothing about G or about the intermediate vertices of
+the walk beyond what (n, k, s, t) already imply.
+
+Run from the repo root:
+
+    python demos/zk_graph_reachability.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import time
+from collections import deque
+from typing import List, Optional, Tuple
+
+from quicksilver.field import F
+from quicksilver.protocol import prove, verify, run as run_protocol
+from quicksilver.vole import trusted_dealer_setup
+from quicksilver.zk_reachability import assemble_witness, build_circuit
+
+
+def bfs_path(E: List[List[int]], source: int, target: int) -> Optional[List[int]]:
+    """Return the shortest s->t path in E, or None if unreachable."""
+    n = len(E)
+    parent = {source: None}
+    q = deque([source])
+    while q:
+        u = q.popleft()
+        if u == target:
+            path = []
+            while u is not None:
+                path.append(u)
+                u = parent[u]
+            return list(reversed(path))
+        for v in range(n):
+            if E[u][v] and v not in parent:
+                parent[v] = u
+                q.append(v)
+    return None
+
+
+def random_dag(n: int, seed: int = 0) -> List[List[int]]:
+    """Build a random small DAG with n vertices."""
+    import random
+
+    rng = random.Random(seed)
+    E = [[0] * n for _ in range(n)]
+    for u in range(n):
+        for v in range(u + 1, n):
+            # Slightly denser than random so reachability is interesting.
+            if rng.random() < 0.45:
+                E[u][v] = 1
+    return E
+
+
+def show_graph(E: List[List[int]], path: List[int]) -> None:
+    n = len(E)
+    print(f"  graph (private to prover): {n} vertices, "
+          f"{sum(sum(r) for r in E)} edges")
+    edges_on_path = {(path[i], path[i + 1]) for i in range(len(path) - 1)}
+    print("    adjacency matrix (* = edge on the chosen walk):")
+    for i in range(n):
+        row = ""
+        for j in range(n):
+            if E[i][j]:
+                row += " *" if (i, j) in edges_on_path else " 1"
+            else:
+                row += " ."
+        print(f"      {i}: {row}")
+    print(f"  walk:    {' -> '.join(map(str, path))}")
+
+
+def demo_basic() -> None:
+    print("=" * 64)
+    print("Demo: ZK reachability on an 8-vertex random DAG")
+    print("=" * 64)
+    n = 8
+    E = random_dag(n, seed=1)
+    source, target = 0, n - 1
+    path = bfs_path(E, source, target)
+    if path is None:
+        # Add a guaranteed path so the demo is reproducible.
+        for u, v in zip(range(n - 1), range(1, n)):
+            E[u][v] = 1
+        path = list(range(n))
+    k = len(path) - 1
+    show_graph(E, path)
+
+    rc = build_circuit(n=n, k=k, source=source, target=target)
+    c = rc.circuit
+    print(f"\n  circuit: {c.num_inputs} private inputs, "
+          f"{c.num_muls} multiplication gates, {c.num_asserts} assertions")
+    print(f"  VOLE elements consumed: {c.vole_count()}")
+
+    witness = assemble_witness(rc, E, path)
+    t0 = time.time()
+    ok = run_protocol(c, witness)
+    dt = (time.time() - t0) * 1000
+    print(f"\n  verifier accepts: {ok}   (in {dt:.1f} ms)\n")
+    assert ok
+
+
+def demo_walk_through_cycle() -> None:
+    print("=" * 64)
+    print("Demo: walk that revisits vertices through a cycle")
+    print("=" * 64)
+    # 4-vertex cycle with a tail to a target.
+    n = 4
+    E = [[0] * n for _ in range(n)]
+    for u, v in [(0, 1), (1, 2), (2, 0), (2, 3)]:
+        E[u][v] = 1
+    source, target = 0, 3
+    path = [0, 1, 2, 0, 1, 2, 3]
+    k = len(path) - 1
+    show_graph(E, path)
+
+    rc = build_circuit(n=n, k=k, source=source, target=target)
+    c = rc.circuit
+    print(f"\n  circuit: {c.num_muls} mul gates, {c.num_asserts} asserts, "
+          f"{c.vole_count()} VOLE elements")
+
+    witness = assemble_witness(rc, E, path)
+    t0 = time.time()
+    ok = run_protocol(c, witness)
+    print(f"  verifier accepts: {ok}   (in {(time.time() - t0)*1000:.1f} ms)\n")
+    assert ok
+
+
+def demo_soundness_tampering() -> None:
+    print("=" * 64)
+    print("Demo: cheating prover who tampers the batched check is rejected")
+    print("=" * 64)
+    n = 6
+    E = [[0] * n for _ in range(n)]
+    for u, v in [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]:
+        E[u][v] = 1
+    rc = build_circuit(n=n, k=5, source=0, target=5)
+    witness = assemble_witness(rc, E, [0, 1, 2, 3, 4, 5])
+
+    p_share, v_share = trusted_dealer_setup(rc.circuit.vole_count())
+    msg1, batched = prove(rc.circuit, witness, p_share)
+    chi = F.rand_nonzero()
+    msg2 = batched(chi)
+
+    # Honest path: verifier accepts.
+    print(f"  honest run accepts: {verify(rc.circuit, v_share, msg1, chi, msg2)}")
+
+    # Tampered path: flip one bit of the U component of the batched check.
+    from quicksilver.protocol import BatchedCheck
+
+    bad = BatchedCheck(U=F.add(msg2.U, 1), V=msg2.V)
+    print(f"  tampered run accepts: {verify(rc.circuit, v_share, msg1, chi, bad)}")
+    print()
+
+
+def demo_size_scaling() -> None:
+    print("=" * 64)
+    print("Demo: circuit-size scaling (mul gates ~ n^2 * k)")
+    print("=" * 64)
+    print(f"  {'n':>4} {'k':>4} {'inputs':>8} {'muls':>8} {'time(ms)':>10}")
+    for n, k in [(4, 3), (8, 4), (12, 5), (16, 5)]:
+        # Build a path graph 0->1->...->n-1 so we always have a walk of length k
+        # for k <= n-1.
+        E = [[0] * n for _ in range(n)]
+        for i in range(n - 1):
+            E[i][i + 1] = 1
+        # walk uses the first k+1 vertices.
+        path = list(range(k + 1))
+        rc = build_circuit(n=n, k=k, source=0, target=k)
+        witness = assemble_witness(rc, E, path)
+        t0 = time.time()
+        ok = run_protocol(rc.circuit, witness)
+        dt = (time.time() - t0) * 1000
+        assert ok
+        print(f"  {n:>4} {k:>4} {rc.circuit.num_inputs:>8} "
+              f"{rc.circuit.num_muls:>8} {dt:>10.1f}")
+    print()
+
+
+if __name__ == "__main__":
+    demo_basic()
+    demo_walk_through_cycle()
+    demo_soundness_tampering()
+    demo_size_scaling()
+    print("All ZK reachability demos passed.")

--- a/quicksilver/README.md
+++ b/quicksilver/README.md
@@ -77,15 +77,18 @@ That is the entire protocol.
 ## Layout
 
     quicksilver/
-        field.py         Mersenne-prime field arithmetic
-        vole.py          Trusted-dealer VOLE preprocessing
-        itmac.py         Information-theoretic MAC wires
-        circuit.py       Tiny arithmetic-circuit DSL
-        protocol.py      Prover and Verifier walkers, message types
-        polynomial.py    Degree-d polynomial-zero check (Section 5)
+        field.py            Mersenne-prime field arithmetic
+        vole.py             Trusted-dealer VOLE preprocessing
+        itmac.py            Information-theoretic MAC wires
+        circuit.py          Tiny arithmetic-circuit DSL
+        protocol.py         Prover and Verifier walkers, message types
+        polynomial.py       Degree-d polynomial-zero check (Section 5)
+        zk_reachability.py  Tensor-logic tie-in: ZK proof of graph reachability
 
-    tests/test_quicksilver.py     completeness + soundness, 18 tests
-    demos/quicksilver_demo.py     factorisation, x^3+x+5=y, batched polys
+    tests/test_quicksilver.py        completeness + soundness, 18 tests
+    tests/test_zk_reachability.py    7 tests for the reachability circuit
+    demos/quicksilver_demo.py        factorisation, x^3+x+5=y, batched polys
+    demos/zk_graph_reachability.py   "I know a graph and a walk inside it"
 
 ## Usage
 
@@ -105,9 +108,27 @@ assert run(c, [1_000_003, 999_983])   # honest prover -> verifier accepts
 ## Run
 
 ```bash
-python -m pytest tests/test_quicksilver.py -v   # 18 passing
+python -m pytest tests/ -v                      # 25 passing
 python demos/quicksilver_demo.py                # ~1 ms total
+python demos/zk_graph_reachability.py           # ~30 ms total
 ```
+
+## Tensor-logic tie-in
+
+The same einsum recurrence that defines transitive closure in
+`demos/transitive_closure.py`,
+
+    Path = step( Edge + einsum('xy,yz->xz', Path, Edge) ),
+
+is also the natural ZK statement: "I know a graph and a walk inside
+it." `zk_reachability.py` builds a QuickSilver circuit that
+constrains, for committed adjacency `E` and a sequence of one-hot
+frontier vectors `alpha_0, ..., alpha_k`, the einsum identity
+`alpha_i^T E alpha_{i+1} = 1` at every step. Verifier learns nothing
+about `E` or about the walk's interior beyond the public boundary
+(n, k, source, target). The same operator, two semantics: deductive
+forward chaining when run on cleartext tensors, ZK reachability proof
+when run on IT-MAC-committed tensors.
 
 ## What this leaves out
 

--- a/quicksilver/README.md
+++ b/quicksilver/README.md
@@ -1,0 +1,128 @@
+# QuickSilver
+
+A pedagogical pure-Python implementation of the QuickSilver
+zero-knowledge proof system from
+
+> Yang, Sarkar, Weng, Wang — *QuickSilver: Efficient and Affordable
+> Zero-Knowledge Proofs for Circuits and Polynomials over Any Field*,
+> ACM CCS 2021. <https://eprint.iacr.org/2021/076>
+
+The implementation focuses on clarity, not performance: ~600 lines of
+Python, no third-party dependencies, no extension fields, no LPN-based
+VOLE extension. It models the VOLE preprocessing as a trusted dealer
+and then implements the QuickSilver protocol on top. Soundness error
+is `~(m + d) / |F|` for `m` multiplication gates of total degree `d`,
+which over the Mersenne prime `p = 2^127 - 1` is well below `2^-120`
+for any circuit you can run in pure Python.
+
+## What QuickSilver does
+
+Designated-verifier zero-knowledge proofs for arbitrary arithmetic
+circuits over a large prime field, with two key properties:
+
+- **Linear operations are free.** Add, subtract, scale-by-constant
+  cost no communication. They reduce to local operations on
+  information-theoretic MACs.
+- **Each multiplication gate costs ~2 field elements amortised.** A
+  single batched check at the end of the circuit covers every mul
+  gate at once.
+- **Polynomial extension:** any degree-`d` polynomial relation between
+  committed values can be checked in `d` field elements per batch,
+  *without* introducing intermediate multiplication wires.
+
+## How it works in one screen
+
+For every committed wire value `x`, the prover holds `(x, M)` and the
+verifier holds `K` such that
+
+    K = M + Delta * x
+
+where `Delta` is a global secret of the verifier sampled once at
+setup. This is an information-theoretic MAC: the prover cannot change
+`x` without knowing `Delta`, but `Delta` is hidden to the prover.
+
+A single VOLE preprocessing element is a triple `(u, v, w)` with
+`w = u * Delta + v`, distributed so the prover gets `(u, v)` and the
+verifier gets `w`. To commit to a value `x`, the prover sends
+`d = x - u` and both sides locally derive `(M, K)` with the IT-MAC
+relation above (see `itmac.py`).
+
+Linear gates compose IT-MACs trivially:
+
+    (x + y, M_x + M_y)   <->   K_x + K_y
+    (c * x, c * M_x)     <->   c * K_x
+    (x + c, M_x)         <->   K_x + Delta * c
+
+For multiplication `z = x * y`, the verifier can locally compute
+
+    B = K_x * K_y - Delta * K_z
+      = M_x * M_y + Delta * (x*M_y + y*M_x - M_z) + Delta^2 * (x*y - z)
+      =: A_0     + Delta *  A_1                  + Delta^2 * (x*y - z)
+
+If `z = x*y`, the `Delta^2` term vanishes and `B` is a linear
+polynomial in `Delta` whose coefficients `(A_0, A_1)` only the prover
+knows. The prover sends them; the verifier checks `B == A_0 + A_1 *
+Delta`. To batch many multiplications and stay zero-knowledge:
+
+1. Verifier picks a random challenge `chi`.
+2. Prover and verifier aggregate `A_e := sum_i chi^i * A_{e,i}` and
+   `B := sum_i chi^i * B_i`.
+3. Prover sends `(U, V) = (A_0 + b, A_1 + a)` where `(a, b)` is one
+   fresh masking VOLE element with verifier-side value
+   `c = a*Delta + b`.
+4. Verifier accepts iff `B + c == U + V * Delta`.
+
+That is the entire protocol.
+
+## Layout
+
+    quicksilver/
+        field.py         Mersenne-prime field arithmetic
+        vole.py          Trusted-dealer VOLE preprocessing
+        itmac.py         Information-theoretic MAC wires
+        circuit.py       Tiny arithmetic-circuit DSL
+        protocol.py      Prover and Verifier walkers, message types
+        polynomial.py    Degree-d polynomial-zero check (Section 5)
+
+    tests/test_quicksilver.py     completeness + soundness, 18 tests
+    demos/quicksilver_demo.py     factorisation, x^3+x+5=y, batched polys
+
+## Usage
+
+```python
+from quicksilver import Circuit, run
+
+# Prove knowledge of (p, q) with p * q == N, without revealing them.
+N = 999985999949
+c = Circuit()
+p_w = c.input()
+q_w = c.input()
+c.assert_eq(c.mul(p_w, q_w), N)
+
+assert run(c, [1_000_003, 999_983])   # honest prover -> verifier accepts
+```
+
+## Run
+
+```bash
+python -m pytest tests/test_quicksilver.py -v   # 18 passing
+python demos/quicksilver_demo.py                # ~1 ms total
+```
+
+## What this leaves out
+
+- **Real VOLE.** Production QuickSilver would generate VOLE
+  correlations via an LPN-based extension protocol (SoftSpoken,
+  Wolverine's Ferret) bootstrapped from a small base OT. That phase
+  is the cryptographically heavy part and is orthogonal to the
+  protocol implemented here.
+- **Binary / extension fields.** The paper handles `F_2`, `F_{2^k}`,
+  and small prime fields via a "subspace VOLE" with MACs in an
+  extension. Here we only do a single large prime field, where the
+  base IT-MAC suffices.
+- **Public verifiability / Fiat-Shamir.** The protocol is interactive
+  designated-verifier as in the paper; non-interactive variants would
+  derive `chi` from a transcript hash and add a commitment phase.
+- **Performance.** Pure Python, no batching of field ops into vectors,
+  no precomputation of `chi^i`. A serious implementation would use
+  C/AVX field arithmetic and parallel VOLE expansion.

--- a/quicksilver/README.md
+++ b/quicksilver/README.md
@@ -7,18 +7,16 @@ zero-knowledge proof system from
 > Zero-Knowledge Proofs for Circuits and Polynomials over Any Field*,
 > ACM CCS 2021. <https://eprint.iacr.org/2021/076>
 
-The implementation focuses on clarity, not performance: ~600 lines of
-Python, no third-party dependencies, no extension fields, no LPN-based
-VOLE extension. It models the VOLE preprocessing as a trusted dealer
-and then implements the QuickSilver protocol on top. Soundness error
-is `~(m + d) / |F|` for `m` multiplication gates of total degree `d`,
-which over the Mersenne prime `p = 2^127 - 1` is well below `2^-120`
-for any circuit you can run in pure Python.
+About 2,500 lines of Python, no third-party dependencies. Eight
+modules, 76 tests, six runnable demos. Soundness error is `~m / |F|`
+for `m` multiplication gates: well below `2^-120` over the Mersenne
+prime `2^127 - 1`, and below `2^-127` over `GF(2^128)` for boolean
+circuits.
 
 ## What QuickSilver does
 
-Designated-verifier zero-knowledge proofs for arbitrary arithmetic
-circuits over a large prime field, with two key properties:
+Designated-verifier zero-knowledge proofs for arbitrary circuits over
+any field, with three signature properties:
 
 - **Linear operations are free.** Add, subtract, scale-by-constant
   cost no communication. They reduce to local operations on
@@ -45,7 +43,7 @@ A single VOLE preprocessing element is a triple `(u, v, w)` with
 `w = u * Delta + v`, distributed so the prover gets `(u, v)` and the
 verifier gets `w`. To commit to a value `x`, the prover sends
 `d = x - u` and both sides locally derive `(M, K)` with the IT-MAC
-relation above (see `itmac.py`).
+relation above.
 
 Linear gates compose IT-MACs trivially:
 
@@ -53,7 +51,7 @@ Linear gates compose IT-MACs trivially:
     (c * x, c * M_x)     <->   c * K_x
     (x + c, M_x)         <->   K_x + Delta * c
 
-For multiplication `z = x * y`, the verifier can locally compute
+For multiplication `z = x * y`, the verifier locally computes
 
     B = K_x * K_y - Delta * K_z
       = M_x * M_y + Delta * (x*M_y + y*M_x - M_z) + Delta^2 * (x*y - z)
@@ -72,23 +70,27 @@ Delta`. To batch many multiplications and stay zero-knowledge:
    `c = a*Delta + b`.
 4. Verifier accepts iff `B + c == U + V * Delta`.
 
-That is the entire protocol.
+Fiat-Shamir replaces the verifier's challenge in step 1 with a hash
+of the transcript, making the proof a single non-interactive object.
 
 ## Layout
 
     quicksilver/
-        field.py            Mersenne-prime field arithmetic
+        field.py            Mersenne-prime field arithmetic (2^127 - 1)
+        gf2k.py             GF(2^128) arithmetic, GCM polynomial
         vole.py             Trusted-dealer VOLE preprocessing
-        itmac.py            Information-theoretic MAC wires
+        lpn_vole.py         LPN-based PCG: sparse base -> pseudorandom output
+        itmac.py            Information-theoretic MAC wires (prime field)
         circuit.py          Tiny arithmetic-circuit DSL
-        protocol.py         Prover and Verifier walkers, message types
+        protocol.py         Prime-field prover and verifier
         polynomial.py       Degree-d polynomial-zero check (Section 5)
-        zk_reachability.py  Tensor-logic tie-in: ZK proof of graph reachability
+        boolean.py          Subspace-VOLE binary-circuit prover and verifier
+        fiat_shamir.py      Non-interactive variant via SHA-256 transcript
+        einsum.py           Compile tensor-logic einsum into a circuit
+        zk_reachability.py  ZK proof of graph reachability
 
-    tests/test_quicksilver.py        completeness + soundness, 18 tests
-    tests/test_zk_reachability.py    7 tests for the reachability circuit
-    demos/quicksilver_demo.py        factorisation, x^3+x+5=y, batched polys
-    demos/zk_graph_reachability.py   "I know a graph and a walk inside it"
+    tests/                  76 tests across 6 files
+    demos/                  6 runnable demos
 
 ## Usage
 
@@ -105,45 +107,106 @@ c.assert_eq(c.mul(p_w, q_w), N)
 assert run(c, [1_000_003, 999_983])   # honest prover -> verifier accepts
 ```
 
+Same shape with the LPN-based VOLE PCG (drop-in for the trusted
+dealer):
+
+```python
+from quicksilver.lpn_vole import LpnParams, lpn_vole_extend
+from quicksilver.protocol import prove, verify
+from quicksilver.field import F
+
+p_share, v_share = lpn_vole_extend(LpnParams.default(n_out=c.vole_count()))
+msg1, batched = prove(c, [1_000_003, 999_983], p_share)
+chi = F.rand_nonzero()
+msg2 = batched(chi)
+assert verify(c, v_share, msg1, chi, msg2)
+```
+
+Boolean circuits (XOR free, AND charged) over `GF(2^128)`:
+
+```python
+from quicksilver.boolean import BoolCircuit, run
+
+c = BoolCircuit()
+a, b = c.input(), c.input()
+c.assert_eq_const(c.and_(a, b), 1)   # prove AND of two secret bits is 1
+assert run(c, [1, 1])
+```
+
+Tensor-logic einsum compiled to a ZK circuit:
+
+```python
+from quicksilver.circuit import Circuit
+from quicksilver.einsum import (
+    alloc_input_tensor, assert_einsum_equals,
+    evaluate_einsum, flatten_row_major,
+)
+from quicksilver.protocol import run
+
+A = [[1, 2], [3, 4]]; B = [[5, 6], [7, 8]]
+expected = evaluate_einsum("ij,jk->ik", [A, B])
+c = Circuit()
+Aw = alloc_input_tensor(c, (2, 2))
+Bw = alloc_input_tensor(c, (2, 2))
+assert_einsum_equals(c, "ij,jk->ik", [Aw, Bw], [(2, 2), (2, 2)], expected)
+witness = flatten_row_major(A) + flatten_row_major(B)
+assert run(c, witness)
+```
+
+Fiat-Shamir non-interactive proof:
+
+```python
+from quicksilver.fiat_shamir import run_ni
+ok, proof = run_ni(c, [1_000_003, 999_983])
+# ``proof`` is a single object; pass to verify_ni later.
+```
+
 ## Run
 
 ```bash
-python -m pytest tests/ -v                      # 25 passing
-python demos/quicksilver_demo.py                # ~1 ms total
-python demos/zk_graph_reachability.py           # ~30 ms total
+python -m pytest tests/ -v                       # 76 passing in <1s
+
+# Prime-field demos
+python demos/quicksilver_demo.py                 # factorisation, polys
+python demos/zk_graph_reachability.py            # graph + walk in ZK
+python demos/zk_einsum.py                        # matmul, grandparent rule
+
+# Binary-field demos
+python demos/quicksilver_boolean_demo.py         # 8-bit multiplier, mixer
+
+# Real-cryptography demos
+python demos/lpn_vole_demo.py                    # LPN-based PCG
 ```
 
 ## Tensor-logic tie-in
 
-The same einsum recurrence that defines transitive closure in
-`demos/transitive_closure.py`,
+The repo's premise -- a Datalog rule head and an einsum are the same
+operation -- gives a one-line ZK frontend. The recurrence that defines
+boolean transitive closure in `demos/transitive_closure.py`,
 
     Path = step( Edge + einsum('xy,yz->xz', Path, Edge) ),
 
-is also the natural ZK statement: "I know a graph and a walk inside
-it." `zk_reachability.py` builds a QuickSilver circuit that
-constrains, for committed adjacency `E` and a sequence of one-hot
-frontier vectors `alpha_0, ..., alpha_k`, the einsum identity
-`alpha_i^T E alpha_{i+1} = 1` at every step. Verifier learns nothing
-about `E` or about the walk's interior beyond the public boundary
-(n, k, source, target). The same operator, two semantics: deductive
-forward chaining when run on cleartext tensors, ZK reachability proof
-when run on IT-MAC-committed tensors.
+is also the natural ZK statement "I know a graph and a walk inside
+it." `zk_reachability.py` constrains, for committed adjacency `E` and
+one-hot frontier vectors `alpha_0, ..., alpha_k`, the einsum identity
+`alpha_i^T E alpha_{i+1} = 1` at every step. The verifier learns
+nothing about `E` or the walk's interior beyond `(n, k, source,
+target)`.
 
-## What this leaves out
+`einsum.py` generalises this: any tensor-logic rule head expressible
+as an einsum is automatically a QuickSilver circuit. One operator,
+two semantics -- deductive forward chaining on cleartext tensors, ZK
+proof on IT-MAC-committed tensors.
 
-- **Real VOLE.** Production QuickSilver would generate VOLE
-  correlations via an LPN-based extension protocol (SoftSpoken,
-  Wolverine's Ferret) bootstrapped from a small base OT. That phase
-  is the cryptographically heavy part and is orthogonal to the
-  protocol implemented here.
-- **Binary / extension fields.** The paper handles `F_2`, `F_{2^k}`,
-  and small prime fields via a "subspace VOLE" with MACs in an
-  extension. Here we only do a single large prime field, where the
-  base IT-MAC suffices.
-- **Public verifiability / Fiat-Shamir.** The protocol is interactive
-  designated-verifier as in the paper; non-interactive variants would
-  derive `chi` from a transcript hash and add a commitment phase.
-- **Performance.** Pure Python, no batching of field ops into vectors,
-  no precomputation of `chi^i`. A serious implementation would use
-  C/AVX field arithmetic and parallel VOLE expansion.
+## What this still leaves out
+
+- **Base OT / GGM-tree single-point VOLE** to remove the trusted base
+  for `lpn_vole.py`. The LPN expansion step is the cryptographically
+  characteristic part of the PCG; the base would still need OT-style
+  primitives implemented separately.
+- **Disjunctions and lookups** (Mac'n'Cheese, lookup arguments). All
+  expressible on top of this protocol but each its own subproject.
+- **Performance.** Pure Python, scalar arithmetic, no FFT, no
+  vectorisation. A serious implementation would use CLMUL/CLMULNI for
+  GF(2^128), a CRT-friendly prime + montgomery for the prime case,
+  and parallel matrix-vector multiplies for LPN expansion.

--- a/quicksilver/__init__.py
+++ b/quicksilver/__init__.py
@@ -1,0 +1,17 @@
+"""QuickSilver: VOLE-based zero-knowledge proofs for arithmetic circuits.
+
+Implements the protocol of Yang, Sarkar, Weng, Wang (CCS 2021,
+https://eprint.iacr.org/2021/076) for the prime-field setting.
+
+Educational implementation: VOLE setup is performed by a trusted dealer
+rather than via LPN/OT-based extension. Everything else (IT-MACs, the
+batched multiplication check, the degree-d polynomial extension) follows
+the paper.
+"""
+
+from quicksilver.field import F, Fp
+from quicksilver.itmac import Wire
+from quicksilver.circuit import Circuit
+from quicksilver.protocol import prove, verify, run
+
+__all__ = ["F", "Fp", "Wire", "Circuit", "prove", "verify", "run"]

--- a/quicksilver/boolean.py
+++ b/quicksilver/boolean.py
@@ -1,0 +1,397 @@
+"""QuickSilver over F_2 with subspace VOLE in GF(2^128).
+
+This is the binary-circuit instantiation of the same protocol that
+``protocol.py`` runs over a prime field. Wire values are bits; IT-MAC
+tags and keys live in GF(2^128); soundness error is ~m * 2^-128 for
+``m`` AND gates.
+
+Wire semantics
+--------------
+
+For each committed bit ``x in {0,1}``, the prover holds
+``M in GF(2^128)`` and the verifier holds ``K in GF(2^128)`` with
+
+    K = M + Delta * x      (Delta in GF(2^128), addition is XOR).
+
+Subspace VOLE preprocessing yields, for each element, ``u in {0,1}``,
+``v in GF(2^128)`` for the prover and ``w = u * Delta + v`` for the
+verifier. To commit to bit ``x`` the prover sends ``d = x XOR u``; if
+``d = 0`` the verifier sets ``K = w``, else ``K = w + Delta``. Both
+sides arrive at the IT-MAC relation above with ``M = v``.
+
+Gates supported
+---------------
+
+XOR (free), AND (one VOLE element + a slot in the batched check),
+NOT (free), constants, and an ``assert_zero`` constraint that opens a
+wire claimed to be 0. NAND/OR/etc. compose from these.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass, field as dc_field
+from enum import Enum
+from typing import Iterator, List, Tuple
+
+from quicksilver.gf2k import GF128, GF2k
+
+
+# ---- Subspace VOLE -------------------------------------------------------
+
+
+@dataclass
+class SubspaceVoleProverShare:
+    u: List[int]  # bits
+    v: List[int]  # GF(2^128) elements
+
+    def __len__(self) -> int:
+        return len(self.u)
+
+
+@dataclass
+class SubspaceVoleVerifierShare:
+    delta: int  # GF(2^128)
+    w: List[int]
+
+    def __len__(self) -> int:
+        return len(self.w)
+
+
+def trusted_dealer_setup(
+    n: int, mac_field: GF2k = GF128, delta: int | None = None
+) -> Tuple[SubspaceVoleProverShare, SubspaceVoleVerifierShare]:
+    if delta is None:
+        delta = mac_field.rand()
+    u = [secrets.randbits(1) for _ in range(n)]
+    v = [mac_field.rand() for _ in range(n)]
+    # u_i is 0 or 1, so u_i * Delta is just 0 or Delta.
+    w = [(delta if u_i else 0) ^ v_i for u_i, v_i in zip(u, v)]
+    return (
+        SubspaceVoleProverShare(u=u, v=v),
+        SubspaceVoleVerifierShare(delta=delta, w=w),
+    )
+
+
+# ---- Boolean wires (IT-MACs) ---------------------------------------------
+
+
+@dataclass(frozen=True)
+class BoolProverWire:
+    x: int  # 0 or 1
+    m: int  # GF(2^128)
+
+
+@dataclass(frozen=True)
+class BoolVerifierWire:
+    k: int  # GF(2^128)
+
+
+def _commit_bit(
+    bit: int, u: int, v: int, mac_field: GF2k = GF128
+) -> tuple[BoolProverWire, int]:
+    d = bit ^ u
+    return BoolProverWire(x=bit, m=v), d
+
+
+def _verifier_receive(
+    d: int, w: int, delta: int, mac_field: GF2k = GF128
+) -> BoolVerifierWire:
+    # K = w + Delta * d_bit. d is 0 or 1, so this is just w or w XOR Delta.
+    return BoolVerifierWire(k=(w ^ delta) if d else w)
+
+
+# ---- Circuit DSL ---------------------------------------------------------
+
+
+class BOp(Enum):
+    INPUT = "input"
+    CONST = "const"
+    XOR = "xor"
+    NOT = "not"
+    AND = "and"
+    XOR_CONST = "xor_const"
+    ASSERT_ZERO = "assert_zero"
+
+
+@dataclass
+class BGate:
+    op: BOp
+    args: tuple
+    out: int | None = None
+
+
+@dataclass
+class BoolCircuit:
+    gates: List[BGate] = dc_field(default_factory=list)
+    num_wires: int = 0
+    num_inputs: int = 0
+    num_ands: int = 0
+    num_asserts: int = 0
+
+    def _new(self) -> int:
+        wid = self.num_wires
+        self.num_wires += 1
+        return wid
+
+    def input(self) -> int:
+        wid = self._new()
+        self.gates.append(BGate(BOp.INPUT, (), out=wid))
+        self.num_inputs += 1
+        return wid
+
+    def const(self, c: int) -> int:
+        if c not in (0, 1):
+            raise ValueError("boolean const must be 0 or 1")
+        wid = self._new()
+        self.gates.append(BGate(BOp.CONST, (c,), out=wid))
+        return wid
+
+    def xor(self, a: int, b: int) -> int:
+        wid = self._new()
+        self.gates.append(BGate(BOp.XOR, (a, b), out=wid))
+        return wid
+
+    def xor_const(self, a: int, c: int) -> int:
+        if c not in (0, 1):
+            raise ValueError("boolean const must be 0 or 1")
+        wid = self._new()
+        self.gates.append(BGate(BOp.XOR_CONST, (a, c), out=wid))
+        return wid
+
+    def not_(self, a: int) -> int:
+        return self.xor_const(a, 1)
+
+    def and_(self, a: int, b: int) -> int:
+        wid = self._new()
+        self.gates.append(BGate(BOp.AND, (a, b), out=wid))
+        self.num_ands += 1
+        return wid
+
+    def or_(self, a: int, b: int) -> int:
+        # a OR b = a XOR b XOR (a AND b)
+        return self.xor(self.xor(a, b), self.and_(a, b))
+
+    def assert_zero(self, a: int) -> None:
+        self.gates.append(BGate(BOp.ASSERT_ZERO, (a,)))
+        self.num_asserts += 1
+
+    def assert_eq(self, a: int, b: int) -> None:
+        self.assert_zero(self.xor(a, b))
+
+    def assert_eq_const(self, a: int, c: int) -> None:
+        self.assert_zero(self.xor_const(a, c))
+
+    def vole_count(self) -> int:
+        return self.num_inputs + self.num_ands + 1
+
+
+# ---- Protocol ------------------------------------------------------------
+
+
+@dataclass
+class BCommitMessage:
+    d_values: List[int]      # bits
+    assert_openings: List[int]  # GF(2^128) elements
+
+
+@dataclass
+class BBatchedCheck:
+    U: int
+    V: int
+
+
+@dataclass
+class _BProverWalker:
+    circuit: BoolCircuit
+    witness: List[int]
+    share: SubspaceVoleProverShare
+    mac_field: GF2k = GF128
+    wires: dict = dc_field(default_factory=dict)
+    d_values: List[int] = dc_field(default_factory=list)
+    assert_openings: List[int] = dc_field(default_factory=list)
+    and_triples: List[Tuple[BoolProverWire, BoolProverWire, BoolProverWire]] = dc_field(default_factory=list)
+    mask_a: int = 0
+    mask_b: int = 0
+
+    def commit(self) -> BCommitMessage:
+        if len(self.witness) != self.circuit.num_inputs:
+            raise ValueError(
+                f"witness length {len(self.witness)} != "
+                f"num inputs {self.circuit.num_inputs}"
+            )
+        vole = iter(zip(self.share.u, self.share.v))
+        wit = iter(self.witness)
+        for g in self.circuit.gates:
+            self._exec(g, wit, vole)
+        # Reserve one final VOLE element for batched-check masking.
+        self.mask_a, self.mask_b = next(vole)
+        return BCommitMessage(self.d_values, self.assert_openings)
+
+    def _exec(self, g, wit, vole):
+        f = self.mac_field
+        op = g.op
+        if op is BOp.INPUT:
+            x = int(next(wit)) & 1
+            u, v = next(vole)
+            wire, d = _commit_bit(x, u, v, f)
+            self.wires[g.out] = wire
+            self.d_values.append(d)
+        elif op is BOp.CONST:
+            (c,) = g.args
+            self.wires[g.out] = BoolProverWire(x=c, m=0)
+        elif op is BOp.XOR:
+            a, b = g.args
+            wa, wb = self.wires[a], self.wires[b]
+            self.wires[g.out] = BoolProverWire(x=wa.x ^ wb.x, m=wa.m ^ wb.m)
+        elif op is BOp.XOR_CONST:
+            a, c = g.args
+            wa = self.wires[a]
+            # K_z = K_a + Delta * c. Prover side: M unchanged, x toggles.
+            self.wires[g.out] = BoolProverWire(x=wa.x ^ c, m=wa.m)
+        elif op is BOp.AND:
+            a, b = g.args
+            wa, wb = self.wires[a], self.wires[b]
+            z = wa.x & wb.x
+            u, v = next(vole)
+            wz, d = _commit_bit(z, u, v, f)
+            self.wires[g.out] = wz
+            self.d_values.append(d)
+            self.and_triples.append((wa, wb, wz))
+        elif op is BOp.ASSERT_ZERO:
+            (a,) = g.args
+            w = self.wires[a]
+            if w.x != 0:
+                raise ValueError("prover wire claimed to be zero is nonzero")
+            self.assert_openings.append(w.m)
+        else:  # pragma: no cover
+            raise AssertionError(f"unknown op {op}")
+
+    def batched_check(self, chi: int) -> BBatchedCheck:
+        f = self.mac_field
+        U_raw = 0
+        V_raw = 0
+        chi_i = 1
+        for xw, yw, zw in self.and_triples:
+            chi_i = f.mul(chi_i, chi)
+            # In characteristic 2: B = K_x*K_y + Delta*K_z; A_0 = M_x*M_y;
+            # A_1 = x*M_y + y*M_x + M_z (with x,y in {0,1}).
+            A0 = f.mul(xw.m, yw.m)
+            xMy = yw.m if xw.x else 0
+            yMx = xw.m if yw.x else 0
+            A1 = xMy ^ yMx ^ zw.m
+            U_raw ^= f.mul(chi_i, A0)
+            V_raw ^= f.mul(chi_i, A1)
+        return BBatchedCheck(U=U_raw ^ self.mask_b, V=V_raw ^ self.mask_a)
+
+
+@dataclass
+class _BVerifierWalker:
+    circuit: BoolCircuit
+    share: SubspaceVoleVerifierShare
+    mac_field: GF2k = GF128
+    wires: dict = dc_field(default_factory=dict)
+    and_keys: List[Tuple[BoolVerifierWire, BoolVerifierWire, BoolVerifierWire]] = dc_field(default_factory=list)
+    assert_keys: List[BoolVerifierWire] = dc_field(default_factory=list)
+    mask_c: int = 0
+    _openings: List[int] = dc_field(default_factory=list)
+
+    def receive(self, msg: BCommitMessage) -> None:
+        f = self.mac_field
+        d_iter = iter(msg.d_values)
+        w_iter = iter(self.share.w)
+        delta = self.share.delta
+        for g in self.circuit.gates:
+            op = g.op
+            if op is BOp.INPUT:
+                d = next(d_iter)
+                w = next(w_iter)
+                self.wires[g.out] = _verifier_receive(d, w, delta, f)
+            elif op is BOp.CONST:
+                (c,) = g.args
+                self.wires[g.out] = BoolVerifierWire(k=delta if c else 0)
+            elif op is BOp.XOR:
+                a, b = g.args
+                self.wires[g.out] = BoolVerifierWire(
+                    k=self.wires[a].k ^ self.wires[b].k
+                )
+            elif op is BOp.XOR_CONST:
+                a, c = g.args
+                self.wires[g.out] = BoolVerifierWire(
+                    k=self.wires[a].k ^ (delta if c else 0)
+                )
+            elif op is BOp.AND:
+                a, b = g.args
+                d = next(d_iter)
+                w = next(w_iter)
+                kz = _verifier_receive(d, w, delta, f)
+                self.wires[g.out] = kz
+                self.and_keys.append((self.wires[a], self.wires[b], kz))
+            elif op is BOp.ASSERT_ZERO:
+                (a,) = g.args
+                self.assert_keys.append(self.wires[a])
+            else:  # pragma: no cover
+                raise AssertionError(f"unknown op {op}")
+        self.mask_c = next(w_iter)
+        self._openings = list(msg.assert_openings)
+
+    def check_assertions(self) -> bool:
+        if len(self._openings) != len(self.assert_keys):
+            return False
+        # K = M + Delta * 0 = M for a wire claimed to be 0.
+        for opened_m, key in zip(self._openings, self.assert_keys):
+            if key.k != opened_m:
+                return False
+        return True
+
+    def check_batched(self, chi: int, msg: BBatchedCheck) -> bool:
+        f = self.mac_field
+        delta = self.share.delta
+        W = 0
+        chi_i = 1
+        for kx, ky, kz in self.and_keys:
+            chi_i = f.mul(chi_i, chi)
+            B = f.mul(kx.k, ky.k) ^ f.mul(delta, kz.k)
+            W ^= f.mul(chi_i, B)
+        lhs = W ^ self.mask_c
+        rhs = msg.U ^ f.mul(msg.V, delta)
+        return lhs == rhs
+
+
+def prove(
+    circuit: BoolCircuit,
+    witness: List[int],
+    share: SubspaceVoleProverShare,
+    mac_field: GF2k = GF128,
+):
+    walker = _BProverWalker(
+        circuit=circuit, witness=witness, share=share, mac_field=mac_field
+    )
+    return walker.commit(), walker.batched_check
+
+
+def verify(
+    circuit: BoolCircuit,
+    share: SubspaceVoleVerifierShare,
+    msg1: BCommitMessage,
+    chi: int,
+    msg2: BBatchedCheck,
+    mac_field: GF2k = GF128,
+) -> bool:
+    walker = _BVerifierWalker(
+        circuit=circuit, share=share, mac_field=mac_field
+    )
+    walker.receive(msg1)
+    if not walker.check_assertions():
+        return False
+    return walker.check_batched(chi, msg2)
+
+
+def run(
+    circuit: BoolCircuit, witness: List[int], mac_field: GF2k = GF128
+) -> bool:
+    p_share, v_share = trusted_dealer_setup(circuit.vole_count(), mac_field)
+    msg1, batched = prove(circuit, witness, p_share, mac_field)
+    chi = mac_field.rand_nonzero()
+    msg2 = batched(chi)
+    return verify(circuit, v_share, msg1, chi, msg2, mac_field)

--- a/quicksilver/circuit.py
+++ b/quicksilver/circuit.py
@@ -1,0 +1,117 @@
+"""Tiny arithmetic-circuit DSL.
+
+A circuit is a sequence of gates referencing previously-defined wires
+by integer id. The same ``Circuit`` object is consumed by both prover
+and verifier in ``protocol.py``; they walk the gate list in lockstep
+and accumulate their respective wire views.
+
+Supported operations
+--------------------
+
+input()                fresh secret input from the prover
+const(c)               public constant
+add(a, b)              wire a + wire b
+sub(a, b)              wire a - wire b
+add_const(a, c)        wire a + public constant
+mul_const(a, c)        wire a * public constant
+mul(a, b)              wire a * wire b   (needs one VOLE element + check)
+assert_zero(a)         add an output check that wire a equals 0
+assert_eq(a, c)        sugar for assert_zero(sub(a, const(c)))
+
+Costs
+-----
+
+VOLE elements consumed: ``num_inputs + num_muls + 1`` (the trailing
+"+1" is the masking element for the batched multiplication check).
+Communication: one field element per input, two per mul gate (the
+``A0, A1`` opening in the batched check is amortised), one MAC per
+output assertion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List
+
+
+class Op(Enum):
+    INPUT = "input"
+    CONST = "const"
+    ADD = "add"
+    SUB = "sub"
+    ADD_CONST = "add_const"
+    MUL_CONST = "mul_const"
+    MUL = "mul"
+    ASSERT_ZERO = "assert_zero"
+
+
+@dataclass
+class Gate:
+    op: Op
+    args: tuple  # interpretation depends on op
+    out: int | None = None  # wire id this gate produces (None for asserts)
+
+
+@dataclass
+class Circuit:
+    gates: List[Gate] = field(default_factory=list)
+    num_wires: int = 0
+    num_inputs: int = 0
+    num_muls: int = 0
+    num_asserts: int = 0
+
+    def _new_wire(self) -> int:
+        wid = self.num_wires
+        self.num_wires += 1
+        return wid
+
+    def input(self) -> int:
+        wid = self._new_wire()
+        self.gates.append(Gate(Op.INPUT, (), out=wid))
+        self.num_inputs += 1
+        return wid
+
+    def const(self, c: int) -> int:
+        wid = self._new_wire()
+        self.gates.append(Gate(Op.CONST, (c,), out=wid))
+        return wid
+
+    def add(self, a: int, b: int) -> int:
+        wid = self._new_wire()
+        self.gates.append(Gate(Op.ADD, (a, b), out=wid))
+        return wid
+
+    def sub(self, a: int, b: int) -> int:
+        wid = self._new_wire()
+        self.gates.append(Gate(Op.SUB, (a, b), out=wid))
+        return wid
+
+    def add_const(self, a: int, c: int) -> int:
+        wid = self._new_wire()
+        self.gates.append(Gate(Op.ADD_CONST, (a, c), out=wid))
+        return wid
+
+    def mul_const(self, a: int, c: int) -> int:
+        wid = self._new_wire()
+        self.gates.append(Gate(Op.MUL_CONST, (a, c), out=wid))
+        return wid
+
+    def mul(self, a: int, b: int) -> int:
+        wid = self._new_wire()
+        self.gates.append(Gate(Op.MUL, (a, b), out=wid))
+        self.num_muls += 1
+        return wid
+
+    def assert_zero(self, a: int) -> None:
+        self.gates.append(Gate(Op.ASSERT_ZERO, (a,)))
+        self.num_asserts += 1
+
+    def assert_eq(self, a: int, c: int) -> None:
+        # a - c == 0
+        diff = self.sub(a, self.const(c))
+        self.assert_zero(diff)
+
+    # Convenience: total VOLE elements consumed by the protocol.
+    def vole_count(self) -> int:
+        return self.num_inputs + self.num_muls + 1  # +1 for batched-check mask

--- a/quicksilver/einsum.py
+++ b/quicksilver/einsum.py
@@ -1,0 +1,238 @@
+"""Compile a tensor-logic einsum into a QuickSilver arithmetic circuit.
+
+The repo's premise -- that a Datalog rule head and an einsum are the
+same operation -- gives a one-line frontend for ZK: any rule head you
+can write as an einsum becomes a QuickSilver circuit that proves
+"I know inputs such that this einsum produces this output."
+
+API
+---
+
+::
+
+    layout = compile_einsum(circuit, spec, input_wires, shapes)
+    # layout[multi_index] -> wire id for that output element
+
+Where ``input_wires[t]`` is a flat row-major list of wire ids for the
+t-th input tensor. The caller decides whether each tensor is public
+(``alloc_constant_tensor``), prover-private (``alloc_input_tensor``),
+or computed by an earlier subgraph.
+
+Cost model
+----------
+
+For an einsum with output indices ``O``, contraction indices ``C``,
+and ``T`` input tensors, the compiler emits
+
+    prod_{i in O} d_i * prod_{j in C} d_j * (T - 1)     mul gates
+    prod_{i in O} d_i * prod_{j in C} d_j               add gates
+
+i.e. it materialises the contraction explicitly. No optimisation
+passes (no early reductions, no factoring out shared sub-products).
+That keeps the lowering as transparent as possible; for serious work
+you would lower via opt-einsum's contraction path, but the asymptotic
+cost is the same.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import product
+from typing import Dict, List, Sequence, Tuple
+
+from quicksilver.circuit import Circuit
+
+
+def parse_einsum(spec: str) -> tuple[list[str], str]:
+    """Split ``'ij,jk->ik'`` into (['ij','jk'], 'ik')."""
+    if "->" not in spec:
+        raise ValueError("einsum spec must contain '->'")
+    lhs, rhs = spec.split("->")
+    inputs = [s.strip() for s in lhs.split(",")]
+    output = rhs.strip()
+    if not all(part for part in inputs):
+        raise ValueError("empty input spec")
+    return inputs, output
+
+
+def resolve_dims(
+    input_specs: Sequence[str], shapes: Sequence[Sequence[int]]
+) -> Dict[str, int]:
+    """Match index symbols to dimensions, checking consistency."""
+    if len(input_specs) != len(shapes):
+        raise ValueError("number of input specs and shapes must match")
+    dims: Dict[str, int] = {}
+    for spec, shape in zip(input_specs, shapes):
+        if len(spec) != len(shape):
+            raise ValueError(
+                f"spec '{spec}' has rank {len(spec)} but shape has {len(shape)}"
+            )
+        for sym, d in zip(spec, shape):
+            if sym in dims:
+                if dims[sym] != d:
+                    raise ValueError(
+                        f"index '{sym}' has inconsistent dims {dims[sym]} vs {d}"
+                    )
+            else:
+                dims[sym] = d
+    return dims
+
+
+def _flat_index(spec: str, assignment: Dict[str, int], dims: Dict[str, int]) -> int:
+    """Row-major flat offset for the index assignment in a tensor of given spec."""
+    offset = 0
+    for sym in spec:
+        offset = offset * dims[sym] + assignment[sym]
+    return offset
+
+
+def alloc_input_tensor(c: Circuit, shape: Sequence[int]) -> List[int]:
+    """Allocate a row-major flat list of fresh ``c.input()`` wires."""
+    n = 1
+    for d in shape:
+        n *= d
+    return [c.input() for _ in range(n)]
+
+
+def alloc_constant_tensor(c: Circuit, values: Sequence[int]) -> List[int]:
+    """Lift a flat sequence of ints into ``c.const`` wires."""
+    return [c.const(v) for v in values]
+
+
+def compile_einsum(
+    c: Circuit,
+    spec: str,
+    input_wires: Sequence[Sequence[int]],
+    shapes: Sequence[Sequence[int]],
+) -> Dict[Tuple[int, ...], int]:
+    """Append the einsum subgraph to ``c``.
+
+    Returns ``output_wires[(i_1, ..., i_k)] -> wire id`` for each
+    multi-index in the output's row-major iteration order.
+    """
+    input_specs, output_spec = parse_einsum(spec)
+    if len(input_wires) != len(input_specs):
+        raise ValueError(
+            f"got {len(input_wires)} input wire lists for {len(input_specs)} tensors"
+        )
+    dims = resolve_dims(input_specs, shapes)
+    for sym in output_spec:
+        if sym not in dims:
+            raise ValueError(f"output index '{sym}' missing from inputs")
+
+    contraction_syms = [s for s in dims if s not in output_spec]
+    output_dims = [dims[s] for s in output_spec]
+    contraction_dims = [dims[s] for s in contraction_syms]
+
+    out: Dict[Tuple[int, ...], int] = {}
+    for out_assign in product(*(range(d) for d in output_dims)):
+        out_map = dict(zip(output_spec, out_assign))
+        acc = c.const(0)
+        contraction_iter = (
+            product(*(range(d) for d in contraction_dims))
+            if contraction_dims
+            else [()]
+        )
+        for con_assign in contraction_iter:
+            con_map = dict(zip(contraction_syms, con_assign))
+            full = {**out_map, **con_map}
+            # Multiply one input tensor entry per input.
+            term = None
+            for t, ispec in enumerate(input_specs):
+                offset = _flat_index(ispec, full, dims)
+                wid = input_wires[t][offset]
+                term = wid if term is None else c.mul(term, wid)
+            if term is None:  # only happens for "->" with no inputs (degenerate)
+                term = c.const(1)
+            acc = c.add(acc, term)
+        out[tuple(out_assign)] = acc
+    return out
+
+
+# ---- High-level helpers --------------------------------------------------
+
+
+def assert_einsum_equals(
+    c: Circuit,
+    spec: str,
+    input_wires: Sequence[Sequence[int]],
+    shapes: Sequence[Sequence[int]],
+    expected_values: Sequence[int],
+) -> Dict[Tuple[int, ...], int]:
+    """Compile the einsum and assert each output element equals a public value.
+
+    ``expected_values`` is a row-major flat list over the output multi-indices.
+    """
+    out = compile_einsum(c, spec, input_wires, shapes)
+    iter_specs, _ = parse_einsum(spec)
+    dims = resolve_dims(iter_specs, shapes)
+    output_dims = [dims[s] for s in parse_einsum(spec)[1]]
+    n_out = 1
+    for d in output_dims:
+        n_out *= d
+    if len(expected_values) != n_out:
+        raise ValueError(
+            f"expected_values has {len(expected_values)} entries; need {n_out}"
+        )
+    flat_iter = product(*(range(d) for d in output_dims))
+    for idx, expected in zip(flat_iter, expected_values):
+        c.assert_eq(out[idx], int(expected))
+    return out
+
+
+def flatten_row_major(tensor) -> List[int]:
+    """Flatten a nested list (of any rank) in row-major order."""
+    out: List[int] = []
+
+    def walk(x):
+        if isinstance(x, (list, tuple)):
+            for v in x:
+                walk(v)
+        else:
+            out.append(int(x))
+
+    walk(tensor)
+    return out
+
+
+def evaluate_einsum(spec: str, tensors: Sequence) -> List[int]:
+    """Reference implementation, used by tests/demos to compute the expected output."""
+    input_specs, output_spec = parse_einsum(spec)
+    flats = [flatten_row_major(t) for t in tensors]
+    shapes = []
+    for spec_i, t in zip(input_specs, tensors):
+        shape = []
+        cur = t
+        for _ in spec_i:
+            shape.append(len(cur))
+            cur = cur[0] if isinstance(cur, (list, tuple)) else cur
+        shapes.append(shape)
+    dims = resolve_dims(input_specs, shapes)
+
+    contraction_syms = [s for s in dims if s not in output_spec]
+    output_dims = [dims[s] for s in output_spec]
+    contraction_dims = [dims[s] for s in contraction_syms]
+
+    n_out = 1
+    for d in output_dims:
+        n_out *= d
+    out = [0] * n_out
+
+    for i, out_assign in enumerate(product(*(range(d) for d in output_dims))):
+        out_map = dict(zip(output_spec, out_assign))
+        total = 0
+        contraction_iter = (
+            product(*(range(d) for d in contraction_dims))
+            if contraction_dims
+            else [()]
+        )
+        for con_assign in contraction_iter:
+            con_map = dict(zip(contraction_syms, con_assign))
+            full = {**out_map, **con_map}
+            term = 1
+            for t, spec_i in enumerate(input_specs):
+                offset = _flat_index(spec_i, full, dims)
+                term *= flats[t][offset]
+            total += term
+        out[i] = total
+    return out

--- a/quicksilver/fiat_shamir.py
+++ b/quicksilver/fiat_shamir.py
@@ -1,0 +1,167 @@
+"""Fiat-Shamir transform for the QuickSilver protocol.
+
+The interactive protocol has one verifier message: the random
+challenge ``chi`` for the batched multiplication-consistency check.
+Replacing it with a hash of the transcript so far makes the proof
+non-interactive: the prover produces a single object ``NIProof =
+(msg1, msg2)`` and any party holding the verifier key can check it.
+
+Note this remains *designated-verifier*. The verifier's secret
+``Delta`` is required to validate the IT-MAC openings; without it a
+third party cannot verify. Fiat-Shamir gives non-interactivity, not
+public verifiability.
+
+Random oracle: SHA-256 in counter mode. Honest-verifier ZK in the
+interactive protocol implies ZK in the random oracle model after the
+transform (standard result, e.g. Pointcheval-Stern).
+
+Whether to absorb the circuit
+-----------------------------
+
+The circuit must be bound into the transcript so a malicious prover
+cannot pick gates after seeing ``chi``. We hash a canonical
+serialisation of (op, args) for every gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from quicksilver.circuit import Circuit, Op
+from quicksilver.field import F, Fp
+from quicksilver.protocol import (
+    BatchedCheck,
+    CommitMessage,
+    prove,
+    verify,
+)
+from quicksilver.vole import VoleProverShare, VoleVerifierShare, trusted_dealer_setup
+
+
+_DOMAIN = b"quicksilver/v1/fiat-shamir"
+
+
+class Transcript:
+    """Sponge-like transcript over SHA-256.
+
+    ``absorb_*`` mixes new bytes into the state; ``challenge`` squeezes
+    a field element. Each squeeze advances the state so subsequent
+    squeezes are independent.
+    """
+
+    __slots__ = ("_buf",)
+
+    def __init__(self, label: bytes = _DOMAIN):
+        self._buf = bytearray()
+        self._buf += b"label:"
+        self._buf += len(label).to_bytes(4, "big")
+        self._buf += label
+
+    def absorb_bytes(self, tag: bytes, data: bytes) -> None:
+        self._buf += b"|"
+        self._buf += tag
+        self._buf += b":"
+        self._buf += len(data).to_bytes(4, "big")
+        self._buf += data
+
+    def absorb_int(self, tag: bytes, x: int, nbytes: int = 32) -> None:
+        self.absorb_bytes(tag, x.to_bytes(nbytes, "big"))
+
+    def absorb_ints(self, tag: bytes, xs: Iterable[int], nbytes: int = 32) -> None:
+        body = bytearray()
+        for x in xs:
+            body += x.to_bytes(nbytes, "big")
+        self.absorb_bytes(tag, bytes(body))
+
+    def absorb_circuit(self, circuit: Circuit) -> None:
+        body = bytearray()
+        # Top-line shape so num-* changes invalidate the transcript even
+        # if gates compare equal (defence in depth).
+        for n in (circuit.num_wires, circuit.num_inputs,
+                  circuit.num_muls, circuit.num_asserts):
+            body += n.to_bytes(8, "big")
+        for g in circuit.gates:
+            body += g.op.value.encode()
+            body += b"("
+            for a in g.args:
+                body += int(a).to_bytes(32, "big", signed=True)
+                body += b","
+            body += b")|"
+            if g.out is not None:
+                body += g.out.to_bytes(8, "big")
+        self.absorb_bytes(b"circuit", bytes(body))
+
+    def challenge(self, field: Fp = F) -> int:
+        # Hash-to-field via rejection on a 32-byte squeeze. p ~= 2^127 so
+        # rejection happens with probability ~ 1/2 per draw; cheap enough.
+        counter = 0
+        while True:
+            h = hashlib.sha256()
+            h.update(b"squeeze")
+            h.update(counter.to_bytes(8, "big"))
+            h.update(bytes(self._buf))
+            digest = h.digest()
+            x = int.from_bytes(digest, "big") % (1 << field.p.bit_length())
+            if x < field.p and x != 0:
+                # Mix the digest back so subsequent squeezes are independent.
+                self._buf += b"|squeezed:"
+                self._buf += digest
+                return x
+            counter += 1
+
+
+@dataclass
+class NIProof:
+    """A non-interactive QuickSilver proof for a designated verifier."""
+
+    msg1: CommitMessage
+    msg2: BatchedCheck
+
+
+def _absorb_msg1(t: Transcript, msg: CommitMessage) -> None:
+    t.absorb_ints(b"d_values", msg.d_values)
+    t.absorb_ints(b"openings", msg.assert_openings)
+
+
+def prove_ni(
+    circuit: Circuit,
+    witness: List[int],
+    share: VoleProverShare,
+    field: Fp = F,
+    label: bytes = _DOMAIN,
+) -> NIProof:
+    """Produce a non-interactive QuickSilver proof."""
+    msg1, batched = prove(circuit, witness, share, field)
+    t = Transcript(label)
+    t.absorb_circuit(circuit)
+    _absorb_msg1(t, msg1)
+    chi = t.challenge(field)
+    return NIProof(msg1=msg1, msg2=batched(chi))
+
+
+def verify_ni(
+    circuit: Circuit,
+    share: VoleVerifierShare,
+    proof: NIProof,
+    field: Fp = F,
+    label: bytes = _DOMAIN,
+) -> bool:
+    t = Transcript(label)
+    t.absorb_circuit(circuit)
+    _absorb_msg1(t, proof.msg1)
+    chi = t.challenge(field)
+    return verify(circuit, share, proof.msg1, chi, proof.msg2, field)
+
+
+def run_ni(
+    circuit: Circuit,
+    witness: List[int],
+    field: Fp = F,
+    label: bytes = _DOMAIN,
+):
+    """End-to-end: setup + non-interactive prove + verify."""
+    p_share, v_share = trusted_dealer_setup(circuit.vole_count(), field)
+    proof = prove_ni(circuit, witness, p_share, field, label)
+    return verify_ni(circuit, v_share, proof, field, label), proof

--- a/quicksilver/field.py
+++ b/quicksilver/field.py
@@ -1,0 +1,69 @@
+"""Prime-field arithmetic over the Mersenne prime p = 2**127 - 1.
+
+A 127-bit prime gives soundness error ~2^-126 per check, comfortably
+beyond the cryptographic threshold while keeping pure-Python arithmetic
+fast (no big-int reductions worth optimising further at this scale).
+
+The field is exposed as a singleton ``F`` whose elements are plain ints
+in [0, p). Operations take and return ints; this stays cheap and avoids
+the per-op overhead of a wrapper class.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Fp:
+    """Prime field F_p with p = 2**bits - 1 (Mersenne) or generic prime."""
+
+    p: int
+
+    def add(self, a: int, b: int) -> int:
+        return (a + b) % self.p
+
+    def sub(self, a: int, b: int) -> int:
+        return (a - b) % self.p
+
+    def neg(self, a: int) -> int:
+        return (-a) % self.p
+
+    def mul(self, a: int, b: int) -> int:
+        return (a * b) % self.p
+
+    def inv(self, a: int) -> int:
+        if a % self.p == 0:
+            raise ZeroDivisionError("inverse of zero in F_p")
+        return pow(a, self.p - 2, self.p)
+
+    def div(self, a: int, b: int) -> int:
+        return self.mul(a, self.inv(b))
+
+    def pow(self, a: int, e: int) -> int:
+        return pow(a, e, self.p)
+
+    def rand(self) -> int:
+        """Uniform sample from F_p via rejection."""
+        # 2**127 - 1 is so close to a power of two that rejection almost
+        # never fires; for general primes this is still correct.
+        bits = self.p.bit_length()
+        while True:
+            r = secrets.randbits(bits)
+            if r < self.p:
+                return r
+
+    def rand_nonzero(self) -> int:
+        while True:
+            r = self.rand()
+            if r != 0:
+                return r
+
+    def encode(self, x: int) -> int:
+        """Reduce an arbitrary int into [0, p)."""
+        return x % self.p
+
+
+# Mersenne prime 2^127 - 1. Soundness error per check ~ 1 / 2^127.
+F = Fp(p=(1 << 127) - 1)

--- a/quicksilver/gf2k.py
+++ b/quicksilver/gf2k.py
@@ -1,0 +1,100 @@
+"""GF(2^128) arithmetic with the GCM irreducible polynomial.
+
+Elements are integers in [0, 2^128). Addition is XOR (characteristic 2).
+Multiplication is carry-less polynomial multiplication followed by
+reduction mod ``x^128 + x^7 + x^2 + x + 1`` -- the same polynomial used
+by AES-GCM, so test vectors are widely available.
+
+Pure Python, ~5 us per multiply on modest hardware. Fast enough for the
+educational MAC-field role and slow enough that you would never use this
+in production. Replace with ``cryptography.hazmat.primitives.poly1305``
+or a CLMUL intrinsic if you actually care.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+
+_MASK = (1 << 128) - 1
+_REDUCTION = 0x87  # low bits of x^128 + x^7 + x^2 + x + 1
+_HIGH_BIT = 1 << 127
+
+
+def _mul(a: int, b: int) -> int:
+    a &= _MASK
+    b &= _MASK
+    result = 0
+    for _ in range(128):
+        if b & 1:
+            result ^= a
+        b >>= 1
+        if a & _HIGH_BIT:
+            a = ((a << 1) & _MASK) ^ _REDUCTION
+        else:
+            a <<= 1
+    return result
+
+
+@dataclass(frozen=True)
+class GF2k:
+    """Field abstraction with the same interface as ``Fp``.
+
+    The ``p`` attribute is set to ``2**128`` for convenience -- it is
+    *not* a prime, and the field has 2^128 elements. Anything that
+    needs a "field size" should use ``order`` instead.
+    """
+
+    bits: int = 128
+    p: int = 1 << 128  # purely for interface compatibility with Fp
+
+    @property
+    def order(self) -> int:
+        return 1 << self.bits
+
+    def encode(self, x: int) -> int:
+        return x & _MASK
+
+    def add(self, a: int, b: int) -> int:
+        return (a ^ b) & _MASK
+
+    def sub(self, a: int, b: int) -> int:
+        return (a ^ b) & _MASK  # characteristic 2
+
+    def neg(self, a: int) -> int:
+        return a & _MASK
+
+    def mul(self, a: int, b: int) -> int:
+        return _mul(a, b)
+
+    def pow(self, a: int, e: int) -> int:
+        """Square-and-multiply."""
+        result = 1
+        base = a & _MASK
+        while e > 0:
+            if e & 1:
+                result = _mul(result, base)
+            base = _mul(base, base)
+            e >>= 1
+        return result
+
+    def inv(self, a: int) -> int:
+        """Inversion via Fermat's little theorem: a^(2^128 - 2)."""
+        if a == 0:
+            raise ZeroDivisionError("inverse of zero in GF(2^128)")
+        return self.pow(a, (1 << 128) - 2)
+
+    def div(self, a: int, b: int) -> int:
+        return self.mul(a, self.inv(b))
+
+    def rand(self) -> int:
+        return secrets.randbits(128)
+
+    def rand_nonzero(self) -> int:
+        while True:
+            r = self.rand()
+            if r != 0:
+                return r
+
+
+GF128 = GF2k()

--- a/quicksilver/itmac.py
+++ b/quicksilver/itmac.py
@@ -1,0 +1,104 @@
+"""Information-theoretic MACs derived from VOLE.
+
+For every wire value ``x in F_p`` the prover holds a tag ``M`` and the
+verifier holds a key ``K`` related by
+
+    K = M + Delta * x.
+
+Linear operations on (x, M) and on K are coordinated so the relation is
+preserved without communication. Only multiplications need the
+QuickSilver consistency check.
+
+Two views of a wire are exposed:
+
+    ProverWire(x, m)   -- prover side
+    VerifierWire(k)    -- verifier side
+
+Constants are lifted into wires by setting ``M = 0`` on the prover and
+``K = Delta * c`` on the verifier.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from quicksilver.field import F, Fp
+
+
+@dataclass(frozen=True)
+class ProverWire:
+    """A wire as seen by the prover: cleartext value and IT-MAC tag."""
+
+    x: int
+    m: int
+
+    def add(self, other: "ProverWire", field: Fp = F) -> "ProverWire":
+        return ProverWire(field.add(self.x, other.x), field.add(self.m, other.m))
+
+    def sub(self, other: "ProverWire", field: Fp = F) -> "ProverWire":
+        return ProverWire(field.sub(self.x, other.x), field.sub(self.m, other.m))
+
+    def add_const(self, c: int, field: Fp = F) -> "ProverWire":
+        # Adding a public constant does not change the tag.
+        return ProverWire(field.add(self.x, c), self.m)
+
+    def mul_const(self, c: int, field: Fp = F) -> "ProverWire":
+        return ProverWire(field.mul(self.x, c), field.mul(self.m, c))
+
+
+@dataclass(frozen=True)
+class VerifierWire:
+    """A wire as seen by the verifier: only the key is known."""
+
+    k: int
+
+    def add(self, other: "VerifierWire", field: Fp = F) -> "VerifierWire":
+        return VerifierWire(field.add(self.k, other.k))
+
+    def sub(self, other: "VerifierWire", field: Fp = F) -> "VerifierWire":
+        return VerifierWire(field.sub(self.k, other.k))
+
+    def add_const(self, c: int, delta: int, field: Fp = F) -> "VerifierWire":
+        # The key for a public constant ``c`` is Delta * c.
+        return VerifierWire(field.add(self.k, field.mul(delta, c)))
+
+    def mul_const(self, c: int, field: Fp = F) -> "VerifierWire":
+        return VerifierWire(field.mul(self.k, c))
+
+
+def prover_commit(value: int, u: int, v: int, field: Fp = F) -> tuple[ProverWire, int]:
+    """Convert one VOLE element into an IT-MAC commitment.
+
+    Returns the prover's wire and the message ``d = x - u`` to send to
+    the verifier.
+    """
+    d = field.sub(value, u)
+    # M = v, since K = w + Delta * d = Delta * u + v + Delta * (x - u) = v + Delta * x.
+    return ProverWire(x=value, m=v), d
+
+
+def verifier_receive(d: int, w: int, delta: int, field: Fp = F) -> VerifierWire:
+    """Verifier's side of ``prover_commit``."""
+    return VerifierWire(k=field.add(w, field.mul(delta, d)))
+
+
+def prover_const(c: int) -> ProverWire:
+    return ProverWire(x=c, m=0)
+
+
+def verifier_const(c: int, delta: int, field: Fp = F) -> VerifierWire:
+    return VerifierWire(k=field.mul(delta, c))
+
+
+def open_to_zero(w: ProverWire) -> int:
+    """Reveal a wire that the prover claims is zero, by sending its tag.
+
+    The verifier checks ``K == M`` (since ``K = M + Delta*0 = M``).
+    """
+    if w.x != 0:
+        raise ValueError("prover wire claimed to be zero is nonzero")
+    return w.m
+
+
+# Sugar: simple alias used in the protocol module.
+Wire = ProverWire

--- a/quicksilver/lpn_vole.py
+++ b/quicksilver/lpn_vole.py
@@ -1,0 +1,171 @@
+"""LPN-based VOLE extension (pseudorandom correlation generator).
+
+The trusted dealer in ``vole.py`` hands out N VOLE correlations
+explicitly. Real VOLE-based ZK protocols replace this with a
+*pseudorandom correlation generator* (PCG): a small sparse base
+correlation gets locally expanded to N pseudorandom correlations
+using public structure, with no further communication. This module
+implements the LPN / regular-syndrome-decoding flavour due to
+Boyle, Couteau, Gilboa, Ishai (CCS 2019) -- the same primitive used
+by Wolverine, Mac'n'Cheese, and (in subspace form) by QuickSilver.
+
+Construction
+------------
+
+Let `k` be a base length, `t` the noise weight, and `N` the output
+length.  The PCG:
+
+1. Produces a length-k VOLE correlation whose prover-side ``u_base``
+   has Hamming weight exactly ``t`` (rest zero). Soundness reduction
+   to "regular LPN / regular syndrome decoding" is well-studied.
+2. Both parties hold a public N x k matrix ``H`` derived from a seed.
+3. Output VOLE = H * base (matrix-vector product on each share).
+   Linearity preserves the IT-MAC relation; ``u_out = H * u_base`` is
+   pseudorandom under regular-LPN with the right (k, t) parameters.
+
+What this module *does*
+-----------------------
+
+- Generates a sparse base VOLE via the trusted dealer (still
+  centralised; the cryptographic step we are replacing is the *expansion*
+  from base to output, not the base itself).
+- Implements the H-multiply expansion deterministically from a seed.
+- Returns standard ``VoleProverShare`` / ``VoleVerifierShare`` objects so
+  the result is a drop-in replacement for ``trusted_dealer_setup``.
+
+What this module *does not* do
+------------------------------
+
+- Implement base OT or SPCOT (the GGM-tree single-point VOLE that
+  removes the trusted base). That is a separate primitive of comparable
+  scope; the extension step here is the more cryptographically
+  characteristic part of the PCG.
+- Pick LPN parameters at any concrete security level. The defaults
+  ``(k=2N, t=N//4)`` are *not* secure -- they are merely large enough
+  to demonstrate the technique. Real parameters from BCGI19 are
+  k around 2^14, t around 760 for 80-bit primary security.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+from typing import Sequence
+
+from quicksilver.field import F, Fp
+from quicksilver.vole import VoleProverShare, VoleVerifierShare
+
+
+@dataclass(frozen=True)
+class LpnParams:
+    n_out: int   # number of output VOLE elements
+    k_base: int  # base correlation length
+    t_weight: int  # Hamming weight of the base error
+    seed: bytes  # public 32-byte seed for the H matrix
+
+    @classmethod
+    def default(cls, n_out: int, seed: bytes | None = None) -> "LpnParams":
+        if seed is None:
+            seed = secrets.token_bytes(32)
+        return cls(n_out=n_out, k_base=2 * n_out, t_weight=max(4, n_out // 4),
+                   seed=seed)
+
+
+def derive_matrix(seed: bytes, n_rows: int, n_cols: int, field: Fp) -> list:
+    """Pseudorandom field-valued ``n_rows x n_cols`` matrix from ``seed``.
+
+    Bulk-streams bytes from SHA-256 in counter mode and reduces each
+    chunk modulo p. This introduces a sub-2^-128 bias (negligible vs p),
+    far below any cryptographic threshold and far cheaper than per-entry
+    rejection sampling.
+    """
+    p = field.p
+    bytes_per = (p.bit_length() + 128 + 7) // 8  # 16-byte slack drowns the bias
+    needed = n_rows * n_cols * bytes_per
+
+    out = bytearray()
+    counter = 0
+    while len(out) < needed:
+        h = hashlib.sha256()
+        h.update(b"lpn-vole/H/v1")
+        h.update(seed)
+        h.update(counter.to_bytes(8, "big"))
+        out += h.digest()
+        counter += 1
+
+    H = []
+    pos = 0
+    for _ in range(n_rows):
+        row = [0] * n_cols
+        for j in range(n_cols):
+            x = int.from_bytes(out[pos:pos + bytes_per], "big") % p
+            row[j] = x
+            pos += bytes_per
+        H.append(row)
+    return H
+
+
+def _matvec(M, x, field: Fp) -> list:
+    out = [0] * len(M)
+    for i, row in enumerate(M):
+        acc = 0
+        for j, h_ij in enumerate(row):
+            if h_ij == 0:
+                continue
+            acc = field.add(acc, field.mul(h_ij, x[j]))
+        out[i] = acc
+    return out
+
+
+def _sparse_base_vole(
+    k: int, t: int, field: Fp, delta: int
+) -> tuple[list[int], list[int], list[int]]:
+    """Trusted-dealer base correlation: ``u`` has Hamming weight exactly ``t``."""
+    if t > k:
+        raise ValueError("hamming weight cannot exceed base length")
+    rng = secrets.SystemRandom()
+    positions = rng.sample(range(k), t)
+    u = [0] * k
+    for pos in positions:
+        u[pos] = field.rand_nonzero()
+    v = [field.rand() for _ in range(k)]
+    w = [field.add(field.mul(u_i, delta), v_i) for u_i, v_i in zip(u, v)]
+    return u, v, w
+
+
+def lpn_vole_extend(
+    params: LpnParams,
+    field: Fp = F,
+    delta: int | None = None,
+) -> tuple[VoleProverShare, VoleVerifierShare]:
+    """Generate ``params.n_out`` VOLE correlations via LPN extension.
+
+    Drop-in replacement for ``trusted_dealer_setup``: the returned
+    ``VoleProverShare`` and ``VoleVerifierShare`` plug straight into
+    ``protocol.prove`` and ``protocol.verify``.
+    """
+    if delta is None:
+        delta = field.rand()
+    H = derive_matrix(params.seed, params.n_out, params.k_base, field)
+    u_base, v_base, w_base = _sparse_base_vole(
+        params.k_base, params.t_weight, field, delta
+    )
+    u_out = _matvec(H, u_base, field)
+    v_out = _matvec(H, v_base, field)
+    w_out = _matvec(H, w_base, field)
+    return (
+        VoleProverShare(u=u_out, v=v_out),
+        VoleVerifierShare(delta=delta, w=w_out),
+    )
+
+
+def correlation_holds(
+    p_share: VoleProverShare, v_share: VoleVerifierShare, field: Fp = F
+) -> bool:
+    if len(p_share) != len(v_share):
+        return False
+    for u, v, w in zip(p_share.u, p_share.v, v_share.w):
+        if w != field.add(field.mul(u, v_share.delta), v):
+            return False
+    return True

--- a/quicksilver/polynomial.py
+++ b/quicksilver/polynomial.py
@@ -1,0 +1,230 @@
+"""Degree-d polynomial constraint check (Section 5 of the paper).
+
+The basic QuickSilver protocol in ``protocol.py`` only proves degree-2
+relations (multiplication gates). The same VOLE-IT-MAC machinery
+extends, with no extra committed wires, to *arbitrary* degree-d
+polynomial relations between committed values. Communication cost is
+``d`` field elements per batch (regardless of how many constraints
+of that degree are batched), versus ``d-1`` extra multiplication
+gates per constraint if you tried to express it via the mul protocol.
+
+Identity exploited
+------------------
+
+For each committed wire i, ``K_i = M_i + Delta * x_i``. To make the
+"leading Delta coefficient = constraint value" identity hold for
+polynomials with mixed-degree monomials, we work with the
+Delta-homogenisation of P:
+
+    P~(K; Delta) := sum_t coeff_t * Delta^{d - deg(t)} * prod_{i in idx_t} K_i
+
+(scaling each degree-e monomial by Delta^{d-e}). Then
+
+    P~(M + Delta x; Delta) = sum_{k=0}^{d} A_k * Delta^k
+
+with ``A_d == P(x_1, ..., x_n)``. Honest prover: ``A_d = 0``. Prover
+sends the lower coefficients ``(A_0, ..., A_{d-1})``; verifier
+recomputes ``P~(K_1, ..., K_n; Delta)`` and checks the identity.
+
+Batching m such constraints with a verifier challenge chi is
+straightforward: ``A_e := sum_j chi^j * A_{e,j}``.
+
+ZK masking uses ``d-1`` fresh VOLE elements; the d=2 case recovers the
+single-mask construction used for multiplication.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from typing import List, Sequence, Tuple
+
+from quicksilver.field import F, Fp
+from quicksilver.itmac import ProverWire, VerifierWire
+from quicksilver.vole import (
+    VoleProverShare,
+    VoleVerifierShare,
+    trusted_dealer_setup,
+)
+
+
+# A monomial is a coefficient and a tuple of wire-ids (with repetition).
+# Example: 3 * x_1 * x_2^2  ==  (3, (1, 2, 2)).
+Monomial = Tuple[int, Tuple[int, ...]]
+
+
+@dataclass(frozen=True)
+class Polynomial:
+    """Sparse multivariate polynomial over wire-id variables."""
+
+    terms: Tuple[Monomial, ...]
+
+    @property
+    def degree(self) -> int:
+        return max((len(idx) for _, idx in self.terms), default=0)
+
+    def evaluate(self, values: dict, field: Fp = F) -> int:
+        out = 0
+        for coeff, idx in self.terms:
+            term = field.encode(coeff)
+            for wid in idx:
+                term = field.mul(term, values[wid])
+            out = field.add(out, term)
+        return out
+
+
+def _delta_coefficients(
+    poly: Polynomial,
+    prover_wires: dict,
+    field: Fp,
+) -> List[int]:
+    """Coefficients A_0..A_d of P~(M + Delta x; Delta) as a poly in Delta.
+
+    A degree-e monomial coeff * prod_{i in idx} (M_i + Delta x_i),
+    pre-scaled by Delta^{d-e}, contributes to A_k for k = (d-e) + |S|
+    where S ranges over subsets of idx (the indices substituted with x).
+    """
+    d = poly.degree
+    coeffs = [0] * (d + 1)
+    for coeff, idx in poly.terms:
+        c = field.encode(coeff)
+        e = len(idx)
+        positions = list(range(e))
+        for s in range(e + 1):
+            k = d - e + s
+            for sset in combinations(positions, s):
+                term = c
+                sset_set = set(sset)
+                for i, wid in enumerate(idx):
+                    w = prover_wires[wid]
+                    factor = w.x if i in sset_set else w.m
+                    term = field.mul(term, factor)
+                coeffs[k] = field.add(coeffs[k], term)
+    return coeffs
+
+
+def _evaluate_on_keys(
+    poly: Polynomial, verifier_wires: dict, delta: int, field: Fp
+) -> int:
+    """Evaluate P~(K_1, ..., K_n; Delta) (the Delta-homogenisation)."""
+    d = poly.degree
+    out = 0
+    for coeff, idx in poly.terms:
+        e = len(idx)
+        term = field.mul(field.encode(coeff), field.pow(delta, d - e))
+        for wid in idx:
+            term = field.mul(term, verifier_wires[wid].k)
+        out = field.add(out, term)
+    return out
+
+
+@dataclass
+class PolyProof:
+    masked_A: List[int]  # length d
+
+
+def prove_polys(
+    polys: Sequence[Polynomial],
+    prover_wires: dict,
+    chi: int,
+    mask: VoleProverShare,
+    field: Fp = F,
+) -> PolyProof:
+    """Prover side of a batched degree-d polynomial-zero check.
+
+    ``mask`` must hold exactly ``d-1`` VOLE elements.  ``chi`` is the
+    verifier's challenge.  Honest prover: every polynomial in ``polys``
+    evaluates to zero on the committed wire values.
+    """
+    if not polys:
+        raise ValueError("need at least one polynomial")
+    d = max(p.degree for p in polys)
+    if any(p.degree != d for p in polys):
+        raise ValueError("batched polys must share the same degree")
+    if d < 1:
+        raise ValueError("degree must be at least 1")
+    if len(mask) != d - 1:
+        raise ValueError(f"need exactly {d - 1} masking VOLE elements, got {len(mask)}")
+
+    # Aggregate A_e = sum_j chi^j * A_{e,j}, e = 0..d.  Honest -> A_d = 0.
+    A = [0] * (d + 1)
+    chi_j = 1
+    for poly in polys:
+        chi_j = field.mul(chi_j, chi)  # chi^1, chi^2, ...
+        coeffs = _delta_coefficients(poly, prover_wires, field)
+        for e, c in enumerate(coeffs):
+            A[e] = field.add(A[e], field.mul(chi_j, c))
+
+    # Mask using the construction described in the module docstring:
+    # A_0' = A_0 + b^{(0)}
+    # A_e' = A_e + a^{(e-1)} + b^{(e)}     for 1 <= e <= d-2
+    # A_{d-1}' = A_{d-1} + a^{(d-2)}
+    masked = list(A[:d])  # drop A_d (must be zero)
+    for j in range(d - 1):
+        a_j, b_j = mask.u[j], mask.v[j]
+        masked[j] = field.add(masked[j], b_j)
+        masked[j + 1] = field.add(masked[j + 1], a_j)
+    return PolyProof(masked_A=masked)
+
+
+def verify_polys(
+    polys: Sequence[Polynomial],
+    verifier_wires: dict,
+    chi: int,
+    proof: PolyProof,
+    mask: VoleVerifierShare,
+    field: Fp = F,
+) -> bool:
+    if not polys:
+        return False
+    d = max(p.degree for p in polys)
+    if any(p.degree != d for p in polys):
+        return False
+    if len(proof.masked_A) != d:
+        return False
+    if len(mask) != d - 1:
+        return False
+    delta = mask.delta
+
+    # LHS: sum_e A_e' * Delta^e
+    lhs = 0
+    delta_pow = 1
+    for e in range(d):
+        lhs = field.add(lhs, field.mul(proof.masked_A[e], delta_pow))
+        delta_pow = field.mul(delta_pow, delta)
+
+    # RHS: sum_j chi^j * P_j(K_1, ..., K_n) + sum_j c^{(j)} * Delta^j
+    rhs = 0
+    chi_j = 1
+    for poly in polys:
+        chi_j = field.mul(chi_j, chi)
+        b_j = _evaluate_on_keys(poly, verifier_wires, delta, field)
+        rhs = field.add(rhs, field.mul(chi_j, b_j))
+    delta_pow = 1
+    for j in range(d - 1):
+        rhs = field.add(rhs, field.mul(mask.w[j], delta_pow))
+        delta_pow = field.mul(delta_pow, delta)
+    return lhs == rhs
+
+
+# ---- One-shot helper for tests / demos -------------------------------------
+
+
+def run_poly_check(
+    polys: Sequence[Polynomial],
+    prover_wires: dict,
+    verifier_wires: dict,
+    delta: int,
+    field: Fp = F,
+) -> bool:
+    """End-to-end batched polynomial-zero check given existing IT-MACs.
+
+    Generates the ``d-1`` masking VOLE elements with ``delta`` fixed
+    (so they are consistent with the wires already committed under
+    that Delta).
+    """
+    d = max(p.degree for p in polys)
+    p_share, v_share = trusted_dealer_setup(d - 1, field, delta=delta)
+    chi = field.rand_nonzero()
+    proof = prove_polys(polys, prover_wires, chi, p_share, field)
+    return verify_polys(polys, verifier_wires, chi, proof, v_share, field)

--- a/quicksilver/protocol.py
+++ b/quicksilver/protocol.py
@@ -1,0 +1,272 @@
+"""QuickSilver interactive protocol.
+
+Three rounds (after VOLE preprocessing):
+
+    P -> V : per-input and per-mul commitments d_i = x_i - u_i,
+             plus opened tag M for each assert-zero wire.
+    V -> P : random challenge chi in F_p.
+    P -> V : batched multiplication-consistency proof (U, V),
+             masked by one fresh VOLE element so it leaks nothing.
+
+The verifier accepts iff every assert-zero check passes and the
+batched identity ``W + c == U + V * Delta`` holds, where W and c are
+verifier-side aggregates (see ``_VerifierWalker.batched_check``).
+
+Soundness error per execution is bounded by ``(m + 2) / |F|`` for ``m``
+multiplication gates (Lemma 3 of the paper, specialised to a large
+prime field). With p = 2^127 - 1 this is well below 2^-120 for any
+circuit you would ever run in pure Python.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dc_field
+from typing import Iterator, List, Tuple
+
+from quicksilver.circuit import Circuit, Gate, Op
+from quicksilver.field import F, Fp
+from quicksilver.itmac import (
+    ProverWire,
+    VerifierWire,
+    open_to_zero,
+    prover_commit,
+    prover_const,
+    verifier_const,
+    verifier_receive,
+)
+from quicksilver.vole import (
+    VoleProverShare,
+    VoleVerifierShare,
+    trusted_dealer_setup,
+)
+
+
+# ---- Messages exchanged between prover and verifier ------------------------
+
+
+@dataclass
+class CommitMessage:
+    """Round 1: prover -> verifier."""
+
+    d_values: List[int]      # one per input or mul gate, in gate order
+    assert_openings: List[int]  # one M tag per assert_zero gate
+
+
+@dataclass
+class BatchedCheck:
+    """Round 3: prover -> verifier."""
+
+    U: int
+    V: int
+
+
+# ---- Prover walker ---------------------------------------------------------
+
+
+@dataclass
+class _ProverWalker:
+    circuit: Circuit
+    witness: List[int]
+    share: VoleProverShare
+    field: Fp = F
+    wires: dict = dc_field(default_factory=dict)
+    d_values: List[int] = dc_field(default_factory=list)
+    assert_openings: List[int] = dc_field(default_factory=list)
+    mul_triples: List[Tuple[ProverWire, ProverWire, ProverWire]] = dc_field(default_factory=list)
+    mask_a: int = 0
+    mask_b: int = 0
+
+    def commit(self) -> CommitMessage:
+        if len(self.witness) != self.circuit.num_inputs:
+            raise ValueError(
+                f"witness length {len(self.witness)} != num inputs {self.circuit.num_inputs}"
+            )
+        vole = iter(zip(self.share.u, self.share.v))
+        wit = iter(self.witness)
+        for g in self.circuit.gates:
+            self._exec(g, wit, vole)
+        # Reserve one final VOLE element to mask the batched mul check.
+        self.mask_a, self.mask_b = next(vole)
+        return CommitMessage(self.d_values, self.assert_openings)
+
+    def _exec(self, g: Gate, wit: Iterator[int], vole: Iterator[Tuple[int, int]]) -> None:
+        F_ = self.field
+        op = g.op
+        if op is Op.INPUT:
+            x = F_.encode(next(wit))
+            u, v = next(vole)
+            wire, d = prover_commit(x, u, v, F_)
+            self.wires[g.out] = wire
+            self.d_values.append(d)
+        elif op is Op.CONST:
+            (c,) = g.args
+            self.wires[g.out] = prover_const(F_.encode(c))
+        elif op is Op.ADD:
+            a, b = g.args
+            self.wires[g.out] = self.wires[a].add(self.wires[b], F_)
+        elif op is Op.SUB:
+            a, b = g.args
+            self.wires[g.out] = self.wires[a].sub(self.wires[b], F_)
+        elif op is Op.ADD_CONST:
+            a, c = g.args
+            self.wires[g.out] = self.wires[a].add_const(F_.encode(c), F_)
+        elif op is Op.MUL_CONST:
+            a, c = g.args
+            self.wires[g.out] = self.wires[a].mul_const(F_.encode(c), F_)
+        elif op is Op.MUL:
+            a, b = g.args
+            xw = self.wires[a]
+            yw = self.wires[b]
+            z = F_.mul(xw.x, yw.x)
+            u, v = next(vole)
+            zw, d = prover_commit(z, u, v, F_)
+            self.wires[g.out] = zw
+            self.d_values.append(d)
+            self.mul_triples.append((xw, yw, zw))
+        elif op is Op.ASSERT_ZERO:
+            (a,) = g.args
+            self.assert_openings.append(open_to_zero(self.wires[a]))
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unknown op {op}")
+
+    def batched_check(self, chi: int) -> BatchedCheck:
+        """Compute (U, V) such that U + V * Delta = sum_i chi^i * B_i + c.
+
+        Honest prover: A0_i = M_x M_y, A1_i = x M_y + y M_x - M_z.
+        We then mask with the reserved VOLE element to make U, V uniform.
+        """
+        F_ = self.field
+        U_raw = 0
+        V_raw = 0
+        chi_i = 1
+        for xw, yw, zw in self.mul_triples:
+            chi_i = F_.mul(chi_i, chi)  # start at chi^1
+            A0 = F_.mul(xw.m, yw.m)
+            A1 = F_.sub(
+                F_.add(F_.mul(xw.x, yw.m), F_.mul(yw.x, xw.m)),
+                zw.m,
+            )
+            U_raw = F_.add(U_raw, F_.mul(chi_i, A0))
+            V_raw = F_.add(V_raw, F_.mul(chi_i, A1))
+        return BatchedCheck(
+            U=F_.add(U_raw, self.mask_b),
+            V=F_.add(V_raw, self.mask_a),
+        )
+
+
+# ---- Verifier walker -------------------------------------------------------
+
+
+@dataclass
+class _VerifierWalker:
+    circuit: Circuit
+    share: VoleVerifierShare
+    field: Fp = F
+    wires: dict = dc_field(default_factory=dict)
+    mul_keys: List[Tuple[VerifierWire, VerifierWire, VerifierWire]] = dc_field(default_factory=list)
+    assert_keys: List[VerifierWire] = dc_field(default_factory=list)
+    mask_c: int = 0
+    _assert_openings: List[int] = dc_field(default_factory=list)
+
+    def receive(self, msg: CommitMessage) -> None:
+        F_ = self.field
+        d_iter = iter(msg.d_values)
+        w_iter = iter(self.share.w)
+        delta = self.share.delta
+        for g in self.circuit.gates:
+            op = g.op
+            if op is Op.INPUT:
+                d = next(d_iter)
+                w = next(w_iter)
+                self.wires[g.out] = verifier_receive(d, w, delta, F_)
+            elif op is Op.CONST:
+                (c,) = g.args
+                self.wires[g.out] = verifier_const(F_.encode(c), delta, F_)
+            elif op is Op.ADD:
+                a, b = g.args
+                self.wires[g.out] = self.wires[a].add(self.wires[b], F_)
+            elif op is Op.SUB:
+                a, b = g.args
+                self.wires[g.out] = self.wires[a].sub(self.wires[b], F_)
+            elif op is Op.ADD_CONST:
+                a, c = g.args
+                self.wires[g.out] = self.wires[a].add_const(F_.encode(c), delta, F_)
+            elif op is Op.MUL_CONST:
+                a, c = g.args
+                self.wires[g.out] = self.wires[a].mul_const(F_.encode(c), F_)
+            elif op is Op.MUL:
+                a, b = g.args
+                d = next(d_iter)
+                w = next(w_iter)
+                kz = verifier_receive(d, w, delta, F_)
+                self.wires[g.out] = kz
+                self.mul_keys.append((self.wires[a], self.wires[b], kz))
+            elif op is Op.ASSERT_ZERO:
+                (a,) = g.args
+                self.assert_keys.append(self.wires[a])
+            else:  # pragma: no cover
+                raise AssertionError(f"unknown op {op}")
+        # Last VOLE element is the masking element.
+        self.mask_c = next(w_iter)
+        self._assert_openings = list(msg.assert_openings)
+
+    def check_assertions(self) -> bool:
+        # For a wire claimed to be zero, K = M + Delta * 0 = M.
+        if len(self._assert_openings) != len(self.assert_keys):
+            return False
+        for opened_m, key_wire in zip(self._assert_openings, self.assert_keys):
+            if key_wire.k != opened_m:
+                return False
+        return True
+
+    def check_batched(self, chi: int, msg: BatchedCheck) -> bool:
+        F_ = self.field
+        delta = self.share.delta
+        W = 0
+        chi_i = 1
+        for kx, ky, kz in self.mul_keys:
+            chi_i = F_.mul(chi_i, chi)
+            B = F_.sub(F_.mul(kx.k, ky.k), F_.mul(delta, kz.k))
+            W = F_.add(W, F_.mul(chi_i, B))
+        lhs = F_.add(W, self.mask_c)
+        rhs = F_.add(msg.U, F_.mul(msg.V, delta))
+        return lhs == rhs
+
+
+# ---- Public API ------------------------------------------------------------
+
+
+def prove(circuit: Circuit, witness: List[int], share: VoleProverShare, field: Fp = F):
+    """Run the prover side. Returns (commit_msg, batched_fn).
+
+    ``batched_fn(chi)`` produces the round-3 message after the verifier
+    sends its challenge. Splitting the prover this way keeps the
+    interaction explicit.
+    """
+    walker = _ProverWalker(circuit=circuit, witness=witness, share=share, field=field)
+    msg1 = walker.commit()
+    return msg1, walker.batched_check
+
+
+def verify(
+    circuit: Circuit,
+    share: VoleVerifierShare,
+    msg1: CommitMessage,
+    chi: int,
+    msg2: BatchedCheck,
+    field: Fp = F,
+) -> bool:
+    walker = _VerifierWalker(circuit=circuit, share=share, field=field)
+    walker.receive(msg1)
+    if not walker.check_assertions():
+        return False
+    return walker.check_batched(chi, msg2)
+
+
+def run(circuit: Circuit, witness: List[int], field: Fp = F) -> bool:
+    """End-to-end: setup + prove + challenge + verify, all in-process."""
+    p_share, v_share = trusted_dealer_setup(circuit.vole_count(), field)
+    msg1, batch = prove(circuit, witness, p_share, field)
+    chi = field.rand_nonzero()
+    msg2 = batch(chi)
+    return verify(circuit, v_share, msg1, chi, msg2, field)

--- a/quicksilver/vole.py
+++ b/quicksilver/vole.py
@@ -1,0 +1,61 @@
+"""VOLE setup, simulated by a trusted dealer.
+
+A single VOLE element gives:
+
+    Prover:   (u, v) in F_p x F_p   with u uniform
+    Verifier: w = u * Delta + v     in F_p
+
+The verifier's global secret Delta is fixed across all VOLE elements
+(a "subspace VOLE"). This is exactly what is needed to derive an
+information-theoretic MAC: see ``itmac.py``.
+
+In a real deployment the (u, v, w) triples would be produced by an
+LPN-based VOLE extension protocol (e.g. SoftSpoken, Wolverine's Ferret).
+That phase is the heavy hitter cryptographically but is orthogonal to
+QuickSilver itself. Here we model it as preprocessing handed out by an
+honest dealer; the rest of the protocol is faithful to the paper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+from quicksilver.field import F, Fp
+
+
+@dataclass
+class VoleProverShare:
+    """Prover's view of the preprocessed VOLE."""
+
+    u: List[int]
+    v: List[int]
+
+    def __len__(self) -> int:
+        return len(self.u)
+
+
+@dataclass
+class VoleVerifierShare:
+    """Verifier's view: a single global key Delta plus per-element w_i."""
+
+    delta: int
+    w: List[int]
+
+    def __len__(self) -> int:
+        return len(self.w)
+
+
+def trusted_dealer_setup(
+    n: int, field: Fp = F, delta: int | None = None
+) -> Tuple[VoleProverShare, VoleVerifierShare]:
+    """Generate ``n`` VOLE correlations honestly.
+
+    If ``delta`` is None a fresh random global key is sampled.
+    """
+    if delta is None:
+        delta = field.rand()
+    u = [field.rand() for _ in range(n)]
+    v = [field.rand() for _ in range(n)]
+    w = [field.add(field.mul(u_i, delta), v_i) for u_i, v_i in zip(u, v)]
+    return VoleProverShare(u=u, v=v), VoleVerifierShare(delta=delta, w=w)

--- a/quicksilver/zk_reachability.py
+++ b/quicksilver/zk_reachability.py
@@ -1,0 +1,236 @@
+"""ZK proof of graph reachability via the tensor-logic einsum recurrence.
+
+The Datalog rule for reachability,
+
+    Path(x, z) :- Edge(x, z).
+    Path(x, z) :- Path(x, y), Edge(y, z).
+
+is the same operation as the einsum
+
+    next_frontier = step( frontier @ Edge ).
+
+We use that recurrence to express a zero-knowledge statement:
+
+    "I know a graph G on n vertices and a length-k walk through G
+     from public source s to public target t."
+
+The prover commits to G (as an n*n adjacency matrix) and to k-1
+intermediate one-hot frontier vectors. The boundary frontiers are
+fixed to the one-hot indicators of s and t (public). The QuickSilver
+circuit enforces:
+
+    1. Every entry of G is in {0, 1}                       (booleanity)
+    2. Every committed frontier is one-hot                 (booleanity + sum-to-one)
+    3. For each step i in 0..k-1:
+           sum_{u, v}  alpha_i[u] * G[u][v] * alpha_{i+1}[v]  ==  1
+       i.e. there is at least one edge between the vertex
+       indicated by alpha_i and the vertex indicated by alpha_{i+1}.
+
+The verifier learns nothing about G or the path beyond (n, k, s, t).
+
+Cost (in QuickSilver multiplication gates):
+
+    booleanity of G                 :  n^2
+    booleanity of intermediate alphas: (k-1) * n
+    step transitions                : 2 * (n^2) + n   for an interior step
+                                       n           for a boundary step
+
+So for n vertices, walk length k, total muls ~= n^2 * k. The pure-Python
+prover handles n=8, k=4 in well under a second.
+
+Tying back to ``transitive_closure.py``: the same step
+``alpha @ Edge`` that drives boolean reachability is the inner product
+that this circuit's edge constraint computes. ZK adds nothing
+mathematically; the einsum is the proof.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from quicksilver.circuit import Circuit
+from quicksilver.field import F, Fp
+from quicksilver.protocol import run as run_protocol
+
+
+@dataclass
+class ReachabilityCircuit:
+    circuit: Circuit
+    n: int
+    k: int
+    source: int
+    target: int
+
+
+def build_circuit(n: int, k: int, source: int, target: int) -> ReachabilityCircuit:
+    """Build the reachability circuit. ``k`` is the walk length (number of edges).
+
+    Vertices are integers 0..n-1. Source and target are public; the
+    intermediate vertices and the entire graph are committed.
+    """
+    if not (0 <= source < n and 0 <= target < n):
+        raise ValueError("source/target out of range")
+    if k < 1:
+        raise ValueError("walk length must be at least 1")
+
+    c = Circuit()
+
+    # ---- 1. Commit edge matrix and enforce booleanity ----------------------
+    E = [[c.input() for _ in range(n)] for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            _enforce_boolean(c, E[i][j])
+
+    # ---- 2. Build the k+1 frontier vectors --------------------------------
+    # alpha_0 and alpha_k are public one-hot vectors at source/target.
+    # alpha_1..alpha_{k-1} are committed and constrained to be one-hot.
+    alpha: List[List[_Slot]] = []
+    for i in range(k + 1):
+        if i == 0:
+            alpha.append([_Public(1 if j == source else 0) for j in range(n)])
+        elif i == k:
+            alpha.append([_Public(1 if j == target else 0) for j in range(n)])
+        else:
+            row = [c.input() for _ in range(n)]
+            for w in row:
+                _enforce_boolean(c, w)
+            _enforce_one_hot(c, row)
+            alpha.append([_Wire(w) for w in row])
+
+    # ---- 3. Each step contributes one edge-existence constraint -----------
+    for i in range(k):
+        _enforce_step(c, alpha[i], E, alpha[i + 1], n)
+
+    return ReachabilityCircuit(circuit=c, n=n, k=k, source=source, target=target)
+
+
+def assemble_witness(
+    rc: ReachabilityCircuit,
+    edge_matrix: Sequence[Sequence[int]],
+    path: Sequence[int],
+) -> List[int]:
+    """Pack the prover's witness into the order ``circuit.input()`` consumed it."""
+    n, k = rc.n, rc.k
+    if len(edge_matrix) != n or any(len(row) != n for row in edge_matrix):
+        raise ValueError(f"edge_matrix must be {n}x{n}")
+    if len(path) != k + 1:
+        raise ValueError(f"path must have length {k + 1} (k+1 vertices)")
+    if path[0] != rc.source or path[-1] != rc.target:
+        raise ValueError("path endpoints do not match circuit source/target")
+    for v in path:
+        if not (0 <= v < n):
+            raise ValueError(f"path vertex {v} out of range")
+    for i in range(k):
+        u, v = path[i], path[i + 1]
+        if edge_matrix[u][v] not in (0, 1):
+            raise ValueError("edge_matrix entries must be 0 or 1")
+        if edge_matrix[u][v] != 1:
+            raise ValueError(
+                f"path uses non-edge ({u} -> {v}); witness is invalid"
+            )
+
+    witness: List[int] = []
+    # First inputs were the n*n edge entries (row-major).
+    for i in range(n):
+        for j in range(n):
+            witness.append(int(edge_matrix[i][j]))
+    # Then the (k-1) intermediate frontier one-hots.
+    for i in range(1, k):
+        v = path[i]
+        for j in range(n):
+            witness.append(1 if j == v else 0)
+    return witness
+
+
+def prove_path(
+    n: int,
+    k: int,
+    source: int,
+    target: int,
+    edge_matrix: Sequence[Sequence[int]],
+    path: Sequence[int],
+    field: Fp = F,
+) -> bool:
+    """End-to-end: build circuit, assemble witness, run prover/verifier."""
+    rc = build_circuit(n, k, source, target)
+    witness = assemble_witness(rc, edge_matrix, path)
+    return run_protocol(rc.circuit, witness, field)
+
+
+# ---- internal helpers --------------------------------------------------------
+
+# A slot in a frontier vector is either a public constant (already known
+# on both sides) or a committed wire id.
+
+
+@dataclass(frozen=True)
+class _Public:
+    value: int
+
+
+@dataclass(frozen=True)
+class _Wire:
+    wid: int
+
+
+_Slot = _Public | _Wire
+
+
+def _enforce_boolean(c: Circuit, w: int) -> None:
+    """Constrain a wire to be in {0, 1} via x*(x-1) == 0."""
+    w_minus_1 = c.add_const(w, -1)
+    c.assert_zero(c.mul(w, w_minus_1))
+
+
+def _enforce_one_hot(c: Circuit, wires: Sequence[int]) -> None:
+    """Constrain ``sum_i wires[i] == 1`` (linear, no mul gates)."""
+    acc = c.const(0)
+    for w in wires:
+        acc = c.add(acc, w)
+    c.assert_zero(c.add_const(acc, -1))
+
+
+def _enforce_step(
+    c: Circuit, a: List[_Slot], E: List[List[int]], b: List[_Slot], n: int
+) -> None:
+    """Enforce sum_{u,v} a[u] * E[u][v] * b[v] == 1.
+
+    Decomposes into: w[v] = sum_u a[u] * E[u][v]; then sum_v w[v] * b[v].
+    Constants in ``a`` or ``b`` shrink mul-gate count automatically.
+    """
+    w = [_inner_with_coeffs(c, a, [E[u][v] for u in range(n)]) for v in range(n)]
+    total = _inner_two_wire_lists(c, w, b)
+    c.assert_zero(c.add_const(total, -1))
+
+
+def _inner_with_coeffs(c: Circuit, a: List[_Slot], wires: List[int]) -> int:
+    """sum_u a[u] * wires[u], where a[u] may be public (use mul_const) or a wire."""
+    acc = c.const(0)
+    for slot, w in zip(a, wires):
+        if isinstance(slot, _Public):
+            if slot.value == 0:
+                continue
+            if slot.value == 1:
+                acc = c.add(acc, w)
+            else:
+                acc = c.add(acc, c.mul_const(w, slot.value))
+        else:
+            acc = c.add(acc, c.mul(slot.wid, w))
+    return acc
+
+
+def _inner_two_wire_lists(c: Circuit, w: List[int], b: List[_Slot]) -> int:
+    """sum_v w[v] * b[v], with b possibly public."""
+    acc = c.const(0)
+    for wv, slot in zip(w, b):
+        if isinstance(slot, _Public):
+            if slot.value == 0:
+                continue
+            if slot.value == 1:
+                acc = c.add(acc, wv)
+            else:
+                acc = c.add(acc, c.mul_const(wv, slot.value))
+        else:
+            acc = c.add(acc, c.mul(wv, slot.wid))
+    return acc

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -1,0 +1,222 @@
+"""Tests for GF(2^128) and the boolean QuickSilver instantiation."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from quicksilver.boolean import (
+    BBatchedCheck,
+    BoolCircuit,
+    prove,
+    run,
+    trusted_dealer_setup,
+    verify,
+)
+from quicksilver.gf2k import GF128, GF2k
+
+
+# ---- GF(2^128) field ----------------------------------------------------
+
+
+def test_gf2k_zero_one():
+    assert GF128.add(0, 0) == 0
+    assert GF128.add(0, 1) == 1
+    assert GF128.add(1, 1) == 0  # characteristic 2
+    assert GF128.mul(0, 12345) == 0
+    assert GF128.mul(1, 12345) == 12345
+    assert GF128.mul(12345, 1) == 12345
+
+
+def test_gf2k_mul_distributive():
+    a, b, c = GF128.rand(), GF128.rand(), GF128.rand()
+    lhs = GF128.mul(a, b ^ c)
+    rhs = GF128.mul(a, b) ^ GF128.mul(a, c)
+    assert lhs == rhs
+
+
+def test_gf2k_mul_associative():
+    a, b, c = GF128.rand(), GF128.rand(), GF128.rand()
+    assert GF128.mul(GF128.mul(a, b), c) == GF128.mul(a, GF128.mul(b, c))
+
+
+def test_gf2k_inverse_random():
+    for _ in range(20):
+        a = GF128.rand_nonzero()
+        assert GF128.mul(a, GF128.inv(a)) == 1
+
+
+def test_gf2k_pow_matches_repeated_mul():
+    a = GF128.rand_nonzero()
+    expected = 1
+    for _ in range(5):
+        expected = GF128.mul(expected, a)
+    assert GF128.pow(a, 5) == expected
+
+
+def test_gf2k_squaring_is_frobenius():
+    """In characteristic 2, (a+b)^2 = a^2 + b^2."""
+    a, b = GF128.rand(), GF128.rand()
+    assert GF128.pow(a ^ b, 2) == GF128.pow(a, 2) ^ GF128.pow(b, 2)
+
+
+# ---- Subspace VOLE ------------------------------------------------------
+
+
+def test_subspace_vole_correlation_holds():
+    p, v = trusted_dealer_setup(64)
+    for u_i, v_i, w_i in zip(p.u, p.v, v.w):
+        assert u_i in (0, 1)
+        expected = ((v.delta if u_i else 0)) ^ v_i
+        assert w_i == expected
+
+
+# ---- Boolean protocol completeness --------------------------------------
+
+
+def test_completeness_single_and():
+    c = BoolCircuit()
+    a = c.input()
+    b = c.input()
+    c.assert_eq_const(c.and_(a, b), 1)
+    assert run(c, [1, 1])
+
+
+def test_completeness_xor_chain_no_ands():
+    c = BoolCircuit()
+    a, b, d = c.input(), c.input(), c.input()
+    s = c.xor(c.xor(a, b), d)
+    c.assert_eq_const(s, 0)  # 1 XOR 1 XOR 0 = 0
+    assert run(c, [1, 1, 0])
+
+
+def test_completeness_or_via_xor_and():
+    c = BoolCircuit()
+    a, b = c.input(), c.input()
+    c.assert_eq_const(c.or_(a, b), 1)
+    assert run(c, [0, 1])
+
+
+def test_completeness_three_input_AND():
+    c = BoolCircuit()
+    a, b, d = c.input(), c.input(), c.input()
+    abd = c.and_(c.and_(a, b), d)
+    c.assert_eq_const(abd, 1)
+    assert run(c, [1, 1, 1])
+
+
+def test_completeness_full_adder():
+    """1-bit full adder: sum = a XOR b XOR cin; cout = (a AND b) OR (cin AND (a XOR b))."""
+    c = BoolCircuit()
+    a, b, cin = c.input(), c.input(), c.input()
+    axb = c.xor(a, b)
+    s = c.xor(axb, cin)
+    cout = c.or_(c.and_(a, b), c.and_(cin, axb))
+    # 1 + 1 + 1 = 11 -> sum=1, cout=1
+    c.assert_eq_const(s, 1)
+    c.assert_eq_const(cout, 1)
+    assert run(c, [1, 1, 1])
+
+
+def test_completeness_negation():
+    c = BoolCircuit()
+    a = c.input()
+    c.assert_eq_const(c.not_(a), 0)
+    assert run(c, [1])
+
+
+# ---- Soundness ----------------------------------------------------------
+
+
+def test_soundness_wrong_witness_caught():
+    c = BoolCircuit()
+    a = c.input()
+    b = c.input()
+    c.assert_eq_const(c.and_(a, b), 1)
+    with pytest.raises(ValueError):
+        run(c, [1, 0])  # 1 AND 0 = 0, not 1
+
+
+def test_soundness_tampered_batched_check_caught():
+    c = BoolCircuit()
+    a, b = c.input(), c.input()
+    c.and_(a, b)
+    p, v = trusted_dealer_setup(c.vole_count())
+    msg1, batched = prove(c, [1, 1], p)
+    chi = GF128.rand_nonzero()
+    msg2 = batched(chi)
+    bad = BBatchedCheck(U=msg2.U ^ 1, V=msg2.V)
+    assert not verify(c, v, msg1, chi, bad)
+
+
+def test_soundness_tampered_assertion_caught():
+    c = BoolCircuit()
+    a, b = c.input(), c.input()
+    c.assert_eq_const(c.and_(a, b), 1)
+    p, v = trusted_dealer_setup(c.vole_count())
+    msg1, batched = prove(c, [1, 1], p)
+    msg1.assert_openings[0] ^= 1  # flip a bit of the opened MAC tag
+    chi = GF128.rand_nonzero()
+    msg2 = batched(chi)
+    assert not verify(c, v, msg1, chi, msg2)
+
+
+# ---- Larger circuit -----------------------------------------------------
+
+
+def test_completeness_4bit_multiplier():
+    """Prove knowledge of (x, y) of 4 bits each with x*y = 21 (= 3*7)."""
+    c = BoolCircuit()
+    x_bits = [c.input() for _ in range(4)]
+    y_bits = [c.input() for _ in range(4)]
+
+    # 4x4 -> 8 partial products, schoolbook addition.
+    # For an educational test: just verify each output bit equals expected.
+    expected_bits = [(21 >> i) & 1 for i in range(8)]
+
+    # Sum of partial products with shifts.
+    # Use a simple ripple-carry adder.
+    pp = [[c.and_(x_bits[i], y_bits[j]) for j in range(4)] for i in range(4)]
+    # partial product i is at column i+0..i+3; build column sums.
+    columns: list[list[int]] = [[] for _ in range(8)]
+    for i in range(4):
+        for j in range(4):
+            columns[i + j].append(pp[i][j])
+
+    def half_adder(a, b):
+        return c.xor(a, b), c.and_(a, b)
+
+    def full_adder(a, b, ci):
+        axb = c.xor(a, b)
+        s = c.xor(axb, ci)
+        co = c.or_(c.and_(a, b), c.and_(ci, axb))
+        return s, co
+
+    # Reduce each column with adders, propagating carries to the next column.
+    out_bits: list[int] = []
+    for col in range(8):
+        bucket = columns[col]
+        # add bucket bits one at a time; carry goes to next column
+        if not bucket:
+            out_bits.append(c.const(0))
+            continue
+        acc = bucket[0]
+        for x in bucket[1:]:
+            acc, carry = half_adder(acc, x)
+            if col + 1 < 8:
+                columns[col + 1].append(carry)
+        out_bits.append(acc)
+
+    for bit, expected in zip(out_bits, expected_bits):
+        c.assert_eq_const(bit, expected)
+    # x = 3 = 0b0011, y = 7 = 0b0111
+    witness = [1, 1, 0, 0, 1, 1, 1, 0]
+    assert run(c, witness)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -1,0 +1,183 @@
+"""Tests for the einsum -> circuit compiler."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from quicksilver.circuit import Circuit
+from quicksilver.einsum import (
+    alloc_constant_tensor,
+    alloc_input_tensor,
+    assert_einsum_equals,
+    compile_einsum,
+    evaluate_einsum,
+    flatten_row_major,
+    parse_einsum,
+    resolve_dims,
+)
+from quicksilver.field import F
+from quicksilver.protocol import run as run_protocol
+
+
+# ---- Parser / dim resolution -------------------------------------------
+
+
+def test_parse_einsum_matmul():
+    inputs, output = parse_einsum("ij,jk->ik")
+    assert inputs == ["ij", "jk"]
+    assert output == "ik"
+
+
+def test_resolve_dims_consistent():
+    dims = resolve_dims(["ij", "jk"], [(3, 4), (4, 5)])
+    assert dims == {"i": 3, "j": 4, "k": 5}
+
+
+def test_resolve_dims_inconsistent_raises():
+    with pytest.raises(ValueError):
+        resolve_dims(["ij", "jk"], [(3, 4), (5, 6)])
+
+
+# ---- Reference evaluator ------------------------------------------------
+
+
+def test_evaluate_matmul():
+    A = [[1, 2], [3, 4]]
+    B = [[5, 6], [7, 8]]
+    out = evaluate_einsum("ij,jk->ik", [A, B])
+    # [[1*5+2*7, 1*6+2*8], [3*5+4*7, 3*6+4*8]] = [[19, 22], [43, 50]]
+    assert out == [19, 22, 43, 50]
+
+
+def test_evaluate_dot_product():
+    a = [1, 2, 3]
+    b = [4, 5, 6]
+    assert evaluate_einsum("i,i->", [a, b]) == [32]
+
+
+def test_evaluate_outer_product():
+    a = [1, 2]
+    b = [3, 4]
+    assert evaluate_einsum("i,j->ij", [a, b]) == [3, 4, 6, 8]
+
+
+def test_evaluate_trace():
+    A = [[1, 2], [3, 4]]
+    assert evaluate_einsum("ii->", [A]) == [5]
+
+
+# ---- Compilation: completeness via real prove/verify --------------------
+
+
+def _prove_einsum(spec: str, shapes, tensors, expected) -> bool:
+    c = Circuit()
+    inputs = [alloc_input_tensor(c, shape) for shape in shapes]
+    assert_einsum_equals(c, spec, inputs, shapes, expected)
+    witness = []
+    for t in tensors:
+        witness += flatten_row_major(t)
+    return run_protocol(c, witness)
+
+
+def test_compile_matmul_2x2():
+    A = [[1, 2], [3, 4]]
+    B = [[5, 6], [7, 8]]
+    expected = evaluate_einsum("ij,jk->ik", [A, B])
+    assert _prove_einsum("ij,jk->ik", [(2, 2), (2, 2)], [A, B], expected)
+
+
+def test_compile_dot_product():
+    a = [1, 2, 3, 4]
+    b = [5, 6, 7, 8]
+    expected = evaluate_einsum("i,i->", [a, b])
+    assert _prove_einsum("i,i->", [(4,), (4,)], [a, b], expected)
+
+
+def test_compile_three_tensor_contraction():
+    """A_ij * B_jk * C_kl -> D_il"""
+    A = [[1, 2], [3, 4]]
+    B = [[1, 0], [0, 1]]  # identity
+    C = [[2, 1], [1, 2]]
+    expected = evaluate_einsum("ij,jk,kl->il", [A, B, C])
+    assert _prove_einsum(
+        "ij,jk,kl->il", [(2, 2), (2, 2), (2, 2)], [A, B, C], expected
+    )
+
+
+def test_compile_with_one_public_tensor():
+    """Public B; private A. Prover proves A @ B = expected."""
+    A = [[1, 2], [3, 4]]
+    B = [[5, 6], [7, 8]]
+    expected = evaluate_einsum("ij,jk->ik", [A, B])
+
+    c = Circuit()
+    A_wires = alloc_input_tensor(c, (2, 2))
+    B_wires = alloc_constant_tensor(c, flatten_row_major(B))
+    assert_einsum_equals(
+        c, "ij,jk->ik", [A_wires, B_wires], [(2, 2), (2, 2)], expected
+    )
+    witness = flatten_row_major(A)
+    assert run_protocol(c, witness)
+
+
+def test_compile_outer_product():
+    a = [1, 2, 3]
+    b = [4, 5]
+    expected = evaluate_einsum("i,j->ij", [a, b])
+    assert _prove_einsum("i,j->ij", [(3,), (2,)], [a, b], expected)
+
+
+# ---- Soundness: lying about the output should be caught -----------------
+
+
+def test_compile_matmul_wrong_output_rejected():
+    A = [[1, 2], [3, 4]]
+    B = [[5, 6], [7, 8]]
+    correct = evaluate_einsum("ij,jk->ik", [A, B])
+    bad = correct[:]
+    bad[0] += 1  # corrupt the (0,0) entry
+    with pytest.raises(ValueError):
+        # The honest prover walking the circuit will fail at the first
+        # assert_zero (the diff wire is nonzero).
+        _prove_einsum("ij,jk->ik", [(2, 2), (2, 2)], [A, B], bad)
+
+
+def test_flatten_row_major():
+    assert flatten_row_major([[1, 2, 3], [4, 5, 6]]) == [1, 2, 3, 4, 5, 6]
+    assert flatten_row_major([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]) == [
+        1, 2, 3, 4, 5, 6, 7, 8,
+    ]
+
+
+# ---- Tensor-logic tie-in: grandparent rule ------------------------------
+
+
+def test_grandparent_rule_einsum():
+    """The Datalog rule  Grandparent(x, z) :- Parent(x, y), Parent(y, z)
+    is the einsum  G_xz = sum_y P_xy * P_yz.
+
+    Prove that the prover knows a Parent matrix P with a specified
+    Grandparent matrix G as its boolean square.
+    """
+    # 4 people: 0->1->2 and 0->3, 3->2 (so 0 is grandparent of 2 via two paths).
+    P = [
+        [0, 1, 0, 1],  # 0 is parent of 1 and 3
+        [0, 0, 1, 0],  # 1 is parent of 2
+        [0, 0, 0, 0],
+        [0, 0, 1, 0],  # 3 is parent of 2
+    ]
+    expected_G = evaluate_einsum("xy,yz->xz", [P, P])
+    # G[0][2] should be 2 (paths 0->1->2 and 0->3->2)
+    assert expected_G[0 * 4 + 2] == 2
+    assert _prove_einsum(
+        "xy,yz->xz", [(4, 4), (4, 4)], [P, P], expected_G
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_fiat_shamir.py
+++ b/tests/test_fiat_shamir.py
@@ -1,0 +1,121 @@
+"""Tests for the Fiat-Shamir non-interactive variant."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from quicksilver.circuit import Circuit
+from quicksilver.field import F
+from quicksilver.fiat_shamir import (
+    NIProof,
+    Transcript,
+    prove_ni,
+    run_ni,
+    verify_ni,
+)
+from quicksilver.protocol import BatchedCheck
+from quicksilver.vole import trusted_dealer_setup
+
+
+def _factor_circuit(target: int) -> Circuit:
+    c = Circuit()
+    p = c.input()
+    q = c.input()
+    c.assert_eq(c.mul(p, q), target)
+    return c
+
+
+def test_ni_completeness():
+    c = _factor_circuit(56)
+    ok, _ = run_ni(c, [7, 8])
+    assert ok
+
+
+def test_ni_proof_is_deterministic_given_setup():
+    c = _factor_circuit(56)
+    p_share, v_share = trusted_dealer_setup(c.vole_count())
+    proof_a = prove_ni(c, [7, 8], p_share)
+    proof_b = prove_ni(c, [7, 8], p_share)
+    # Same setup + same witness -> same proof (Fiat-Shamir is deterministic
+    # once the prover side has its share).
+    assert proof_a.msg1.d_values == proof_b.msg1.d_values
+    assert proof_a.msg2.U == proof_b.msg2.U
+    assert proof_a.msg2.V == proof_b.msg2.V
+    assert verify_ni(c, v_share, proof_a)
+
+
+def test_ni_tamper_msg2_rejected():
+    c = _factor_circuit(56)
+    p_share, v_share = trusted_dealer_setup(c.vole_count())
+    proof = prove_ni(c, [7, 8], p_share)
+    bad = NIProof(
+        msg1=proof.msg1,
+        msg2=BatchedCheck(U=F.add(proof.msg2.U, 1), V=proof.msg2.V),
+    )
+    assert not verify_ni(c, v_share, bad)
+
+
+def test_ni_tamper_msg1_invalidates_chi():
+    """Mutating msg1 changes the challenge but msg2 was bound to the
+    original chi. The verifier recomputes chi from the new msg1 and
+    rejects."""
+    c = _factor_circuit(56)
+    p_share, v_share = trusted_dealer_setup(c.vole_count())
+    proof = prove_ni(c, [7, 8], p_share)
+    bad = NIProof(
+        msg1=type(proof.msg1)(
+            d_values=[F.add(proof.msg1.d_values[0], 1)] + proof.msg1.d_values[1:],
+            assert_openings=proof.msg1.assert_openings,
+        ),
+        msg2=proof.msg2,
+    )
+    assert not verify_ni(c, v_share, bad)
+
+
+def test_ni_label_must_match():
+    c = _factor_circuit(56)
+    p_share, v_share = trusted_dealer_setup(c.vole_count())
+    proof = prove_ni(c, [7, 8], p_share, label=b"context-A")
+    assert verify_ni(c, v_share, proof, label=b"context-A")
+    assert not verify_ni(c, v_share, proof, label=b"context-B")
+
+
+def test_transcript_squeezes_are_independent():
+    t = Transcript()
+    t.absorb_int(b"x", 42)
+    a = t.challenge()
+    b = t.challenge()
+    assert a != b
+    assert 0 < a < F.p and 0 < b < F.p
+
+
+def test_ni_works_for_polynomial_circuit():
+    # Same x^3 + x + 5 = y demo as the interactive version.
+    x = 17
+    y = (x ** 3 + x + 5) % F.p
+    c = Circuit()
+    xw = c.input()
+    x2 = c.mul(xw, xw)
+    x3 = c.mul(x2, xw)
+    s = c.add(x3, xw)
+    s = c.add_const(s, 5)
+    c.assert_eq(s, y)
+    ok, _ = run_ni(c, [x])
+    assert ok
+
+
+def test_ni_rejects_wrong_witness_at_assertion():
+    # Same shape circuit, different witness.
+    c = _factor_circuit(56)
+    p_share, _ = trusted_dealer_setup(c.vole_count())
+    with pytest.raises(ValueError):
+        prove_ni(c, [2, 3], p_share)  # 2*3 != 56; assert_zero raises
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_lpn_vole.py
+++ b/tests/test_lpn_vole.py
@@ -1,0 +1,139 @@
+"""Tests for the LPN-based VOLE extension."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from quicksilver.circuit import Circuit
+from quicksilver.field import F
+from quicksilver.lpn_vole import (
+    LpnParams,
+    correlation_holds,
+    derive_matrix,
+    lpn_vole_extend,
+)
+from quicksilver.protocol import prove, verify
+
+
+# ---- Correlation correctness --------------------------------------------
+
+
+def test_lpn_vole_correlation_holds():
+    p, v = lpn_vole_extend(LpnParams.default(n_out=64, seed=b"x" * 32))
+    assert correlation_holds(p, v)
+
+
+def test_lpn_vole_returns_requested_length():
+    n = 128
+    p, v = lpn_vole_extend(LpnParams.default(n_out=n, seed=b"y" * 32))
+    assert len(p) == n
+    assert len(v) == n
+
+
+def test_lpn_vole_uses_supplied_delta():
+    delta = F.rand_nonzero()
+    p, v = lpn_vole_extend(LpnParams.default(n_out=32), delta=delta)
+    assert v.delta == delta
+    assert correlation_holds(p, v)
+
+
+# ---- Determinism in the matrix derivation ------------------------------
+
+
+def test_derive_matrix_deterministic():
+    seed = b"\x42" * 32
+    H1 = derive_matrix(seed, 4, 8, F)
+    H2 = derive_matrix(seed, 4, 8, F)
+    assert H1 == H2
+
+
+def test_derive_matrix_seed_varies_output():
+    H1 = derive_matrix(b"\x01" * 32, 4, 8, F)
+    H2 = derive_matrix(b"\x02" * 32, 4, 8, F)
+    assert H1 != H2
+
+
+# ---- u_out looks unstructured even though u_base is sparse -------------
+
+
+def test_extension_hides_sparsity_of_base():
+    """u_base has Hamming weight t out of k=2*n; u_out should have ~no zeros."""
+    n = 64
+    params = LpnParams.default(n_out=n)
+    p, _ = lpn_vole_extend(params)
+    zeros = sum(1 for x in p.u if x == 0)
+    # Probability of any single u_out[i] being zero by chance is ~1/p, vanishing.
+    assert zeros < 2
+
+
+# ---- Drop-in replacement for trusted dealer in the main protocol -------
+
+
+def test_lpn_vole_plugs_into_protocol():
+    c = Circuit()
+    a = c.input()
+    b = c.input()
+    c.assert_eq(c.mul(a, b), 56)
+    p, v = lpn_vole_extend(LpnParams.default(n_out=c.vole_count()))
+    msg1, batched = prove(c, [7, 8], p)
+    chi = F.rand_nonzero()
+    msg2 = batched(chi)
+    assert verify(c, v, msg1, chi, msg2)
+
+
+def test_lpn_vole_plugs_into_polynomial_circuit():
+    """x^3 + x + 5 = y for x=17 via LPN-extended VOLE."""
+    x = 17
+    y = (x ** 3 + x + 5) % F.p
+    c = Circuit()
+    xw = c.input()
+    x2 = c.mul(xw, xw)
+    x3 = c.mul(x2, xw)
+    s = c.add(x3, xw)
+    s = c.add_const(s, 5)
+    c.assert_eq(s, y)
+    p, v = lpn_vole_extend(LpnParams.default(n_out=c.vole_count()))
+    msg1, batched = prove(c, [x], p)
+    chi = F.rand_nonzero()
+    msg2 = batched(chi)
+    assert verify(c, v, msg1, chi, msg2)
+
+
+def test_soundness_preserved_with_lpn_vole():
+    """Tampering with the batched check is still rejected when using LPN."""
+    from quicksilver.protocol import BatchedCheck
+
+    c = Circuit()
+    a = c.input()
+    b = c.input()
+    c.assert_eq(c.mul(a, b), 56)
+    p, v = lpn_vole_extend(LpnParams.default(n_out=c.vole_count()))
+    msg1, batched = prove(c, [7, 8], p)
+    chi = F.rand_nonzero()
+    msg2 = batched(chi)
+    bad = BatchedCheck(U=F.add(msg2.U, 1), V=msg2.V)
+    assert not verify(c, v, msg1, chi, bad)
+
+
+# ---- Parameters guard rails ---------------------------------------------
+
+
+def test_lpn_params_default_picks_consistent_seed_length():
+    params = LpnParams.default(n_out=32)
+    assert isinstance(params.seed, bytes)
+    assert len(params.seed) == 32
+
+
+def test_lpn_extend_rejects_oversized_weight():
+    bad = LpnParams(n_out=8, k_base=4, t_weight=10, seed=b"z" * 32)
+    with pytest.raises(ValueError):
+        lpn_vole_extend(bad)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_quicksilver.py
+++ b/tests/test_quicksilver.py
@@ -1,0 +1,327 @@
+"""Tests for the QuickSilver implementation."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Allow running with `python tests/test_quicksilver.py` from repo root.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from quicksilver.circuit import Circuit
+from quicksilver.field import F
+from quicksilver.itmac import (
+    ProverWire,
+    VerifierWire,
+    prover_commit,
+    verifier_receive,
+)
+from quicksilver.polynomial import (
+    Polynomial,
+    prove_polys,
+    run_poly_check,
+    verify_polys,
+)
+from quicksilver.protocol import (
+    BatchedCheck,
+    CommitMessage,
+    _ProverWalker,
+    _VerifierWalker,
+    prove,
+    run,
+    verify,
+)
+from quicksilver.vole import trusted_dealer_setup
+
+
+# ---- Field --------------------------------------------------------------
+
+
+def test_field_inverse():
+    for _ in range(50):
+        a = F.rand_nonzero()
+        assert F.mul(a, F.inv(a)) == 1
+
+
+def test_field_arith_in_range():
+    for _ in range(20):
+        a, b = F.rand(), F.rand()
+        for x in (F.add(a, b), F.sub(a, b), F.mul(a, b), F.neg(a)):
+            assert 0 <= x < F.p
+
+
+# ---- VOLE / IT-MAC ------------------------------------------------------
+
+
+def test_vole_correlation_holds():
+    p_share, v_share = trusted_dealer_setup(64)
+    for u, v, w in zip(p_share.u, p_share.v, v_share.w):
+        assert w == F.add(F.mul(u, v_share.delta), v)
+
+
+def test_itmac_relation_holds():
+    p_share, v_share = trusted_dealer_setup(1)
+    x = F.rand()
+    pw, d = prover_commit(x, p_share.u[0], p_share.v[0])
+    vw = verifier_receive(d, v_share.w[0], v_share.delta)
+    # K == M + Delta * x
+    assert vw.k == F.add(pw.m, F.mul(v_share.delta, pw.x))
+
+
+def test_itmac_addition_preserves_relation():
+    p_share, v_share = trusted_dealer_setup(2)
+    x, y = F.rand(), F.rand()
+    pw_x, dx = prover_commit(x, p_share.u[0], p_share.v[0])
+    pw_y, dy = prover_commit(y, p_share.u[1], p_share.v[1])
+    vw_x = verifier_receive(dx, v_share.w[0], v_share.delta)
+    vw_y = verifier_receive(dy, v_share.w[1], v_share.delta)
+
+    pw_sum = pw_x.add(pw_y)
+    vw_sum = vw_x.add(vw_y)
+    assert vw_sum.k == F.add(pw_sum.m, F.mul(v_share.delta, pw_sum.x))
+
+
+# ---- Circuit / protocol completeness -----------------------------------
+
+
+def test_completeness_single_mul():
+    c = Circuit()
+    x = c.input()
+    y = c.input()
+    z = c.mul(x, y)
+    c.assert_eq(z, 56)
+    assert run(c, [7, 8])
+
+
+def test_completeness_linear_only():
+    c = Circuit()
+    a = c.input()
+    b = c.input()
+    s = c.add(a, b)
+    s2 = c.mul_const(s, 3)
+    s3 = c.add_const(s2, 1)
+    c.assert_eq(s3, 3 * (10 + 5) + 1)
+    assert run(c, [10, 5])
+
+
+def test_completeness_polynomial_circuit():
+    # Prove knowledge of x with x^3 + x + 5 = y for public y.
+    x_val = 17
+    y_val = (x_val ** 3 + x_val + 5) % F.p
+    c = Circuit()
+    x = c.input()
+    x2 = c.mul(x, x)
+    x3 = c.mul(x2, x)
+    s = c.add(x3, x)
+    s = c.add_const(s, 5)
+    c.assert_eq(s, y_val)
+    assert run(c, [x_val])
+
+
+def test_completeness_many_muls():
+    # Inner product: <a, b> = c.
+    n = 16
+    a = [F.rand() for _ in range(n)]
+    b = [F.rand() for _ in range(n)]
+    expected = 0
+    for ai, bi in zip(a, b):
+        expected = F.add(expected, F.mul(ai, bi))
+
+    c = Circuit()
+    a_w = [c.input() for _ in range(n)]
+    b_w = [c.input() for _ in range(n)]
+    acc = c.const(0)
+    for ai, bi in zip(a_w, b_w):
+        prod = c.mul(ai, bi)
+        acc = c.add(acc, prod)
+    c.assert_eq(acc, expected)
+    assert run(c, a + b)
+
+
+# ---- Soundness ----------------------------------------------------------
+
+
+def _build_mul_circuit(target_z: int) -> Circuit:
+    c = Circuit()
+    x = c.input()
+    y = c.input()
+    z = c.mul(x, y)
+    c.assert_eq(z, target_z)
+    return c
+
+
+def test_soundness_wrong_witness_caught_at_assertion():
+    # Prover lies about x*y by claiming a different z. The assertion check
+    # will fail because the opened tag won't match the verifier's key.
+    c = _build_mul_circuit(target_z=99)  # but real x*y will be 56
+    # Witness is (7, 8) -> 7*8 = 56, not 99. Honest prover walking this
+    # circuit will produce assertion-zero on (56 - 99), which is nonzero;
+    # `open_to_zero` raises.
+    with pytest.raises(ValueError):
+        run(c, [7, 8])
+
+
+def test_soundness_prover_lies_about_mul_output():
+    """A cheating prover who tries to make 7*8 == 99 pass.
+
+    They have to commit to z=99 but claim it equals 7*8. We simulate by
+    hand-crafting a malicious commit message and watching the batched
+    multiplication check reject.
+    """
+    c = Circuit()
+    x = c.input()
+    y = c.input()
+    z = c.mul(x, y)
+    # Note: no assertion, so the only thing that catches the lie is the
+    # batched mul check.
+
+    p_share, v_share = trusted_dealer_setup(c.vole_count())
+    delta = v_share.delta
+
+    # Honest commits for x=7, y=8.
+    x_val, y_val = 7, 8
+    fake_z = 99  # the lie
+    u0, v0 = p_share.u[0], p_share.v[0]
+    u1, v1 = p_share.u[1], p_share.v[1]
+    u2, v2 = p_share.u[2], p_share.v[2]
+    d_x = F.sub(x_val, u0)
+    d_y = F.sub(y_val, u1)
+    d_z = F.sub(fake_z, u2)  # commit to fake z
+    msg1 = CommitMessage(d_values=[d_x, d_y, d_z], assert_openings=[])
+
+    # Prover then sends a batched check assuming z = x*y = 56, i.e., uses
+    # M values consistent with z = 56. (Equivalently, an honest A0/A1 over
+    # the fake commitment.)
+    Mx, My = v0, v1
+    Mz_real = v2  # tag the prover holds for the committed value (which is 99)
+    A0 = F.mul(Mx, My)
+    A1 = F.sub(F.add(F.mul(x_val, My), F.mul(y_val, Mx)), Mz_real)
+
+    chi = F.rand_nonzero()
+    # Mask using the last VOLE element (index 3 = num_inputs + num_muls).
+    a, b = p_share.u[3], p_share.v[3]
+    U = F.add(F.mul(chi, A0), b)
+    V = F.add(F.mul(chi, A1), a)
+    msg2 = BatchedCheck(U=U, V=V)
+
+    assert not verify(c, v_share, msg1, chi, msg2)
+
+
+def test_soundness_tampered_assertion_caught():
+    c = Circuit()
+    x = c.input()
+    y = c.input()
+    z = c.mul(x, y)
+    c.assert_eq(z, 56)
+
+    p_share, v_share = trusted_dealer_setup(c.vole_count())
+    msg1, batched = prove(c, [7, 8], p_share)
+    # Tamper with the opened tag.
+    msg1.assert_openings[0] = F.add(msg1.assert_openings[0], 1)
+    chi = F.rand_nonzero()
+    msg2 = batched(chi)
+    assert not verify(c, v_share, msg1, chi, msg2)
+
+
+def test_soundness_tampered_batched_check_caught():
+    c = Circuit()
+    x = c.input()
+    y = c.input()
+    z = c.mul(x, y)
+    p_share, v_share = trusted_dealer_setup(c.vole_count())
+    msg1, batched = prove(c, [7, 8], p_share)
+    chi = F.rand_nonzero()
+    msg2 = batched(chi)
+    msg2 = BatchedCheck(U=F.add(msg2.U, 1), V=msg2.V)
+    assert not verify(c, v_share, msg1, chi, msg2)
+
+
+# ---- Polynomial extension ----------------------------------------------
+
+
+def _commit_values(values, share, delta):
+    """Helper: produce ProverWire / VerifierWire dicts keyed by 0..n-1."""
+    pwires, vwires = {}, {}
+    for i, val in enumerate(values):
+        pw, d = prover_commit(val, share.u[i], share.v[i])
+        vw = verifier_receive(d, F.add(F.mul(share.u[i], delta), share.v[i]), delta)
+        pwires[i] = pw
+        vwires[i] = vw
+    return pwires, vwires
+
+
+def test_polynomial_completeness_cubic():
+    # Prove x^3 - 8 == 0 with x=2.
+    p_share, v_share = trusted_dealer_setup(1)
+    delta = v_share.delta
+    pwires, vwires = _commit_values([2], p_share, delta)
+    poly = Polynomial(terms=((1, (0, 0, 0)), (-8, ())))
+    assert run_poly_check([poly], pwires, vwires, delta)
+
+
+def test_polynomial_completeness_multivariate():
+    # Prove x*y*z + 2*x - 3 == 0 with x=1, y=1, z=1: 1+2-3 = 0.
+    p_share, v_share = trusted_dealer_setup(3)
+    delta = v_share.delta
+    pwires, vwires = _commit_values([1, 1, 1], p_share, delta)
+    poly = Polynomial(terms=((1, (0, 1, 2)), (2, (0,)), (-3, ())))
+    assert run_poly_check([poly], pwires, vwires, delta)
+
+
+def test_polynomial_batched_quadratic():
+    # Three quadratic constraints, all zero on the witness.
+    p_share, v_share = trusted_dealer_setup(3)
+    delta = v_share.delta
+    a, b, c = 5, 7, 11
+    pwires, vwires = _commit_values([a, b, c], p_share, delta)
+    polys = [
+        Polynomial(terms=((1, (0, 0)), (-a * a, ()))),  # x0^2 - 25
+        Polynomial(terms=((1, (1, 1)), (-b * b, ()))),  # x1^2 - 49
+        Polynomial(terms=((1, (2, 2)), (-c * c, ()))),  # x2^2 - 121
+    ]
+    assert run_poly_check(polys, pwires, vwires, delta)
+
+
+def test_polynomial_soundness_caught():
+    # x is committed to value 2, but we try to prove x^3 == 9 (false: 2^3 = 8).
+    p_share, v_share = trusted_dealer_setup(1)
+    delta = v_share.delta
+    pwires, vwires = _commit_values([2], p_share, delta)
+    poly = Polynomial(terms=((1, (0, 0, 0)), (-9, ())))
+
+    # Honest prove call ignores soundness and just reports A_0..A_{d-1}.
+    # The verifier's check should still fail because A_d != 0.
+    mask_p, mask_v = trusted_dealer_setup(2, delta=delta)  # d-1 = 2 mask elements
+    chi = F.rand_nonzero()
+    proof = prove_polys([poly], pwires, chi, mask_p)
+    assert not verify_polys([poly], vwires, chi, proof, mask_v)
+
+
+# ---- Sanity: low-level walker computes coherent state ------------------
+
+
+def test_walker_produces_consistent_views():
+    c = Circuit()
+    x = c.input()
+    y = c.input()
+    z = c.mul(x, y)
+    s = c.add_const(z, 5)
+    c.assert_eq(s, 7 * 8 + 5)
+
+    p_share, v_share = trusted_dealer_setup(c.vole_count())
+    pw = _ProverWalker(circuit=c, witness=[7, 8], share=p_share)
+    msg1 = pw.commit()
+    vw = _VerifierWalker(circuit=c, share=v_share)
+    vw.receive(msg1)
+
+    # Spot check: the IT-MAC relation holds on every wire.
+    for wid, prover_wire in pw.wires.items():
+        verifier_wire = vw.wires[wid]
+        expected_k = F.add(prover_wire.m, F.mul(v_share.delta, prover_wire.x))
+        assert verifier_wire.k == expected_k
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_zk_reachability.py
+++ b/tests/test_zk_reachability.py
@@ -1,0 +1,138 @@
+"""Tests for the ZK graph-reachability circuit."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from quicksilver.field import F
+from quicksilver.protocol import prove, verify
+from quicksilver.vole import trusted_dealer_setup
+from quicksilver.zk_reachability import (
+    assemble_witness,
+    build_circuit,
+    prove_path,
+)
+
+
+def _toy_graph():
+    """5-node DAG: 0->1->2->3, plus 1->4. Direct path 0->1->2->3 has length 3."""
+    n = 5
+    E = [[0] * n for _ in range(n)]
+    for u, v in [(0, 1), (1, 2), (2, 3), (1, 4)]:
+        E[u][v] = 1
+    return n, E
+
+
+def test_completeness_path_3():
+    n, E = _toy_graph()
+    assert prove_path(n=n, k=3, source=0, target=3, edge_matrix=E, path=[0, 1, 2, 3])
+
+
+def test_completeness_walk_with_repeats():
+    """A walk may revisit edges/vertices; reachability is just the existence of one."""
+    n, E = _toy_graph()
+    # walk 0 -> 1 -> 4 -> ... can't continue; instead try 0->1->2->3 with k=3.
+    # For k=4 with self-loops we'd need self-loops; without them, no length-4 walk
+    # exists in this DAG ending at 3. Skip this case.
+    # Use a graph with cycles instead.
+    n = 4
+    E = [[0] * n for _ in range(n)]
+    for u, v in [(0, 1), (1, 2), (2, 0), (2, 3)]:
+        E[u][v] = 1
+    # walk 0 -> 1 -> 2 -> 0 -> 1 -> 2 -> 3, length 6
+    assert prove_path(n=n, k=6, source=0, target=3, edge_matrix=E,
+                      path=[0, 1, 2, 0, 1, 2, 3])
+
+
+def test_assemble_witness_rejects_non_edge_path():
+    n, E = _toy_graph()
+    rc = build_circuit(n=n, k=3, source=0, target=3)
+    # Path 0 -> 2 -> ... uses non-edge (0, 2).
+    with pytest.raises(ValueError, match="non-edge"):
+        assemble_witness(rc, E, [0, 2, 3, 3])
+
+
+def test_assemble_witness_rejects_endpoint_mismatch():
+    n, E = _toy_graph()
+    rc = build_circuit(n=n, k=3, source=0, target=3)
+    with pytest.raises(ValueError, match="endpoints"):
+        assemble_witness(rc, E, [1, 2, 3, 3])
+
+
+def test_soundness_lying_about_edge_existence():
+    """A prover who claims a path through a non-edge is rejected.
+
+    We build the same circuit but feed an edge matrix that lacks an edge
+    on the path. The witness assembler refuses to produce inputs (good
+    sanity), so we hand-roll a malicious witness that pretends E[0][2]=1
+    while the rest of the matrix really has E[0][1]=E[1][2]=E[2][3]=1.
+    The booleanity constraints all hold; the step constraint at i=0 fails.
+    """
+    n = 5
+    rc = build_circuit(n=n, k=3, source=0, target=3)
+
+    # Real graph (no edge 0->2).
+    E = [[0] * n for _ in range(n)]
+    for u, v in [(0, 1), (1, 2), (2, 3)]:
+        E[u][v] = 1
+
+    # Build the witness manually: claim path 0->2->3->3 with E unchanged.
+    # That requires E[0][2]=1 (it isn't) and E[3][3]=1 (it isn't).
+    # We just pass the real E with a mis-aligned path; the prover side will
+    # refuse via assemble_witness, so go around it:
+    fake_witness = []
+    for i in range(n):
+        for j in range(n):
+            fake_witness.append(int(E[i][j]))
+    # Intermediate alphas claim vertices 2 and 3.
+    for v in (2, 3):
+        for j in range(n):
+            fake_witness.append(1 if j == v else 0)
+
+    # Honest prover walking with this witness will fail at the first step
+    # constraint, where the prover's local "step" sum is 0 not 1, and
+    # ``open_to_zero`` raises (since the diff wire is -1, not 0).
+    p_share, v_share = trusted_dealer_setup(rc.circuit.vole_count())
+    with pytest.raises(ValueError):
+        prove(rc.circuit, fake_witness, p_share)
+
+
+def test_soundness_tampered_post_commit():
+    """A prover who submits a real proof but tampers the batched-check
+    response is rejected by the verifier.
+    """
+    n, E = _toy_graph()
+    rc = build_circuit(n=n, k=3, source=0, target=3)
+    witness = assemble_witness(rc, E, [0, 1, 2, 3])
+
+    p_share, v_share = trusted_dealer_setup(rc.circuit.vole_count())
+    msg1, batched = prove(rc.circuit, witness, p_share)
+    chi = F.rand_nonzero()
+    msg2 = batched(chi)
+    # Flip one bit of U.
+    from quicksilver.protocol import BatchedCheck
+    msg2 = BatchedCheck(U=F.add(msg2.U, 1), V=msg2.V)
+    assert not verify(rc.circuit, v_share, msg1, chi, msg2)
+
+
+def test_circuit_size_scales_as_n2_k():
+    """Sanity-check the asymptotic gate count for a few (n, k)."""
+    sizes = []
+    for n, k in [(4, 2), (4, 4), (6, 4), (8, 4)]:
+        rc = build_circuit(n=n, k=k, source=0, target=n - 1)
+        sizes.append((n, k, rc.circuit.num_muls))
+    # Print for inspection (assertion just guards monotonicity).
+    print(sizes)
+    # Doubling n at fixed k should roughly quadruple the mul-gate count.
+    n4 = next(m for n, k, m in sizes if n == 4 and k == 4)
+    n8 = next(m for n, k, m in sizes if n == 8 and k == 4)
+    assert n8 > 3 * n4
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
This PR adds a complete, pedagogical pure-Python implementation of the QuickSilver zero-knowledge proof system from Yang, Sarkar, Weng, Wang (CCS 2021). QuickSilver enables designated-verifier ZK proofs for arithmetic circuits over any field with three key properties: linear operations are free, each multiplication gate costs ~2 field elements amortised, and polynomial constraints can be checked without introducing intermediate wires.

## Key Changes

**Core Protocol Implementation**
- `quicksilver/field.py`: Prime field arithmetic over Mersenne prime p = 2^127 - 1
- `quicksilver/vole.py`: VOLE (Vector Oblivious Linear Evaluation) setup via trusted dealer
- `quicksilver/itmac.py`: Information-theoretic MACs derived from VOLE, preserving the relation K = M + Delta * x
- `quicksilver/circuit.py`: Minimal arithmetic circuit DSL supporting input, const, add, mul, and assert operations
- `quicksilver/protocol.py`: Three-round interactive protocol with batched multiplication consistency check

**Extensions**
- `quicksilver/polynomial.py`: Degree-d polynomial constraint checking without extra circuit wires
- `quicksilver/boolean.py`: Binary-circuit instantiation over GF(2^128) with subspace VOLE
- `quicksilver/gf2k.py`: GF(2^128) arithmetic using GCM irreducible polynomial
- `quicksilver/einsum.py`: Compiler from tensor-logic einsums to QuickSilver circuits
- `quicksilver/zk_reachability.py`: ZK proof of graph reachability via einsum recurrence
- `quicksilver/lpn_vole.py`: LPN-based VOLE extension (pseudorandom correlation generator)
- `quicksilver/fiat_shamir.py`: Non-interactive variant via Fiat-Shamir transform

**Demonstrations & Tests**
- `demos/quicksilver_demo.py`: Factorisation, cubic root, and polynomial constraint proofs
- `demos/quicksilver_boolean_demo.py`: Boolean circuit demos (bit multiplication, XOR preimage)
- `demos/zk_graph_reachability.py`: Interactive graph reachability proof
- `demos/zk_einsum.py`: Tensor-logic einsum proofs (matmul, dot product, outer product)
- `demos/lpn_vole_demo.py`: LPN-extended VOLE as drop-in replacement for trusted dealer
- Comprehensive test suites: `tests/test_quicksilver.py`, `tests/test_boolean.py`, `tests/test_einsum.py`, `tests/test_polynomial.py`, `tests/test_fiat_shamir.py`, `tests/test_lpn_vole.py`, `tests/test_zk_reachability.py`

## Notable Implementation Details

- **Soundness error**: ~m/|F| for m multiplication gates; well below 2^-120 over the Mersenne prime and below 2^-127 over GF(2^128)
- **No external dependencies**: Pure Python implementation suitable for education and prototyping
- **Designated-verifier**: Verifier's secret Delta is required for verification; Fiat-Shamir gives non-interactivity but not public verifiability
- **Cost model**: Linear operations are free; multiplication gates cost one VOLE element plus a slot in the batched check; polynomial constraints cost d field elements per batch for degree d
- **Extensibility**: VOLE can be replaced with LPN-based pseudorandom correlation generator for practical deployments

The implementation includes ~2,500 lines of code across 8 core modules, 76 tests, and 6 runnable demos demonstrating the full prover/verifier loop.

https://claude.ai/code/session_01CGY2FJdADSP9eSsMEAQ8Si