### PR TITLE
docs: Add Symphony run protocol (SYM-25)

### DIFF
--- a/docs/SYMPHONY_RUN_PROTOCOL.md
+++ b/docs/SYMPHONY_RUN_PROTOCOL.md
@@ -1,0 +1,21 @@
+# Symphony Run Protocol
+
+This document defines the repo-local run protocol for Symphony/Jules-style workers executing Tensor Linear issues. Future runnable issues should link to this protocol.
+
+## Handoff Contract
+
+When executing an issue in this repository, follow these rules strictly:
+
+1. **Task Contract**: Treat the Linear issue as the complete and final task contract.
+2. **Branch Naming**: Create or use a git branch named exactly after the issue key (e.g., `SYM-25`).
+3. **Execution Notes**: Write local execution notes or use a workpad if the repository has an established place for that (e.g., in `notes/` directory or a designated task file).
+4. **Scope Constraint**: Keep one issue to one branch and one Pull Request. Do not bundle multiple issues.
+5. **Validation**: Validate your changes with the smallest, most direct command that proves the acceptance criteria have been met.
+6. **Documentation of Results**: Record the PR URL, commit SHA, validation command used, and any blockers encountered during execution.
+7. **Status Management**: Do not mark the Linear issue as Done until the PR is fully merged or explicitly accepted by a maintainer.
+
+## Notes for Agents
+
+- Keep your actions practical and executable.
+- Avoid broad implementation changes unless explicitly requested by the issue.
+- If you are making only documentation changes, state why no code test was needed in your validation step.


### PR DESCRIPTION
Adds `docs/SYMPHONY_RUN_PROTOCOL.md` to define the execution handoff contract for Symphony/Jules workers, as requested in SYM-25.

The protocol covers:
- Treating the Linear issue as the source of truth.
- Creating a branch strictly matching the issue key.
- Keeping work limited to 1 issue / 1 PR.
- Validation guidelines (smallest command to prove success).
- Required reporting.
- A hold on marking an issue "Done" until merged.

No code tests are needed or modified, as this strictly relates to repository procedures and documentation.

---
*PR created automatically by Jules for task [3272357715591138839](https://jules.google.com/task/3272357715591138839) started by @jwalin-shah*