### PR TITLE
Add repo dependency graph view (CLI + helpers) for Module/imports/depends_on fixtures

### DIFF
--- a/tensor_logic/__main__.py
+++ b/tensor_logic/__main__.py
@@ -6,6 +6,7 @@ import sys
 
 from .file_format import Command, load_tl
 from .proofs import fmt_proof_tree, fmt_negative_proof_tree, prove, prove_negative, Proof, NegativeProof
+from .repo_graph_view import dependency_report, repo_graph_repl
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -31,10 +32,26 @@ def main(argv: list[str] | None = None) -> int:
 
     sub.add_parser("repl")
 
+    graph_p = sub.add_parser("repo-graph", help="Dependency graph view for Module/imports/depends_on facts")
+    graph_p.add_argument("file", nargs="?", default="/tmp/repo.tl")
+    graph_p.add_argument("--module", help="Show direct imports for one module")
+    graph_p.add_argument("--src", help="Source module for depends_on query")
+    graph_p.add_argument("--dst", help="Destination module for depends_on query")
+    graph_p.add_argument("--interactive", action="store_true", help="Open interactive dependency graph view")
+
     args = parser.parse_args(argv)
 
     if args.cmd == "repl":
         _run_repl()
+        return 0
+
+    if args.cmd == "repo-graph":
+        if args.interactive:
+            repo_graph_repl(args.file)
+            return 0
+        if (args.src is None) != (args.dst is None):
+            parser.error("--src and --dst must be provided together")
+        print(dependency_report(args.file, module=args.module, src=args.src, dst=args.dst))
         return 0
 
     loaded = load_tl(args.file)

--- a/tensor_logic/repo_graph_view.py
+++ b/tensor_logic/repo_graph_view.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Iterable
+
+from .file_format import load_tl
+from .proofs import Proof, fmt_proof_tree, prove
+
+
+@dataclass(frozen=True)
+class RepoGraphData:
+    modules: tuple[str, ...]
+    imports: tuple[tuple[str, str], ...]
+
+
+def load_repo_graph(path: str) -> RepoGraphData:
+    loaded = load_tl(path)
+    program = loaded.program
+    if "Module" not in program.domains:
+        raise ValueError("domain 'Module' is required for repo graph view")
+    if "imports" not in program.relations:
+        raise ValueError("relation 'imports' is required for repo graph view")
+
+    modules = tuple(program.domains["Module"].symbols)
+    imports_rel = program.relations["imports"]
+    edges: list[tuple[str, str]] = []
+    for src in modules:
+        for dst in modules:
+            if imports_rel.value(src, dst, semiring="boolean") > 0:
+                edges.append((src, dst))
+    return RepoGraphData(modules=modules, imports=tuple(edges))
+
+
+def build_adjacency(modules: Iterable[str], imports: Iterable[tuple[str, str]]) -> dict[str, list[str]]:
+    adj = {module: [] for module in modules}
+    for src, dst in imports:
+        adj.setdefault(src, []).append(dst)
+        adj.setdefault(dst, [])
+    for dsts in adj.values():
+        dsts.sort()
+    return adj
+
+
+def filter_modules(modules: Iterable[str], query: str) -> list[str]:
+    query = query.strip().lower()
+    if not query:
+        return sorted(modules)
+    return sorted(module for module in modules if query in module.lower())
+
+
+def imports_path(modules: Iterable[str], imports: Iterable[tuple[str, str]], src: str, dst: str) -> list[str] | None:
+    adj = build_adjacency(modules, imports)
+    if src not in adj or dst not in adj:
+        return None
+    queue = deque([src])
+    parent: dict[str, str | None] = {src: None}
+    while queue:
+        node = queue.popleft()
+        if node == dst:
+            break
+        for nxt in adj[node]:
+            if nxt in parent:
+                continue
+            parent[nxt] = node
+            queue.append(nxt)
+    if dst not in parent:
+        return None
+    rev = [dst]
+    while parent[rev[-1]] is not None:
+        rev.append(parent[rev[-1]])
+    rev.reverse()
+    return rev
+
+
+def extract_path_from_proof(proof: Proof, base_relation: str = "imports") -> list[str] | None:
+    edges = _proof_edges(proof, base_relation)
+    if not edges:
+        return None
+    return imports_path({s for edge in edges for s in edge}, edges, proof.head[1], proof.head[2])
+
+
+def _proof_edges(proof: Proof, base_relation: str) -> set[tuple[str, str]]:
+    edges: set[tuple[str, str]] = set()
+    rel, src, dst = proof.head
+    if rel == base_relation:
+        edges.add((src, dst))
+    for child in proof.body:
+        edges.update(_proof_edges(child, base_relation))
+    return edges
+
+
+def format_adjacency(adjacency: dict[str, list[str]]) -> str:
+    lines = []
+    for module in sorted(adjacency):
+        imports = ", ".join(adjacency[module]) if adjacency[module] else "(none)"
+        lines.append(f"- {module}: {imports}")
+    return "\n".join(lines)
+
+
+def repo_graph_repl(path: str, out=None) -> None:
+    import sys
+
+    if out is None:
+        out = sys.stdout
+
+    loaded = load_tl(path)
+    graph = load_repo_graph(path)
+    modules = graph.modules
+    adjacency = build_adjacency(modules, graph.imports)
+
+    print("tensor-logic repo dependency graph view", file=out)
+    print("Commands: search <text> | show <module> | depends <src> <dst> | adj | help | exit", file=out)
+
+    while True:
+        try:
+            line = input("repo> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print(file=out)
+            break
+        if not line:
+            continue
+        if line in {"exit", "quit"}:
+            break
+        if line == "help":
+            print("search <text>     Filter Module symbols", file=out)
+            print("show <module>     Direct imports for one module", file=out)
+            print("depends a b       Query/prove depends_on(a,b)", file=out)
+            print("adj               Full import adjacency list", file=out)
+            continue
+        if line == "adj":
+            print(format_adjacency(adjacency), file=out)
+            continue
+        if line.startswith("search "):
+            term = line[len("search "):]
+            hits = filter_modules(modules, term)
+            if not hits:
+                print("No matching modules.", file=out)
+            else:
+                print("\n".join(f"- {h}" for h in hits), file=out)
+            continue
+        if line.startswith("show "):
+            module = line[len("show "):].strip()
+            if module not in adjacency:
+                print(f"Unknown module: {module}", file=out)
+                continue
+            direct = adjacency[module]
+            if direct:
+                print(f"direct imports({module}): {', '.join(direct)}", file=out)
+            else:
+                print(f"direct imports({module}): (none)", file=out)
+            continue
+        if line.startswith("depends "):
+            parts = line.split()
+            if len(parts) != 3:
+                print("Usage: depends <src> <dst>", file=out)
+                continue
+            src, dst = parts[1], parts[2]
+            if src not in adjacency or dst not in adjacency:
+                print("Unknown module symbol(s)", file=out)
+                continue
+            answer = bool(loaded.program.query("depends_on", src, dst, recursive=True))
+            print(f"depends_on({src}, {dst}) = {answer}", file=out)
+            if not answer:
+                continue
+            proof = prove(loaded.program, "depends_on", src, dst, recursive=True)
+            if proof is not None:
+                path = extract_path_from_proof(proof)
+                if path is not None:
+                    print("path: " + " -> ".join(path), file=out)
+                print(fmt_proof_tree(proof), file=out)
+            continue
+        print(f"Unknown command: {line}", file=out)
+
+
+def dependency_report(path: str, module: str | None = None, src: str | None = None, dst: str | None = None) -> str:
+    loaded = load_tl(path)
+    graph = load_repo_graph(path)
+    adjacency = build_adjacency(graph.modules, graph.imports)
+
+    lines = ["Repo dependency graph report"]
+    lines.append(f"modules={len(graph.modules)} imports={len(graph.imports)}")
+
+    if module is not None:
+        if module not in adjacency:
+            raise ValueError(f"Unknown module: {module}")
+        direct = adjacency[module]
+        lines.append(f"direct imports({module}): {', '.join(direct) if direct else '(none)'}")
+
+    if src is not None and dst is not None:
+        answer = bool(loaded.program.query("depends_on", src, dst, recursive=True))
+        lines.append(f"depends_on({src}, {dst}) = {answer}")
+        if answer:
+            proof = prove(loaded.program, "depends_on", src, dst, recursive=True)
+            if proof is not None:
+                path = extract_path_from_proof(proof)
+                if path is not None:
+                    lines.append("path: " + " -> ".join(path))
+                lines.append(fmt_proof_tree(proof))
+
+    lines.append("adjacency:")
+    lines.append(format_adjacency(adjacency))
+    return "\n".join(lines)

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -494,5 +494,45 @@ class TensorLogicCoreTest(unittest.TestCase):
         self.assertEqual(proof.body[0].head[0], "imports")
 
 
+    def test_repo_graph_helpers_and_report(self):
+        from tensor_logic.repo_graph_view import load_repo_graph, build_adjacency, filter_modules, imports_path, dependency_report
+
+        graph = load_repo_graph("examples/code_dependencies.tl")
+        self.assertIn("worker", graph.modules)
+        self.assertIn(("worker", "api"), graph.imports)
+
+        adjacency = build_adjacency(graph.modules, graph.imports)
+        self.assertEqual(adjacency["worker"], ["api"])
+        self.assertEqual(filter_modules(graph.modules, "mo"), ["models"])
+        self.assertEqual(imports_path(graph.modules, graph.imports, "worker", "models"), ["worker", "api", "db", "models"])
+
+        report = dependency_report("examples/code_dependencies.tl", module="worker", src="worker", dst="models")
+        self.assertIn("direct imports(worker): api", report)
+        self.assertIn("depends_on(worker, models) = True", report)
+        self.assertIn("path: worker -> api -> db -> models", report)
+
+    def test_repo_graph_cli_subcommand(self):
+        from tensor_logic.__main__ import main
+        import io
+        from contextlib import redirect_stdout
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = main([
+                "repo-graph",
+                "examples/code_dependencies.tl",
+                "--module",
+                "worker",
+                "--src",
+                "worker",
+                "--dst",
+                "models",
+            ])
+        self.assertEqual(rc, 0)
+        result = out.getvalue()
+        self.assertIn("Repo dependency graph report", result)
+        self.assertIn("depends_on(worker, models) = True", result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a lightweight dependency-graph UI for generated repo facts (Module symbols, `imports(a,b)` facts and `depends_on(a,b)` proofs) to support searching modules, showing direct imports and transitive proof-backed paths. 
- Use adjacency-list output to avoid introducing a heavy graph-visualization dependency and allow the tool to operate on `/tmp/repo.tl`-style fixtures.

### Description
- Add a new module `tensor_logic/repo_graph_view.py` implementing `load_repo_graph`, `build_adjacency`, `filter_modules`, `imports_path`, `extract_path_from_proof`, an interactive `repo_graph_repl` and a textual `dependency_report` renderer that extracts proof-backed paths from `depends_on` proofs.
- Wire a new CLI subcommand `repo-graph` into `tensor_logic.__main__` with optional `--interactive` mode, `--module` for direct-import display, and paired `--src/--dst` options for transitive `depends_on` queries, defaulting the file argument to `/tmp/repo.tl`.
- Use adjacency-list output and simple BFS for transitive path discovery and proof edge extraction to keep the implementation small and dependency-free.
- Add unit tests to `tests/test_tensor_logic_core.py` covering the helpers (`load_repo_graph`, `build_adjacency`, `filter_modules`, `imports_path`, `dependency_report`) and a CLI invocation of the new `repo-graph` subcommand using `examples/code_dependencies.tl` as fixture data.

### Testing
- Ran `python -m compileall tensor_logic`, which succeeded and compiled the updated package files.  
- Ran a targeted `pytest` invocation (selection including the new repo-graph tests), but collection failed in this environment due to `ModuleNotFoundError: No module named 'torch'`, so the test run did not complete.  
- Ran the packaged CLI `python -m tensor_logic repo-graph examples/code_dependencies.tl --module worker --src worker --dst models`, which exercised the new CLI path but failed in this environment for the same missing `torch` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdc11e7bc832c9409f25028510744)