### PR TITLE
Share proof result presentation

### DIFF
--- a/tensor_logic/__init__.py
+++ b/tensor_logic/__init__.py
@@ -6,6 +6,7 @@ from .program import Program, FactSource
 from .file_format import load_tl
 from .http_api import ingest_python_source, prove_source, query_source, run_source, serve
 from .ingest import PythonImportGraph, ingest_python, render_python_imports_tl
+from .proof_result import format_proof_result
 from .proofs import fmt_proof_tree, fmt_negative_proof_tree, prove, prove_negative, prove_with_do, Proof, NegativeProof
 from .proof_tree_viewer import ProofTreeNode, build_proof_tree_view, render_proof_tree
 from .provenance import evaluate_with_provenance, fmt_proof, proof_score
@@ -39,6 +40,7 @@ __all__ = [
     "facts",
     "fmt_proof_tree",
     "fmt_negative_proof_tree",
+    "format_proof_result",
     "load_tl",
     "ingest_python",
     "ingest_python_source",

--- a/tensor_logic/__main__.py
+++ b/tensor_logic/__main__.py
@@ -7,7 +7,8 @@ import sys
 from .file_format import Command, load_tl
 from .http_api import serve
 from .ingest import ingest_python, render_python_imports_tl
-from .proofs import fmt_proof_tree, fmt_negative_proof_tree, prove, prove_negative, Proof, NegativeProof
+from .proof_result import format_proof_result
+from .proofs import prove, prove_negative
 from .repo_graph_view import dependency_report, repo_graph_repl
 
 
@@ -92,29 +93,6 @@ def main(argv: list[str] | None = None) -> int:
     return 1
 
 
-def _proof_to_json(proof: Proof) -> dict:
-    rel, src, dst = proof.head
-    result = {
-        "head": [rel, src, dst],
-        "confidence": proof.confidence,
-        "body": [_proof_to_json(child) for child in proof.body],
-    }
-    if proof.source is not None:
-        result["source"] = {"file": proof.source.file, "lineno": proof.source.lineno}
-    return result
-
-def _negative_proof_to_json(neg_proof: NegativeProof) -> dict:
-    rel, src, dst = neg_proof.head
-    return {
-        "answer": False,
-        "explanation": {
-            "head": [rel, src, dst],
-            "reason": neg_proof.reason,
-            "body": [_negative_proof_to_json(child) for child in neg_proof.body] if neg_proof.body else []
-        }
-    }
-
-
 def _execute_command(program, command: Command, format_type: str = "tree", why_not: bool = False, out=None) -> None:
     if out is None:
         out = sys.stdout
@@ -129,10 +107,8 @@ def _execute_command(program, command: Command, format_type: str = "tree", why_n
         if why_not:
             neg_proof = prove_negative(program, command.relation, command.args[0], command.args[1], recursive=command.recursive)
             if neg_proof is not None:
-                if format_type == "json":
-                    print(json.dumps(_negative_proof_to_json(neg_proof)), file=out)
-                else:
-                    print(fmt_negative_proof_tree(neg_proof), file=out)
+                result = format_proof_result(negative_proof=neg_proof, format_type=format_type)
+                print(json.dumps(result) if format_type == "json" else result["proof"], file=out)
             else:
                 print(f"{command.relation}({', '.join(command.args)}) = True", file=out)
         else:
@@ -142,9 +118,9 @@ def _execute_command(program, command: Command, format_type: str = "tree", why_n
                 print(f"{command.relation}({', '.join(command.args)}) = False", file=out)
     else:
         if format_type == "json":
-            print(json.dumps({"answer": True, "proof": _proof_to_json(proof)}), file=out)
+            print(json.dumps(format_proof_result(proof=proof, format_type=format_type)), file=out)
         else:
-            print(fmt_proof_tree(proof), file=out)
+            print(format_proof_result(proof=proof, format_type=format_type)["proof"], file=out)
 
 
 def _repl_eval(program, line: str, out=None) -> None:

--- a/tensor_logic/http_api.py
+++ b/tensor_logic/http_api.py
@@ -11,7 +11,8 @@ from typing import Any
 
 from .file_format import Command, load_tl
 from .ingest import ingest_python, render_python_imports_tl
-from .proofs import NegativeProof, Proof, fmt_negative_proof_tree, fmt_proof_tree, prove, prove_negative
+from .proof_result import format_proof_result
+from .proofs import prove, prove_negative
 
 
 @dataclass(frozen=True)
@@ -62,12 +63,8 @@ def prove_source(
         neg_proof = prove_negative(loaded.program, relation, args[0], args[1], recursive=recursive)
         if neg_proof is None:
             return {"answer": True}
-        if format_type == "json":
-            return _negative_proof_to_json(neg_proof)
-        return {"answer": False, "proof": fmt_negative_proof_tree(neg_proof)}
-    if format_type == "json":
-        return {"answer": True, "proof": _proof_to_json(proof)}
-    return {"answer": True, "proof": fmt_proof_tree(proof)}
+        return format_proof_result(negative_proof=neg_proof, format_type=format_type)
+    return format_proof_result(proof=proof, format_type=format_type)
 
 
 class TensorLogicHandler(BaseHTTPRequestHandler):
@@ -158,33 +155,6 @@ def _execute_command(program, command: Command, format_type: str = "tree", why_n
             print(f"{command.relation}({', '.join(command.args)}) = False", file=out)
         return
     if format_type == "json":
-        print(json.dumps({"answer": True, "proof": _proof_to_json(proof)}), file=out)
+        print(json.dumps(format_proof_result(proof=proof, format_type=format_type)), file=out)
     else:
-        print(fmt_proof_tree(proof), file=out)
-
-
-def _proof_to_json(proof: Proof) -> dict[str, Any]:
-    rel, src, dst = proof.head
-    source = None
-    if proof.source is not None:
-        source = {"file": proof.source.file, "lineno": proof.source.lineno}
-    result = {
-        "head": [rel, src, dst],
-        "confidence": proof.confidence,
-        "body": [_proof_to_json(child) for child in proof.body],
-    }
-    if source is not None:
-        result["source"] = source
-    return result
-
-
-def _negative_proof_to_json(neg_proof: NegativeProof) -> dict[str, Any]:
-    rel, src, dst = neg_proof.head
-    return {
-        "answer": False,
-        "explanation": {
-            "head": [rel, src, dst],
-            "reason": neg_proof.reason,
-            "body": [_negative_proof_to_json(child) for child in neg_proof.body] if neg_proof.body else [],
-        },
-    }
+        print(format_proof_result(proof=proof, format_type=format_type)["proof"], file=out)

--- a/tensor_logic/proof_result.py
+++ b/tensor_logic/proof_result.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .proofs import NegativeProof, Proof, fmt_negative_proof_tree, fmt_proof_tree
+
+
+def format_proof_result(
+    *,
+    proof: Proof | None = None,
+    negative_proof: NegativeProof | None = None,
+    format_type: str = "tree",
+) -> dict[str, Any]:
+    if format_type not in {"tree", "json"}:
+        raise ValueError("format_type must be 'tree' or 'json'")
+    if negative_proof is not None:
+        if format_type == "tree":
+            return {"answer": False, "proof": fmt_negative_proof_tree(negative_proof)}
+        return _negative_proof_to_json(negative_proof)
+    if proof is None:
+        return {"answer": False, "proof": None}
+    if format_type == "tree":
+        return {"answer": True, "proof": fmt_proof_tree(proof)}
+    return {"answer": True, "proof": _proof_to_json(proof)}
+
+
+def _proof_to_json(proof: Proof) -> dict[str, Any]:
+    rel, src, dst = proof.head
+    result = {
+        "head": [rel, src, dst],
+        "confidence": proof.confidence,
+        "body": [_proof_to_json(child) for child in proof.body],
+    }
+    if proof.source is not None:
+        result["source"] = {"file": proof.source.file, "lineno": proof.source.lineno}
+    return result
+
+
+def _negative_proof_to_json(neg_proof: NegativeProof) -> dict[str, Any]:
+    return {"answer": False, "explanation": _negative_proof_explanation_to_json(neg_proof)}
+
+
+def _negative_proof_explanation_to_json(neg_proof: NegativeProof) -> dict[str, Any]:
+    rel, src, dst = neg_proof.head
+    return {
+        "head": [rel, src, dst],
+        "reason": neg_proof.reason,
+        "body": [_negative_proof_explanation_to_json(child) for child in neg_proof.body],
+    }

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -428,8 +428,8 @@ class TensorLogicCoreTest(unittest.TestCase):
                 load_tl(a_path)
 
     def test_proof_json_roundtrip(self):
+        from tensor_logic import format_proof_result
         from tensor_logic.proofs import Proof
-        from tensor_logic.__main__ import _proof_to_json
         original = Proof(
             head=("path", "a", "c"),
             body=(
@@ -438,7 +438,7 @@ class TensorLogicCoreTest(unittest.TestCase):
             ),
             confidence=0.72,
         )
-        d = _proof_to_json(original)
+        d = format_proof_result(proof=original, format_type="json")["proof"]
         restored = Proof.from_json(d)
         self.assertEqual(restored.head, original.head)
         self.assertAlmostEqual(restored.confidence, original.confidence, places=6)
@@ -447,16 +447,39 @@ class TensorLogicCoreTest(unittest.TestCase):
         self.assertAlmostEqual(restored.body[0].confidence, 0.9, places=6)
 
     def test_negative_proof_json_roundtrip(self):
+        from tensor_logic import format_proof_result
         from tensor_logic.proofs import NegativeProof
-        from tensor_logic.__main__ import _negative_proof_to_json
         original = NegativeProof(
             head=("edge", "a", "z"),
             reason="no_rules",
         )
-        d = _negative_proof_to_json(original)
+        d = format_proof_result(negative_proof=original, format_type="json")
         restored = NegativeProof.from_json(d)
         self.assertEqual(restored.head, original.head)
         self.assertEqual(restored.reason, original.reason)
+
+
+    def test_negative_proof_json_uses_nested_explanation_nodes(self):
+        from tensor_logic import format_proof_result
+        from tensor_logic.proofs import NegativeProof
+
+        original = NegativeProof(
+            head=("path", "a", "c"),
+            reason="rule_body_failed",
+            body=(
+                NegativeProof(
+                    head=("edge", "b", "c"),
+                    reason="no_fact",
+                ),
+            ),
+        )
+
+        result = format_proof_result(negative_proof=original, format_type="json")
+
+        self.assertFalse(result["answer"])
+        self.assertEqual(result["explanation"]["body"][0]["head"], ["edge", "b", "c"])
+        self.assertEqual(result["explanation"]["body"][0]["reason"], "no_fact")
+        self.assertNotIn("explanation", result["explanation"]["body"][0])
 
 
     def test_disjunctive_rule_splits_into_two_rules(self):
@@ -588,6 +611,86 @@ class TensorLogicCoreTest(unittest.TestCase):
                 f.write("")
             tl_source = ingest_python_source(tmpdir)
         self.assertIn("fact imports(pkg_api, pkg_db)", tl_source)
+
+    def test_cli_and_http_share_positive_proof_json_semantics(self):
+        import json
+        import subprocess
+        import sys
+        from tensor_logic.http_api import prove_source
+
+        def normalize_source_files(node):
+            if isinstance(node, dict):
+                return {
+                    key: (
+                        {"lineno": value["lineno"]}
+                        if key == "source" and isinstance(value, dict) and "lineno" in value
+                        else normalize_source_files(value)
+                    )
+                    for key, value in node.items()
+                }
+            if isinstance(node, list):
+                return [normalize_source_files(item) for item in node]
+            return node
+
+        source = open("examples/code_dependencies.tl", encoding="utf-8").read()
+        http_result = prove_source(source, "depends_on", ["worker", "models"], recursive=True, format_type="json")
+        cli_result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tensor_logic",
+                "prove",
+                "examples/code_dependencies.tl",
+                "depends_on",
+                "worker",
+                "models",
+                "--recursive",
+                "--format",
+                "json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(normalize_source_files(json.loads(cli_result.stdout)), normalize_source_files(http_result))
+
+    def test_cli_and_http_share_negative_proof_json_semantics(self):
+        import json
+        import subprocess
+        import sys
+        from tensor_logic.http_api import prove_source
+
+        source = open("examples/code_dependencies.tl", encoding="utf-8").read()
+        http_result = prove_source(
+            source,
+            "depends_on",
+            ["models", "worker"],
+            recursive=True,
+            why_not=True,
+            format_type="json",
+        )
+        cli_result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tensor_logic",
+                "prove",
+                "examples/code_dependencies.tl",
+                "depends_on",
+                "models",
+                "worker",
+                "--recursive",
+                "--why-not",
+                "--format",
+                "json",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(json.loads(cli_result.stdout), http_result)
 
     def test_web_workbench_sample_is_valid_tl(self):
         import re


### PR DESCRIPTION
## Summary
- Add `tensor_logic.proof_result.format_proof_result` as the shared positive/negative proof presentation path.
- Route CLI and HTTP proof JSON/tree responses through the shared formatter.
- Normalize nested NegativeProof JSON bodies so only the top-level result carries `answer` / `explanation`.

## Validation
- `PYTHONPATH=. pytest tests/test_tensor_logic_core.py -q` -> 43 passed
- `PYTHONPATH=. pytest tests/ -q` -> 115 passed, 2 warnings

Closes #17