### PR TITLE
Add HTTP API wrapper for tensor-logic CLI workflows

### DIFF
--- a/tensor_logic/__init__.py
+++ b/tensor_logic/__init__.py
@@ -5,6 +5,7 @@ from .language import Domain, Relation, evaluate_expr, facts
 from .program import Program, FactSource
 from .file_format import load_tl
 from .proofs import fmt_proof_tree, fmt_negative_proof_tree, prove, prove_negative, Proof, NegativeProof
+from .http_api import ingest_python, run_source, query_source, prove_source, serve
 from .provenance import evaluate_with_provenance, fmt_proof, proof_score
 from .rules import (
     Atom,
@@ -37,6 +38,11 @@ __all__ = [
     "prove_negative",
     "fmt_proof",
     "parse_rule",
+    "ingest_python",
+    "run_source",
+    "query_source",
+    "prove_source",
+    "serve",
     "proof_score",
     "query_relation",
 ]

--- a/tensor_logic/__main__.py
+++ b/tensor_logic/__main__.py
@@ -6,6 +6,7 @@ import sys
 
 from .file_format import Command, load_tl
 from .proofs import fmt_proof_tree, fmt_negative_proof_tree, prove, prove_negative, Proof, NegativeProof
+from .http_api import serve
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -31,10 +32,17 @@ def main(argv: list[str] | None = None) -> int:
 
     sub.add_parser("repl")
 
+    serve_p = sub.add_parser("serve")
+    serve_p.add_argument("--host", default="127.0.0.1")
+    serve_p.add_argument("--port", type=int, default=8000)
+
     args = parser.parse_args(argv)
 
     if args.cmd == "repl":
         _run_repl()
+        return 0
+    if args.cmd == "serve":
+        serve(args.host, args.port)
         return 0
 
     loaded = load_tl(args.file)

--- a/tensor_logic/http_api.py
+++ b/tensor_logic/http_api.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+from .file_format import Command, load_tl
+from .proofs import fmt_negative_proof_tree, fmt_proof_tree, prove, prove_negative, NegativeProof, Proof
+
+
+@dataclass(frozen=True)
+class ApiError(Exception):
+    status_code: int
+    message: str
+
+
+def _module_name_from_path(path: Path) -> str:
+    if path.stem == "__init__":
+        return path.parent.name
+    return path.stem
+
+
+def _normalize_module_name(name: str) -> str:
+    return name.split(".", 1)[0]
+
+
+def ingest_python(path: str) -> str:
+    src_path = Path(path).resolve()
+    if not src_path.exists() or not src_path.is_file():
+        raise ApiError(HTTPStatus.BAD_REQUEST, f"invalid path: {path}")
+
+    module_name = _module_name_from_path(src_path)
+    text = src_path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(src_path))
+
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.add(_normalize_module_name(alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imports.add(_normalize_module_name(node.module))
+            elif node.level > 0:
+                for alias in node.names:
+                    imports.add(_normalize_module_name(alias.name))
+
+    imports.discard(module_name)
+    modules = sorted({module_name, *imports})
+
+    lines = [
+        "domain Module {",
+        *[f"  {name}" for name in modules],
+        "}",
+        "",
+        "relation imports(Module, Module)",
+        "relation depends_on(Module, Module)",
+        "",
+        *[f"fact imports({module_name}, {name})" for name in sorted(imports)],
+        "",
+        "rule depends_on(x,z) := (imports(x,z) + depends_on(x,y) * imports(y,z)).step()",
+    ]
+    return "\n".join(lines).strip() + "\n"
+
+
+def _proof_to_json(proof: Proof) -> dict[str, Any]:
+    rel, src, dst = proof.head
+    return {
+        "head": [rel, src, dst],
+        "confidence": proof.confidence,
+        "body": [_proof_to_json(child) for child in proof.body],
+    }
+
+
+def _negative_proof_to_json(neg_proof: NegativeProof) -> dict[str, Any]:
+    rel, src, dst = neg_proof.head
+    return {
+        "answer": False,
+        "explanation": {
+            "head": [rel, src, dst],
+            "reason": neg_proof.reason,
+            "body": [_negative_proof_to_json(child) for child in neg_proof.body] if neg_proof.body else [],
+        },
+    }
+
+
+def _load_program_from_source(source: str):
+    fd, path = tempfile.mkstemp(suffix=".tl", prefix="tensor_logic_api_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(source)
+        return load_tl(path)
+    finally:
+        os.unlink(path)
+
+
+def run_source(source: str) -> dict[str, Any]:
+    loaded = _load_program_from_source(source)
+    outputs: list[str] = []
+    for command in loaded.commands:
+        out = StringIO()
+        _execute_command(loaded.program, command, format_type="tree", why_not=False, out=out)
+        outputs.append(out.getvalue().strip())
+    return {"outputs": outputs}
+
+
+def query_source(source: str, relation: str, args: list[str], recursive: bool = False) -> dict[str, Any]:
+    if len(args) != 2:
+        raise ApiError(HTTPStatus.BAD_REQUEST, "query requires exactly 2 args")
+    loaded = _load_program_from_source(source)
+    value = loaded.program.query(relation, *args, recursive=recursive)
+    return {
+        "answer": bool(value),
+        "value": float(value),
+        "relation": relation,
+        "args": args,
+        "recursive": recursive,
+    }
+
+
+def prove_source(
+    source: str,
+    relation: str,
+    args: list[str],
+    recursive: bool = False,
+    why_not: bool = False,
+    format_type: str = "tree",
+) -> dict[str, Any]:
+    if len(args) != 2:
+        raise ApiError(HTTPStatus.BAD_REQUEST, "prove requires exactly 2 args")
+    if format_type not in {"tree", "json"}:
+        raise ApiError(HTTPStatus.BAD_REQUEST, "format must be 'tree' or 'json'")
+
+    loaded = _load_program_from_source(source)
+    proof = prove(loaded.program, relation, args[0], args[1], recursive=recursive)
+
+    if proof is None:
+        if why_not:
+            neg_proof = prove_negative(loaded.program, relation, args[0], args[1], recursive=recursive)
+            if neg_proof is None:
+                return {"answer": True}
+            if format_type == "json":
+                return _negative_proof_to_json(neg_proof)
+            return {"answer": False, "proof": fmt_negative_proof_tree(neg_proof)}
+        return {"answer": False, "proof": None}
+
+    if format_type == "json":
+        return {"answer": True, "proof": _proof_to_json(proof)}
+    return {"answer": True, "proof": fmt_proof_tree(proof)}
+
+
+def _execute_command(program, command: Command, format_type: str = "tree", why_not: bool = False, out=None) -> None:
+    if out is None:
+        out = StringIO()
+    if len(command.args) != 2:
+        raise ValueError("CLI proof/query currently supports binary relations")
+    if command.kind == "query":
+        value = program.query(command.relation, *command.args, recursive=command.recursive)
+        print(f"{command.relation}({', '.join(command.args)}) = {bool(value)}", file=out)
+        return
+
+    proof = prove(program, command.relation, command.args[0], command.args[1], recursive=command.recursive)
+    if proof is None:
+        if why_not:
+            neg_proof = prove_negative(program, command.relation, command.args[0], command.args[1], recursive=command.recursive)
+            if neg_proof is not None:
+                if format_type == "json":
+                    print(json.dumps(_negative_proof_to_json(neg_proof)), file=out)
+                else:
+                    print(fmt_negative_proof_tree(neg_proof), file=out)
+            else:
+                print(f"{command.relation}({', '.join(command.args)}) = True", file=out)
+        else:
+            if format_type == "json":
+                print(json.dumps({"answer": False, "proof": None}), file=out)
+            else:
+                print(f"{command.relation}({', '.join(command.args)}) = False", file=out)
+    else:
+        if format_type == "json":
+            print(json.dumps({"answer": True, "proof": _proof_to_json(proof)}), file=out)
+        else:
+            print(fmt_proof_tree(proof), file=out)
+
+
+class TensorLogicHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        try:
+            body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            payload = json.loads(body.decode("utf-8") or "{}")
+            if not isinstance(payload, dict):
+                raise ApiError(HTTPStatus.BAD_REQUEST, "request body must be a JSON object")
+
+            if self.path == "/ingest-python":
+                result = {"source": ingest_python(str(payload.get("path", "")))}
+            elif self.path == "/run":
+                result = run_source(str(payload.get("source", "")))
+            elif self.path == "/query":
+                result = query_source(
+                    source=str(payload.get("source", "")),
+                    relation=str(payload.get("relation", "")),
+                    args=[str(v) for v in payload.get("args", [])],
+                    recursive=bool(payload.get("recursive", False)),
+                )
+            elif self.path == "/prove":
+                result = prove_source(
+                    source=str(payload.get("source", "")),
+                    relation=str(payload.get("relation", "")),
+                    args=[str(v) for v in payload.get("args", [])],
+                    recursive=bool(payload.get("recursive", False)),
+                    why_not=bool(payload.get("why_not", False)),
+                    format_type=str(payload.get("format", "tree")),
+                )
+            else:
+                raise ApiError(HTTPStatus.NOT_FOUND, f"unknown endpoint: {self.path}")
+
+            self._write_json(HTTPStatus.OK, result)
+        except json.JSONDecodeError:
+            self._write_json(HTTPStatus.BAD_REQUEST, {"error": "invalid JSON"})
+        except ApiError as exc:
+            self._write_json(exc.status_code, {"error": exc.message})
+        except Exception as exc:  # pragma: no cover - defensive
+            self._write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
+
+    def _write_json(self, status: int, payload: dict[str, Any]) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(int(status))
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+        return
+
+
+def serve(host: str = "127.0.0.1", port: int = 8000) -> None:
+    server = ThreadingHTTPServer((host, port), TensorLogicHandler)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="tensor-logic-api")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default=8000, type=int)
+    args = parser.parse_args(argv)
+    serve(args.host, args.port)
+    return 0

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -1,5 +1,11 @@
 import unittest
 
+import json
+import tempfile
+import threading
+from pathlib import Path
+from urllib.request import Request, urlopen
+
 import torch
 
 from tensor_logic import (
@@ -21,6 +27,8 @@ from tensor_logic import (
     fmt_proof_tree,
 )
 from tensor_logic.semirings import gf2_matmul
+from tensor_logic.http_api import TensorLogicHandler
+from http.server import ThreadingHTTPServer
 
 
 GRAPH = {
@@ -492,6 +500,102 @@ class TensorLogicCoreTest(unittest.TestCase):
         proof = prove(loaded.program, "depends_on", "worker", "api")
         self.assertIsNotNone(proof)
         self.assertEqual(proof.body[0].head[0], "imports")
+
+
+class TensorLogicHttpApiTest(unittest.TestCase):
+    def _post_json(self, base_url: str, path: str, payload: dict):
+        req = Request(
+            url=f"{base_url}{path}",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urlopen(req) as resp:
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+
+    def test_source_api_helpers_on_code_dependencies_example(self):
+        from tensor_logic.http_api import run_source, query_source, prove_source
+
+        source = Path("examples/code_dependencies.tl").read_text(encoding="utf-8")
+
+        run_result = run_source(source)
+        self.assertEqual(len(run_result["outputs"]), 2)
+        self.assertIn("depends_on(worker, models) = True", run_result["outputs"][0])
+
+        query_result = query_source(source, relation="depends_on", args=["worker", "models"], recursive=True)
+        self.assertTrue(query_result["answer"])
+        self.assertEqual(query_result["value"], 1.0)
+
+        prove_result = prove_source(
+            source,
+            relation="depends_on",
+            args=["models", "worker"],
+            recursive=True,
+            why_not=True,
+            format_type="json",
+        )
+        self.assertFalse(prove_result["answer"])
+        self.assertIn("explanation", prove_result)
+
+    def test_ingest_python_builds_tl(self):
+        from tensor_logic.http_api import ingest_python
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            py_path = Path(tmpdir) / "worker.py"
+            py_path.write_text("import api\nfrom db import models\n", encoding="utf-8")
+            tl_source = ingest_python(str(py_path))
+
+        self.assertIn("domain Module", tl_source)
+        self.assertIn("fact imports(worker, api)", tl_source)
+        self.assertIn("fact imports(worker, db)", tl_source)
+        self.assertIn("rule depends_on", tl_source)
+
+    def test_http_endpoints(self):
+        source = Path("examples/code_dependencies.tl").read_text(encoding="utf-8")
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), TensorLogicHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        try:
+            host, port = server.server_address
+            base_url = f"http://{host}:{port}"
+
+            status, run_payload = self._post_json(base_url, "/run", {"source": source})
+            self.assertEqual(status, 200)
+            self.assertEqual(len(run_payload["outputs"]), 2)
+
+            status, query_payload = self._post_json(
+                base_url,
+                "/query",
+                {
+                    "source": source,
+                    "relation": "depends_on",
+                    "args": ["worker", "models"],
+                    "recursive": True,
+                },
+            )
+            self.assertEqual(status, 200)
+            self.assertTrue(query_payload["answer"])
+
+            status, prove_payload = self._post_json(
+                base_url,
+                "/prove",
+                {
+                    "source": source,
+                    "relation": "depends_on",
+                    "args": ["worker", "models"],
+                    "recursive": True,
+                    "format": "json",
+                },
+            )
+            self.assertEqual(status, 200)
+            self.assertTrue(prove_payload["answer"])
+            self.assertIn("proof", prove_payload)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a small HTTP wrapper so CLI functionality (ingest, run, query, prove) can be called programmatically via JSON endpoints. 
- Enable Python->`.tl` ingestion to turn import graphs into tensor-logic source for tool-driven reasoning. 
- Make the server easy to run from the existing CLI with a `serve` subcommand and expose helper functions from the package entrypoint for programmatic use.

### Description
- Add a new module `tensor_logic.http_api` that implements endpoints `POST /ingest-python`, `POST /run`, `POST /query`, and `POST /prove`, and a `serve(host, port)` function to run a `ThreadingHTTPServer`. 
- Implement Python ingestion in `ingest_python(path)` which parses `import`/`from` statements and synthesizes a `.tl` source string representing modules, `imports` facts, and a `depends_on` closure rule. 
- Provide helper functions `run_source`, `query_source`, and `prove_source` that execute `.tl` source via a safely-created temporary file and return structured JSON-friendly Python dictionaries (with proof JSON or tree/text as requested). 
- Wire the HTTP wrapper into the CLI by adding a `serve` subcommand in `tensor_logic.__main__` and export the new helpers from `tensor_logic.__init__` for convenience. 
- Ensure safe temporary-file handling using `tempfile.mkstemp(...)` with guaranteed cleanup in a `finally` block, and include structured `ApiError`/HTTPStatus handling and JSON responses.

### Testing
- Syntax/compile checks were run with `python -m py_compile tensor_logic/http_api.py tensor_logic/__main__.py tensor_logic/__init__.py tests/test_tensor_logic_core.py` and succeeded. 
- Added unit tests in `tests/test_tensor_logic_core.py` covering `run_source`, `query_source`, `prove_source`, `ingest_python`, and in-process HTTP endpoint tests using `ThreadingHTTPServer` against `examples/code_dependencies.tl`. 
- Executing `python -m unittest tests/test_tensor_logic_core.py` in this environment failed due to a missing runtime dependency (`ModuleNotFoundError: No module named 'torch'`), so the new tests were not run end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdc207584832c9e1baa236d89f297)