### PR TITLE
Add proof tree viewer for positive/negative JSON outputs

### DIFF
--- a/tensor_logic/__init__.py
+++ b/tensor_logic/__init__.py
@@ -6,6 +6,7 @@ from .program import Program, FactSource
 from .file_format import load_tl
 from .proofs import fmt_proof_tree, fmt_negative_proof_tree, prove, prove_negative, Proof, NegativeProof
 from .provenance import evaluate_with_provenance, fmt_proof, proof_score
+from .proof_tree_viewer import ProofTreeNode, build_proof_tree_view, render_proof_tree
 from .rules import (
     Atom,
     Rule,
@@ -38,5 +39,8 @@ __all__ = [
     "fmt_proof",
     "parse_rule",
     "proof_score",
+    "ProofTreeNode",
+    "build_proof_tree_view",
+    "render_proof_tree",
     "query_relation",
 ]

--- a/tensor_logic/proof_tree_viewer.py
+++ b/tensor_logic/proof_tree_viewer.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class ProofTreeNode:
+    node_id: str
+    head: tuple[str, str, str]
+    children: tuple["ProofTreeNode", ...] = ()
+    confidence: float | None = None
+    reason: str | None = None
+    source: tuple[str, int] | None = None
+    is_negative: bool = False
+
+
+def build_proof_tree_view(payload: dict) -> ProofTreeNode:
+    """Build a tree model from CLI JSON output.
+
+    Supports:
+      - positive: {"answer": true, "proof": {...}}
+      - negative: {"answer": false, "explanation": {...}}
+    """
+    if payload.get("answer") is True:
+        proof = payload.get("proof")
+        if not isinstance(proof, dict):
+            raise ValueError("expected 'proof' object when answer=true")
+        return _parse_positive_node(proof, "0")
+
+    if payload.get("answer") is False:
+        explanation = payload.get("explanation")
+        if not isinstance(explanation, dict):
+            raise ValueError("expected 'explanation' object when answer=false")
+        return _parse_negative_node(explanation, "0")
+
+    raise ValueError("payload must include boolean 'answer'")
+
+
+def render_proof_tree(node: ProofTreeNode, collapsed: Iterable[str] | None = None) -> str:
+    """Render a proof tree with collapsible nodes.
+
+    Args:
+      node: root proof node.
+      collapsed: iterable of node_ids that should be rendered collapsed.
+    """
+    collapsed_set = set(collapsed or ())
+    lines: list[str] = []
+    _render(node, collapsed_set, lines, depth=0)
+    return "\n".join(lines)
+
+
+def _parse_positive_node(data: dict, node_id: str) -> ProofTreeNode:
+    head = _parse_head(data)
+    source = None
+    src_obj = data.get("source")
+    if isinstance(src_obj, dict):
+        file_name = src_obj.get("file")
+        lineno = src_obj.get("lineno")
+        if isinstance(file_name, str) and isinstance(lineno, int):
+            source = (file_name, lineno)
+    children = tuple(_parse_positive_node(child, f"{node_id}.{idx}") for idx, child in enumerate(data.get("body", [])))
+    confidence = data.get("confidence")
+    if not isinstance(confidence, (float, int)):
+        confidence = None
+    else:
+        confidence = float(confidence)
+    return ProofTreeNode(
+        node_id=node_id,
+        head=head,
+        children=children,
+        confidence=confidence,
+        source=source,
+        is_negative=False,
+    )
+
+
+def _parse_negative_node(data: dict, node_id: str) -> ProofTreeNode:
+    head = _parse_head(data)
+    body = data.get("body", [])
+    children: list[ProofTreeNode] = []
+    for idx, child in enumerate(body):
+        if isinstance(child, dict) and "explanation" in child and isinstance(child["explanation"], dict):
+            children.append(_parse_negative_node(child["explanation"], f"{node_id}.{idx}"))
+        elif isinstance(child, dict):
+            children.append(_parse_negative_node(child, f"{node_id}.{idx}"))
+    reason = data.get("reason")
+    return ProofTreeNode(
+        node_id=node_id,
+        head=head,
+        children=tuple(children),
+        reason=reason if isinstance(reason, str) else None,
+        is_negative=True,
+    )
+
+
+def _parse_head(data: dict) -> tuple[str, str, str]:
+    raw_head = data.get("head")
+    if not isinstance(raw_head, (list, tuple)) or len(raw_head) != 3:
+        raise ValueError("expected head as [relation, src, dst]")
+    rel, src, dst = raw_head
+    return str(rel), str(src), str(dst)
+
+
+def _render(node: ProofTreeNode, collapsed: set[str], out: list[str], depth: int) -> None:
+    indent = "  " * depth
+    has_children = bool(node.children)
+    marker = "▸" if node.node_id in collapsed and has_children else ("▾" if has_children else "•")
+    rel, src, dst = node.head
+    text = f"{rel}({src}, {dst})"
+    if node.is_negative:
+        text += " = False"
+    if node.reason:
+        text += f" [{node.reason}]"
+    if node.confidence is not None:
+        text += f" ({node.confidence:.2f})"
+    if node.source is not None:
+        file_name, lineno = node.source
+        text += f" [{file_name}:{lineno}]"
+
+    out.append(f"{indent}{marker} {text}")
+    if node.node_id in collapsed:
+        return
+    for child in node.children:
+        _render(child, collapsed, out, depth + 1)

--- a/tests/fixtures/proof_tree_negative.json
+++ b/tests/fixtures/proof_tree_negative.json
@@ -1,0 +1,20 @@
+{
+  "answer": false,
+  "explanation": {
+    "head": ["depends_on", "models", "worker"],
+    "reason": "all_rules_failed",
+    "body": [
+      {
+        "head": ["depends_on", "models", "worker"],
+        "reason": "rule_body_failed",
+        "body": [
+          {
+            "head": ["imports", "models", "worker"],
+            "reason": "no_rules",
+            "body": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/proof_tree_positive.json
+++ b/tests/fixtures/proof_tree_positive.json
@@ -1,0 +1,28 @@
+{
+  "answer": true,
+  "proof": {
+    "head": ["depends_on", "worker", "models"],
+    "confidence": 0.81,
+    "source": {"file": "examples/code_dependencies.tl", "lineno": 14},
+    "body": [
+      {
+        "head": ["imports", "worker", "api"],
+        "confidence": 0.9,
+        "source": {"file": "examples/code_dependencies.tl", "lineno": 11},
+        "body": []
+      },
+      {
+        "head": ["depends_on", "api", "models"],
+        "confidence": 0.9,
+        "body": [
+          {
+            "head": ["imports", "api", "models"],
+            "confidence": 0.9,
+            "source": {"file": "examples/code_dependencies.tl", "lineno": 12},
+            "body": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_proof_tree_viewer.py
+++ b/tests/test_proof_tree_viewer.py
@@ -1,0 +1,78 @@
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_MODULE_PATH = _ROOT / "tensor_logic" / "proof_tree_viewer.py"
+_spec = importlib.util.spec_from_file_location("proof_tree_viewer", _MODULE_PATH)
+_module = importlib.util.module_from_spec(_spec)
+assert _spec is not None and _spec.loader is not None
+sys.modules[_spec.name] = _module
+_spec.loader.exec_module(_module)
+build_proof_tree_view = _module.build_proof_tree_view
+render_proof_tree = _module.render_proof_tree
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+class ProofTreeViewerTest(unittest.TestCase):
+    def test_positive_tree_renders_confidence_and_source(self):
+        payload = json.loads((_FIXTURE_DIR / "proof_tree_positive.json").read_text())
+        tree = build_proof_tree_view(payload)
+
+        rendered = render_proof_tree(tree)
+
+        self.assertIn("depends_on(worker, models)", rendered)
+        self.assertIn("(0.81)", rendered)
+        self.assertIn("[examples/code_dependencies.tl:14]", rendered)
+        self.assertIn("imports(api, models)", rendered)
+
+    def test_negative_tree_renders_reason(self):
+        payload = json.loads((_FIXTURE_DIR / "proof_tree_negative.json").read_text())
+        tree = build_proof_tree_view(payload)
+
+        rendered = render_proof_tree(tree)
+
+        self.assertIn("depends_on(models, worker) = False", rendered)
+        self.assertIn("[all_rules_failed]", rendered)
+        self.assertIn("imports(models, worker) = False", rendered)
+
+    def test_collapsed_nodes_hide_subtrees(self):
+        payload = json.loads((_FIXTURE_DIR / "proof_tree_positive.json").read_text())
+        tree = build_proof_tree_view(payload)
+
+        rendered = render_proof_tree(tree, collapsed={"0.1"})
+
+        self.assertIn("▸ depends_on(api, models)", rendered)
+        self.assertNotIn("imports(api, models)", rendered)
+
+    def test_supports_nested_negative_child_explanation_shape(self):
+        payload = {
+            "answer": False,
+            "explanation": {
+                "head": ["edge", "a", "z"],
+                "reason": "all_rules_failed",
+                "body": [
+                    {
+                        "answer": False,
+                        "explanation": {
+                            "head": ["edge", "a", "z"],
+                            "reason": "no_rules",
+                            "body": []
+                        },
+                    }
+                ],
+            },
+        }
+
+        tree = build_proof_tree_view(payload)
+        rendered = render_proof_tree(tree)
+
+        self.assertIn("edge(a, z) = False", rendered)
+        self.assertIn("[no_rules]", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a small, local proof-tree viewer that can consume the CLI/JSON outputs for both positive (`answer: true`) and negative (`answer: false`) proofs and render them for inspection.
- Support rendering of nested proof nodes with metadata (confidence, source location, negative reasons) and collapsed/expanded UI state for large trees.
- Add deterministic fixtures and component tests to validate the parser/renderer shape and edge cases (nested negative-child wrappers).

### Description
- Add `tensor_logic/proof_tree_viewer.py` which defines `ProofTreeNode`, parses both positive (`proof`) and negative (`explanation`) JSON payload shapes, and renders trees with confidence, source, reason tags, and collapse support via node IDs.
- Include fixture payloads `tests/fixtures/proof_tree_positive.json` and `tests/fixtures/proof_tree_negative.json` and a component test file `tests/test_proof_tree_viewer.py` that verifies positive rendering, negative reasons, collapsed-node behavior, and nested negative-child shapes.
- Export the viewer API (`ProofTreeNode`, `build_proof_tree_view`, `render_proof_tree`) from the package `tensor_logic.__init__` for convenient imports.

### Testing
- Ran the component tests with `python -m unittest tests/test_proof_tree_viewer.py` and they passed (checked rendering of confidence, source tags, negative reasons, collapse behavior, and nested shapes). 
- Attempted to run the core suite with `python -m unittest tests/test_proof_tree_viewer.py tests/test_tensor_logic_core.py` which errored because the environment lacks the `torch` dependency (import failure). 
- Attempted `uv run --with torch python -m unittest tests/test_proof_tree_viewer.py` to install/run with `torch`, but dependency fetch failed due to network/PyPI access in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdc086908832c8cb2838a6253ed70)