### PR TITLE
Issue #19: Share TL source execution path

### DIFF
--- a/tensor_logic/__main__.py
+++ b/tensor_logic/__main__.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 
 from .file_format import Command, load_tl
 from .http_api import serve
 from .ingest import ingest_python, render_python_imports_tl
-from .proof_result import format_proof_result
-from .proofs import prove, prove_negative
+from .execution import execute_command, write_command_result
 from .repo_graph_view import dependency_report, repo_graph_repl
 
 
@@ -96,31 +94,7 @@ def main(argv: list[str] | None = None) -> int:
 def _execute_command(program, command: Command, format_type: str = "tree", why_not: bool = False, out=None) -> None:
     if out is None:
         out = sys.stdout
-    if len(command.args) != 2:
-        raise ValueError("CLI proof/query currently supports binary relations")
-    if command.kind == "query":
-        value = program.query(command.relation, *command.args, recursive=command.recursive)
-        print(f"{command.relation}({', '.join(command.args)}) = {bool(value)}", file=out)
-        return
-    proof = prove(program, command.relation, command.args[0], command.args[1], recursive=command.recursive)
-    if proof is None:
-        if why_not:
-            neg_proof = prove_negative(program, command.relation, command.args[0], command.args[1], recursive=command.recursive)
-            if neg_proof is not None:
-                result = format_proof_result(negative_proof=neg_proof, format_type=format_type)
-                print(json.dumps(result) if format_type == "json" else result["proof"], file=out)
-            else:
-                print(f"{command.relation}({', '.join(command.args)}) = True", file=out)
-        else:
-            if format_type == "json":
-                print(json.dumps({"answer": False, "proof": None}), file=out)
-            else:
-                print(f"{command.relation}({', '.join(command.args)}) = False", file=out)
-    else:
-        if format_type == "json":
-            print(json.dumps(format_proof_result(proof=proof, format_type=format_type)), file=out)
-        else:
-            print(format_proof_result(proof=proof, format_type=format_type)["proof"], file=out)
+    write_command_result(execute_command(program, command, format_type=format_type, why_not=why_not), out)
 
 
 def _repl_eval(program, line: str, out=None) -> None:

--- a/tensor_logic/execution.py
+++ b/tensor_logic/execution.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from io import StringIO
+from typing import Any
+
+from .file_format import Command, LoadedProgram, load_tl
+from .program import Program
+from .proof_result import format_proof_result
+from .proofs import prove, prove_negative
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    payload: dict[str, Any]
+    text: str
+
+
+def load_tl_source(source: str, prefix: str = "tensor_logic_source_") -> LoadedProgram:
+    fd, path = tempfile.mkstemp(suffix=".tl", prefix=prefix)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(source)
+        return load_tl(path)
+    finally:
+        os.unlink(path)
+
+
+def execute_run(loaded: LoadedProgram, format_type: str = "tree") -> dict[str, Any]:
+    outputs = []
+    for command in loaded.commands:
+        outputs.append(execute_command(loaded.program, command, format_type=format_type).text)
+    return {"outputs": outputs}
+
+
+def execute_query(program: Program, relation: str, args: list[str] | tuple[str, ...], recursive: bool = False) -> dict[str, Any]:
+    _require_binary_args(args, "query requires exactly 2 args")
+    value = program.query(relation, *args, recursive=recursive)
+    return {"answer": bool(value), "value": float(value), "relation": relation, "args": list(args), "recursive": recursive}
+
+
+def execute_prove(
+    program: Program,
+    relation: str,
+    args: list[str] | tuple[str, ...],
+    recursive: bool = False,
+    why_not: bool = False,
+    format_type: str = "tree",
+) -> dict[str, Any]:
+    _require_binary_args(args, "prove requires exactly 2 args")
+    proof = prove(program, relation, args[0], args[1], recursive=recursive)
+    if proof is not None:
+        return format_proof_result(proof=proof, format_type=format_type)
+    if not why_not:
+        return {"answer": False, "proof": None}
+    neg_proof = prove_negative(program, relation, args[0], args[1], recursive=recursive)
+    if neg_proof is None:
+        return {"answer": True}
+    return format_proof_result(negative_proof=neg_proof, format_type=format_type)
+
+
+def execute_command(
+    program: Program,
+    command: Command,
+    format_type: str = "tree",
+    why_not: bool = False,
+) -> CommandResult:
+    _require_binary_args(command.args, "CLI proof/query currently supports binary relations")
+    if command.kind == "query":
+        payload = execute_query(program, command.relation, command.args, recursive=command.recursive)
+        text = f"{command.relation}({', '.join(command.args)}) = {payload['answer']}"
+        return CommandResult(payload=payload, text=text)
+    payload = execute_prove(
+        program,
+        command.relation,
+        command.args,
+        recursive=command.recursive,
+        why_not=why_not,
+        format_type=format_type,
+    )
+    return CommandResult(payload=payload, text=_format_prove_text(payload, command, format_type))
+
+
+def write_command_result(result: CommandResult, out) -> None:
+    print(result.text, file=out)
+
+
+def render_command(
+    program: Program,
+    command: Command,
+    format_type: str = "tree",
+    why_not: bool = False,
+) -> str:
+    out = StringIO()
+    write_command_result(execute_command(program, command, format_type=format_type, why_not=why_not), out)
+    return out.getvalue().strip()
+
+
+def _format_prove_text(payload: dict[str, Any], command: Command, format_type: str) -> str:
+    if format_type == "json":
+        return json.dumps(payload)
+    proof_text = payload.get("proof")
+    if proof_text is not None:
+        return str(proof_text)
+    return f"{command.relation}({', '.join(command.args)}) = {payload['answer']}"
+
+
+def _require_binary_args(args: list[str] | tuple[str, ...], message: str) -> None:
+    if len(args) != 2:
+        raise ValueError(message)

--- a/tensor_logic/http_api.py
+++ b/tensor_logic/http_api.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from dataclasses import dataclass
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from io import StringIO
 from typing import Any
 
-from .file_format import Command, load_tl
+from .execution import execute_command, execute_prove, execute_query, execute_run, load_tl_source
+from .file_format import Command
 from .ingest import ingest_python, render_python_imports_tl
-from .proof_result import format_proof_result
-from .proofs import prove, prove_negative
 
 
 @dataclass(frozen=True)
@@ -26,21 +22,16 @@ def ingest_python_source(path: str) -> str:
 
 
 def run_source(source: str) -> dict[str, Any]:
-    loaded = _load_program_from_source(source)
-    outputs = []
-    for command in loaded.commands:
-        out = StringIO()
-        _execute_command(loaded.program, command, out=out)
-        outputs.append(out.getvalue().strip())
-    return {"outputs": outputs}
+    return execute_run(_load_program_from_source(source))
 
 
 def query_source(source: str, relation: str, args: list[str], recursive: bool = False) -> dict[str, Any]:
-    if len(args) != 2:
-        raise ApiError(HTTPStatus.BAD_REQUEST, "query requires exactly 2 args")
-    loaded = _load_program_from_source(source)
-    value = loaded.program.query(relation, *args, recursive=recursive)
-    return {"answer": bool(value), "value": float(value), "relation": relation, "args": args, "recursive": recursive}
+    try:
+        return execute_query(_load_program_from_source(source).program, relation, args, recursive=recursive)
+    except ValueError as exc:
+        if str(exc) == "query requires exactly 2 args":
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc)) from exc
+        raise
 
 
 def prove_source(
@@ -55,16 +46,19 @@ def prove_source(
         raise ApiError(HTTPStatus.BAD_REQUEST, "prove requires exactly 2 args")
     if format_type not in {"tree", "json"}:
         raise ApiError(HTTPStatus.BAD_REQUEST, "format must be 'tree' or 'json'")
-    loaded = _load_program_from_source(source)
-    proof = prove(loaded.program, relation, args[0], args[1], recursive=recursive)
-    if proof is None:
-        if not why_not:
-            return {"answer": False, "proof": None}
-        neg_proof = prove_negative(loaded.program, relation, args[0], args[1], recursive=recursive)
-        if neg_proof is None:
-            return {"answer": True}
-        return format_proof_result(negative_proof=neg_proof, format_type=format_type)
-    return format_proof_result(proof=proof, format_type=format_type)
+    try:
+        return execute_prove(
+            _load_program_from_source(source).program,
+            relation,
+            args,
+            recursive=recursive,
+            why_not=why_not,
+            format_type=format_type,
+        )
+    except ValueError as exc:
+        if str(exc) == "prove requires exactly 2 args":
+            raise ApiError(HTTPStatus.BAD_REQUEST, str(exc)) from exc
+        raise
 
 
 class TensorLogicHandler(BaseHTTPRequestHandler):
@@ -125,36 +119,10 @@ def serve(host: str = "127.0.0.1", port: int = 8000) -> None:
 
 
 def _load_program_from_source(source: str):
-    fd, path = tempfile.mkstemp(suffix=".tl", prefix="tensor_logic_api_")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(source)
-        return load_tl(path)
-    finally:
-        os.unlink(path)
+    return load_tl_source(source, prefix="tensor_logic_api_")
 
 
 def _execute_command(program, command: Command, format_type: str = "tree", why_not: bool = False, out=None) -> None:
     if out is None:
-        out = StringIO()
-    if len(command.args) != 2:
-        raise ValueError("CLI proof/query currently supports binary relations")
-    if command.kind == "query":
-        value = program.query(command.relation, *command.args, recursive=command.recursive)
-        print(f"{command.relation}({', '.join(command.args)}) = {bool(value)}", file=out)
         return
-    proof = prove(program, command.relation, command.args[0], command.args[1], recursive=command.recursive)
-    if proof is None:
-        if why_not:
-            neg_proof = prove_negative(program, command.relation, command.args[0], command.args[1], recursive=command.recursive)
-            if neg_proof is not None:
-                print(fmt_negative_proof_tree(neg_proof), file=out)
-            else:
-                print(f"{command.relation}({', '.join(command.args)}) = True", file=out)
-        else:
-            print(f"{command.relation}({', '.join(command.args)}) = False", file=out)
-        return
-    if format_type == "json":
-        print(json.dumps(format_proof_result(proof=proof, format_type=format_type)), file=out)
-    else:
-        print(format_proof_result(proof=proof, format_type=format_type)["proof"], file=out)
+    print(execute_command(program, command, format_type=format_type, why_not=why_not).text, file=out)

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -692,6 +692,148 @@ class TensorLogicCoreTest(unittest.TestCase):
 
         self.assertEqual(json.loads(cli_result.stdout), http_result)
 
+    def test_cli_run_query_and_prove_execute_tl_commands(self):
+        import json
+        import os
+        import subprocess
+        import sys
+        import tempfile
+
+        source = "\n".join(
+            [
+                "domain Node { a, b, c }",
+                "relation edge(Node, Node)",
+                "relation path(Node, Node)",
+                "fact edge(a, b)",
+                "fact edge(b, c)",
+                "rule path(x,y) := edge(x,y).step()",
+                "rule path(x,y) := edge(x,z) * path(z,y).step()",
+                "query path(a, c) recursive",
+                "prove path(a, c) recursive",
+            ]
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".tl", delete=False, encoding="utf-8") as f:
+            f.write(source)
+            path = f.name
+        try:
+            run_result = subprocess.run(
+                [sys.executable, "-m", "tensor_logic", "run", path],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertIn("path(a, c) = True", run_result.stdout)
+            self.assertIn("edge(a, b)", run_result.stdout)
+
+            query_result = subprocess.run(
+                [sys.executable, "-m", "tensor_logic", "query", path, "path", "a", "c", "--recursive"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(query_result.stdout.strip(), "path(a, c) = True")
+
+            prove_result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "tensor_logic",
+                    "prove",
+                    path,
+                    "path",
+                    "a",
+                    "c",
+                    "--recursive",
+                    "--format",
+                    "json",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertTrue(json.loads(prove_result.stdout)["answer"])
+        finally:
+            os.unlink(path)
+
+    def test_cli_invalid_arity_and_parse_errors_are_external_failures(self):
+        import os
+        import subprocess
+        import sys
+        import tempfile
+
+        source = "\n".join(
+            [
+                "domain Node { a, b }",
+                "relation edge(Node, Node)",
+                "fact edge(a, b)",
+            ]
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".tl", delete=False, encoding="utf-8") as f:
+            f.write(source)
+            valid_path = f.name
+        with tempfile.NamedTemporaryFile("w", suffix=".tl", delete=False, encoding="utf-8") as f:
+            f.write("not valid tl\n")
+            invalid_path = f.name
+        try:
+            arity = subprocess.run(
+                [sys.executable, "-m", "tensor_logic", "query", valid_path, "edge", "a"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(arity.returncode, 0)
+            self.assertIn("query currently supports binary relations", arity.stderr)
+
+            parse = subprocess.run(
+                [sys.executable, "-m", "tensor_logic", "run", invalid_path],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(parse.returncode, 0)
+            self.assertIn("unrecognized statement", parse.stderr)
+        finally:
+            os.unlink(valid_path)
+            os.unlink(invalid_path)
+
+    def test_http_source_execution_preserves_arity_and_load_errors(self):
+        from http import HTTPStatus
+        from tensor_logic.http_api import ApiError, query_source, run_source
+
+        source = "\n".join(
+            [
+                "domain Node { a, b }",
+                "relation edge(Node, Node)",
+                "fact edge(a, b)",
+            ]
+        )
+        with self.assertRaises(ApiError) as caught:
+            query_source(source, "edge", ["a"])
+        self.assertEqual(caught.exception.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(caught.exception.message, "query requires exactly 2 args")
+
+        with self.assertRaises(ValueError) as parse:
+            run_source("not valid tl\n")
+        self.assertIn("unrecognized statement", str(parse.exception))
+
+    def test_repl_uses_recursive_query_and_prove_semantics(self):
+        from tensor_logic.__main__ import _repl_eval
+        from tensor_logic.program import Program
+        import io
+
+        program = Program()
+        out = io.StringIO()
+        _repl_eval(program, "domain Node { a, b, c }", out)
+        _repl_eval(program, "relation edge(Node, Node)", out)
+        _repl_eval(program, "relation path(Node, Node)", out)
+        _repl_eval(program, "fact edge(a, b)", out)
+        _repl_eval(program, "fact edge(b, c)", out)
+        _repl_eval(program, "rule path(x,y) := edge(x,y).step()", out)
+        _repl_eval(program, "rule path(x,y) := edge(x,z) * path(z,y).step()", out)
+        _repl_eval(program, "query path(a, c) recursive", out)
+        _repl_eval(program, "prove path(a, c) recursive", out)
+        result = out.getvalue()
+        self.assertIn("path(a, c) = True", result)
+        self.assertIn("edge(a, b)", result)
+
     def test_web_workbench_sample_is_valid_tl(self):
         import re
         from tensor_logic.file_format import load_tl


### PR DESCRIPTION
## Summary
- Adds `tensor_logic.execution` as the shared source/load/command execution layer.
- Routes CLI, REPL, and HTTP helpers through the shared execution path while preserving response semantics.
- Adds external behavior coverage for CLI run/query/prove, recursive REPL semantics, invalid arity, and parse/load errors.

## Validation
- `python3 -m pytest tests/test_tensor_logic_core.py -q` -> 47 passed
- Worker also reported `python3 -m pytest tests/ -v` -> 122 passed and `git diff --check` passed

Closes #19