### PR TITLE
Add minimal web workbench shell for tensor_logic

### DIFF
--- a/web_workbench/README.md
+++ b/web_workbench/README.md
@@ -1,0 +1,21 @@
+# tensor_logic web workbench
+
+Minimal shell UI for iterative `.tl` editing and command execution.
+
+## Features
+
+- Left pane: editable source.
+- Right pane: command output.
+- Toolbar actions: `Run`, `Query`, `Prove`, `Why Not`.
+- POSTs to local endpoints (`/api/run`, `/api/query`, `/api/prove`, `/api/why-not`).
+- Frontend falls back to a mock response if the backend endpoint is unavailable.
+
+## Run
+
+```bash
+python web_workbench/server.py --host 127.0.0.1 --port 8080
+```
+
+Then open <http://127.0.0.1:8080>.
+
+The backend wraps the existing CLI (`python -m tensor_logic ...`) by writing current source to a temporary `.tl` file per request.

--- a/web_workbench/server.py
+++ b/web_workbench/server.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+STATIC_DIR = ROOT / "static"
+
+
+class WorkbenchHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(STATIC_DIR), **kwargs)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if not self.path.startswith("/api/"):
+            self.send_error(HTTPStatus.NOT_FOUND, "Unknown endpoint")
+            return
+
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            raw_body = self.rfile.read(length)
+            payload = json.loads(raw_body.decode("utf-8") or "{}")
+        except (ValueError, json.JSONDecodeError):
+            self._write_json({"error": "Invalid JSON payload"}, HTTPStatus.BAD_REQUEST)
+            return
+
+        action = self.path.rsplit("/", 1)[-1]
+        result, status = run_tensor_logic_action(action, payload)
+        self._write_json(result, status)
+
+    def log_message(self, format: str, *args) -> None:
+        sys.stderr.write(f"[workbench] {self.address_string()} - {format % args}\n")
+
+    def _write_json(self, payload: dict, status: HTTPStatus = HTTPStatus.OK) -> None:
+        encoded = json.dumps(payload, indent=2).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def run_tensor_logic_action(action: str, payload: dict) -> tuple[dict, HTTPStatus]:
+    source = payload.get("source", "")
+    if not source.strip():
+        return {"error": "Missing source"}, HTTPStatus.BAD_REQUEST
+
+    relation = str(payload.get("relation", "")).strip()
+    arg1 = str(payload.get("arg1", "")).strip()
+    arg2 = str(payload.get("arg2", "")).strip()
+    recursive = bool(payload.get("recursive", False))
+
+    with tempfile.NamedTemporaryFile("w", suffix=".tl", delete=False, encoding="utf-8") as handle:
+        handle.write(source)
+        temp_path = Path(handle.name)
+
+    cmd = [sys.executable, "-m", "tensor_logic"]
+    if action == "run":
+        cmd += ["run", str(temp_path)]
+    elif action == "query":
+        if not (relation and arg1 and arg2):
+            temp_path.unlink(missing_ok=True)
+            return {"error": "relation, arg1, and arg2 are required"}, HTTPStatus.BAD_REQUEST
+        cmd += ["query", str(temp_path), relation, arg1, arg2]
+        if recursive:
+            cmd.append("--recursive")
+    elif action == "prove":
+        if not (relation and arg1 and arg2):
+            temp_path.unlink(missing_ok=True)
+            return {"error": "relation, arg1, and arg2 are required"}, HTTPStatus.BAD_REQUEST
+        cmd += ["prove", str(temp_path), relation, arg1, arg2]
+        if recursive:
+            cmd.append("--recursive")
+    elif action == "why-not":
+        if not (relation and arg1 and arg2):
+            temp_path.unlink(missing_ok=True)
+            return {"error": "relation, arg1, and arg2 are required"}, HTTPStatus.BAD_REQUEST
+        cmd += ["prove", str(temp_path), relation, arg1, arg2, "--why-not"]
+        if recursive:
+            cmd.append("--recursive")
+    else:
+        temp_path.unlink(missing_ok=True)
+        return {"error": f"Unknown action: {action}"}, HTTPStatus.NOT_FOUND
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT.parent), check=False)
+    except Exception as exc:  # pragma: no cover - defensive
+        temp_path.unlink(missing_ok=True)
+        return {"error": str(exc)}, HTTPStatus.INTERNAL_SERVER_ERROR
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    response = {
+        "action": action,
+        "command": " ".join(cmd),
+        "exit_code": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }
+    status = HTTPStatus.OK if proc.returncode == 0 else HTTPStatus.BAD_REQUEST
+    return response, status
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="tensor_logic web workbench")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8080)
+    args = parser.parse_args(argv)
+
+    server = ThreadingHTTPServer((args.host, args.port), WorkbenchHandler)
+    print(f"Serving tensor_logic workbench at http://{args.host}:{args.port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down...")
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web_workbench/static/app.js
+++ b/web_workbench/static/app.js
@@ -1,0 +1,70 @@
+const sourceEl = document.getElementById("source");
+const resultEl = document.getElementById("result");
+const relationEl = document.getElementById("relation");
+const arg1El = document.getElementById("arg1");
+const arg2El = document.getElementById("arg2");
+const recursiveEl = document.getElementById("recursive");
+
+sourceEl.value = `# Minimal sample
+parent(alice,bob).
+parent(bob,cara).
+
+ancestor(X,Y) :- parent(X,Y).
+ancestor(X,Y) :- parent(X,Z), ancestor(Z,Y).
+
+query ancestor(alice,cara).`;
+
+function payload() {
+  return {
+    source: sourceEl.value,
+    relation: relationEl.value,
+    arg1: arg1El.value,
+    arg2: arg2El.value,
+    recursive: recursiveEl.checked,
+  };
+}
+
+function mockResponse(action, body) {
+  if (action === "query") {
+    return {
+      action,
+      mock: true,
+      stdout: `${body.relation}(${body.arg1}, ${body.arg2}) = <mock result>`,
+      stderr: "",
+      exit_code: 0,
+    };
+  }
+  return {
+    action,
+    mock: true,
+    stdout: `Mock ${action} completed. Connect /api/${action} to backend to execute real tensor_logic commands.`,
+    stderr: "",
+    exit_code: 0,
+  };
+}
+
+async function invoke(action) {
+  const body = payload();
+  resultEl.textContent = `$ ${action}...`;
+
+  try {
+    const res = await fetch(`/api/${action}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      resultEl.textContent = `HTTP ${res.status}\n${JSON.stringify(data, null, 2)}`;
+      return;
+    }
+    resultEl.textContent = `${data.stdout || ""}${data.stderr ? `\n[stderr]\n${data.stderr}` : ""}`.trim();
+  } catch {
+    const data = mockResponse(action, body);
+    resultEl.textContent = `[mock mode]\n${data.stdout}`;
+  }
+}
+
+document.querySelectorAll("button[data-action]").forEach((button) => {
+  button.addEventListener("click", () => invoke(button.dataset.action));
+});

--- a/web_workbench/static/index.html
+++ b/web_workbench/static/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>tensor_logic workbench</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="toolbar">
+      <button data-action="run">Run</button>
+      <button data-action="query">Query</button>
+      <button data-action="prove">Prove</button>
+      <button data-action="why-not">Why Not</button>
+      <label>relation <input id="relation" value="ancestor" /></label>
+      <label>arg1 <input id="arg1" value="alice" /></label>
+      <label>arg2 <input id="arg2" value="cara" /></label>
+      <label class="toggle"><input id="recursive" type="checkbox" checked />recursive</label>
+    </header>
+
+    <main class="split">
+      <section>
+        <div class="pane-title">source.tl</div>
+        <textarea id="source" spellcheck="false"></textarea>
+      </section>
+      <section>
+        <div class="pane-title">result</div>
+        <pre id="result"></pre>
+      </section>
+    </main>
+
+    <script src="./app.js" type="module"></script>
+  </body>
+</html>

--- a/web_workbench/static/styles.css
+++ b/web_workbench/static/styles.css
@@ -1,0 +1,106 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f1115;
+  --panel: #161b22;
+  --line: #31363f;
+  --text: #d7dde8;
+  --muted: #8b95a7;
+  --accent: #4e8cff;
+}
+
+* {
+  box-sizing: border-box;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--line);
+  background: #0c0f13;
+  flex-wrap: wrap;
+}
+
+button,
+input {
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--line);
+  padding: 0.25rem 0.45rem;
+  font-size: 12px;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+label {
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 12px;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 0;
+}
+
+section {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  border-right: 1px solid var(--line);
+}
+
+section:last-child {
+  border-right: 0;
+}
+
+.pane-title {
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+textarea,
+pre {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: var(--panel);
+  color: var(--text);
+  padding: 0.65rem;
+  resize: none;
+  outline: none;
+  font-size: 13px;
+  line-height: 1.25;
+  overflow: auto;
+}
+
+pre {
+  white-space: pre-wrap;
+}
+
+.toggle {
+  user-select: none;
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal, utilitarian web UI for iteratively editing `.tl` source and running tensor_logic commands without touching core library code.
- Allow future wiring to a full backend by exposing simple local HTTP endpoints that wrap the existing CLI and fall back to a mock response when unavailable.

### Description

- Add `web_workbench/server.py`, a small stdlib HTTP server that serves static assets and exposes `/api/run`, `/api/query`, `/api/prove`, and `/api/why-not` by writing the current source to a temporary `.tl` file and invoking `python -m tensor_logic`.
- Add frontend static assets under `web_workbench/static/`: `index.html` for a split-pane UI with a dense toolbar, `styles.css` for compact dark styling, and `app.js` which posts to the local API endpoints and provides a mock-mode fallback when the backend is unreachable.
- Add `web_workbench/README.md` with run instructions showing how to start the workbench and noting that the backend delegates to the CLI via temporary files.
- The change does not modify any files under `tensor_logic/` and keeps all core logic intact.

### Testing

- Compiled the server file successfully with `python -m py_compile web_workbench/server.py` which passed.
- Exercised the backend wrapper via the `run_tensor_logic_action` function in automated Python calls, which returned non-zero exit codes and `HTTPStatus.BAD_REQUEST` because importing the core package failed in this environment due to the missing runtime dependency `torch` (this is an environment issue, not a code change failure).
- No frontend integration tests were run; the frontend includes a network-failure fallback that was exercised manually by simulating unavailable backend calls which triggers the mock response behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdbfdc234832cbbb02e94343a0fb0)