### PR TITLE
Issue #20: Adapt tl_rule tags to shared Rule language

### DIFF
--- a/tensor_logic/program.py
+++ b/tensor_logic/program.py
@@ -13,6 +13,19 @@ TOKEN_RE = re.compile(r"\s*(?:(?P<ID>[A-Za-z_]\w*)|(?P<ASSIGN>:=)|(?P<LP>\()|(?P
 class Atom:
     relation: str
     args: tuple[str, ...]
+    negated: bool = False
+
+    @property
+    def rel(self) -> str:
+        return self.relation
+
+    @property
+    def left(self) -> str:
+        return self.args[0]
+
+    @property
+    def right(self) -> str:
+        return self.args[1]
 
 
 @dataclass(frozen=True)

--- a/tensor_logic/provenance.py
+++ b/tensor_logic/provenance.py
@@ -31,10 +31,10 @@ def evaluate_with_provenance(
     entities = all_entities(graph)
 
     for rule in rules:
-        if rule.head.rel != rel:
+        if rule.head.relation != rel or len(rule.head.args) != 2:
             continue
-        bindings = {rule.head.left: subj, rule.head.right: obj}
-        body_vars = {var for atom in rule.body for var in (atom.left, atom.right)}
+        bindings = {rule.head.args[0]: subj, rule.head.args[1]: obj}
+        body_vars = {var for atom in rule.body for var in atom.args}
         free_vars = [var for var in sorted(body_vars) if var not in bindings]
         for assignment in _enumerate_assignments(free_vars, entities):
             full_bindings = {**bindings, **assignment}
@@ -68,21 +68,24 @@ def _enumerate_assignments(vars_: list[str], entities: list[str]):
 def _try_body(graph, rules, rule: Rule, bindings, max_depth, depth):
     per_atom = []
     for atom in rule.body:
+        if len(atom.args) != 2:
+            return []
+        left, right = atom.args
         if atom.negated:
-            if atom.left not in bindings or atom.right not in bindings:
+            if left not in bindings or right not in bindings:
                 return []
-            has_fact = bool(primitive_proofs(graph, atom.rel, bindings[atom.left], bindings[atom.right]))
+            has_fact = bool(primitive_proofs(graph, atom.relation, bindings[left], bindings[right]))
             if has_fact:
                 return []
             continue
-        if atom.left not in bindings or atom.right not in bindings:
+        if left not in bindings or right not in bindings:
             return []
         atom_proofs = evaluate_with_provenance(
             graph,
             rules,
-            atom.rel,
-            bindings[atom.left],
-            bindings[atom.right],
+            atom.relation,
+            bindings[left],
+            bindings[right],
             max_depth=max_depth,
             _depth=depth + 1,
         )
@@ -119,10 +122,10 @@ def fmt_proof(proof, indent: int = 0) -> str:
     head_rel, subj, obj = proof["head"]
     rule = proof["rule"]
     body = ", ".join(
-        f"{'!' if atom.negated else ''}{atom.rel}({atom.left},{atom.right})"
+        f"{'!' if atom.negated else ''}{atom.relation}({','.join(atom.args)})"
         for atom in rule.body
     )
-    lines = [f"{pad}- {head_rel}({subj}, {obj})  via  {rule.head.rel}({rule.head.left}, {rule.head.right}) :- {body}"]
+    lines = [f"{pad}- {head_rel}({subj}, {obj})  via  {rule.head.relation}({', '.join(rule.head.args)}) :- {body}"]
     for child in proof["body"]:
         lines.append(fmt_proof(child, indent + 1))
     return "\n".join(lines)

--- a/tensor_logic/rules.py
+++ b/tensor_logic/rules.py
@@ -1,26 +1,13 @@
-from dataclasses import dataclass
 import re
 
 import torch
+
+from .program import Atom, Rule
 
 RULE_RE = re.compile(
     r'<tl_rule\s+head="(?P<head>[^"]+)"\s+body="(?P<body>[^"]+)"\s*></tl_rule>'
 )
 ATOM_RE = re.compile(r'(?P<neg>!?)\s*(?P<rel>\w+)\s*\(\s*(?P<a>\w+)\s*,\s*(?P<b>\w+)\s*\)')
-
-
-@dataclass(frozen=True)
-class Atom:
-    rel: str
-    left: str
-    right: str
-    negated: bool = False
-
-
-@dataclass(frozen=True)
-class Rule:
-    head: Atom
-    body: tuple[Atom, ...]
 
 
 def parse_rule(text: str) -> Rule | None:
@@ -29,25 +16,51 @@ def parse_rule(text: str) -> Rule | None:
     if not match:
         return None
     head_match = ATOM_RE.fullmatch(match.group("head").strip())
-    body_matches = tuple(ATOM_RE.finditer(match.group("body")))
-    if not head_match or not body_matches:
+    body_atoms = _parse_body_atoms(match.group("body"))
+    if not head_match or head_match.group("neg") or not body_atoms:
         return None
     head = Atom(
         head_match.group("rel"),
-        head_match.group("a"),
-        head_match.group("b"),
-        False,
+        (head_match.group("a"), head_match.group("b")),
     )
-    body = tuple(
-        Atom(
-            atom.group("rel"),
-            atom.group("a"),
-            atom.group("b"),
-            atom.group("neg") == "!",
+    return Rule(head, tuple(body_atoms))
+
+
+def _parse_body_atoms(body: str) -> list[Atom] | None:
+    atoms: list[Atom] = []
+    pos = 0
+    expecting_atom = True
+    while pos < len(body):
+        if body[pos].isspace():
+            pos += 1
+            continue
+        if not expecting_atom:
+            if body[pos] != ",":
+                return None
+            pos += 1
+            expecting_atom = True
+            continue
+        atom = ATOM_RE.match(body, pos)
+        if atom is None:
+            return None
+        atoms.append(
+            Atom(
+                atom.group("rel"),
+                (atom.group("a"), atom.group("b")),
+                atom.group("neg") == "!",
+            )
         )
-        for atom in body_matches
-    )
-    return Rule(head, body)
+        pos = atom.end()
+        expecting_atom = False
+    if expecting_atom:
+        return None
+    return atoms
+
+
+def _binary_args(atom: Atom) -> tuple[str, str] | None:
+    if len(atom.args) != 2:
+        return None
+    return atom.args[0], atom.args[1]
 
 
 def all_entities(graph: dict[str, list[list[str]] | list[tuple[str, str]]]) -> list[str]:
@@ -93,37 +106,53 @@ def evaluate_rule(graph: dict, rule: Rule, name_to_idx: dict[str, int] | None = 
         operands = []
         operand_strs = []
         for atom in pos_atoms:
-            if atom.rel not in rel_tensors:
-                return None, f"unknown body relation: {atom.rel}"
-            for var in (atom.left, atom.right):
+            args = _binary_args(atom)
+            if args is None:
+                return None, f"body relation {atom.relation} expects 2 args, got {len(atom.args)}"
+            left, right = args
+            if atom.relation not in rel_tensors:
+                return None, f"unknown body relation: {atom.relation}"
+            for var in (left, right):
                 if var not in var_to_axis:
                     var_to_axis[var] = chr(ord("a") + len(var_to_axis))
-            operands.append(rel_tensors[atom.rel])
-            operand_strs.append(var_to_axis[atom.left] + var_to_axis[atom.right])
-        if rule.head.left not in var_to_axis or rule.head.right not in var_to_axis:
-            return None, f"head variables {rule.head.left}, {rule.head.right} not in positive body"
-        equation = ",".join(operand_strs) + "->" + var_to_axis[rule.head.left] + var_to_axis[rule.head.right]
+            operands.append(rel_tensors[atom.relation])
+            operand_strs.append(var_to_axis[left] + var_to_axis[right])
+        head_args = _binary_args(rule.head)
+        if head_args is None:
+            return None, f"head relation {rule.head.relation} expects 2 args, got {len(rule.head.args)}"
+        head_left, head_right = head_args
+        if head_left not in var_to_axis or head_right not in var_to_axis:
+            return None, f"head variables {head_left}, {head_right} not in positive body"
+        equation = ",".join(operand_strs) + "->" + var_to_axis[head_left] + var_to_axis[head_right]
         result = (torch.einsum(equation, *operands) > 0).float()
     else:
+        head_args = _binary_args(rule.head)
+        if head_args is None:
+            return None, f"head relation {rule.head.relation} expects 2 args, got {len(rule.head.args)}"
+        head_left, head_right = head_args
         result = torch.ones(n, n)
 
-    head_vars = {rule.head.left, rule.head.right}
+    head_vars = {head_left, head_right}
     for atom in neg_atoms:
-        if atom.rel not in rel_tensors:
-            return None, f"unknown negated relation: {atom.rel}"
-        if {atom.left, atom.right} != head_vars:
+        args = _binary_args(atom)
+        if args is None:
+            return None, f"negated relation {atom.relation} expects 2 args, got {len(atom.args)}"
+        left, right = args
+        if atom.relation not in rel_tensors:
+            return None, f"unknown negated relation: {atom.relation}"
+        if {left, right} != head_vars:
             return None, (
-                f"negated atom {atom.rel}({atom.left}, {atom.right}) must match head "
-                f"variables {rule.head.left}, {rule.head.right}"
+                f"negated atom {atom.relation}({left}, {right}) must match head "
+                f"variables {head_left}, {head_right}"
             )
-        neg_tensor = rel_tensors[atom.rel]
-        if (atom.left, atom.right) == (rule.head.left, rule.head.right):
+        neg_tensor = rel_tensors[atom.relation]
+        if (left, right) == (head_left, head_right):
             neg_aligned = neg_tensor
         else:
             neg_aligned = neg_tensor.t()
         result = result * (1.0 - neg_aligned)
 
-    return ((result > 0).float(), names, name_to_idx, rule.head.rel), None
+    return ((result > 0).float(), names, name_to_idx, rule.head.relation), None
 
 
 def query_relation(head_result, subj: str, obj: str) -> bool:

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -3,9 +3,11 @@ import unittest
 import torch
 
 from tensor_logic import (
+    Atom,
     Domain,
     Program,
     Relation,
+    Rule,
     bfs_per_source_closure,
     bfs_query,
     dense_closure,
@@ -63,6 +65,14 @@ class TensorLogicCoreTest(unittest.TestCase):
 
     def test_positive_rule_join(self):
         rule = parse_rule('<tl_rule head="uncle(X, Y)" body="sibling(X, P), parent(P, Y)"></tl_rule>')
+        self.assertIsInstance(rule, Rule)
+        self.assertIsInstance(rule.head, Atom)
+        self.assertEqual(rule.head.relation, "uncle")
+        self.assertEqual(rule.head.args, ("X", "Y"))
+        self.assertEqual(rule.head.rel, "uncle")
+        self.assertEqual((rule.head.left, rule.head.right), ("X", "Y"))
+        self.assertEqual(rule.body[0].relation, "sibling")
+        self.assertEqual(rule.body[0].args, ("X", "P"))
         result, err = evaluate_rule(GRAPH, rule)
         self.assertIsNone(err)
         self.assertTrue(query_relation(result, "carol", "dave"))
@@ -72,10 +82,31 @@ class TensorLogicCoreTest(unittest.TestCase):
         rule = parse_rule(
             '<tl_rule head="sibling_not_parent(X, Y)" body="sibling(X, Y), !parent(X, Y)"></tl_rule>'
         )
+        self.assertTrue(rule.body[1].negated)
+        self.assertEqual(rule.body[1], Atom("parent", ("X", "Y"), negated=True))
         result, err = evaluate_rule(GRAPH, rule)
         self.assertIsNone(err)
         self.assertTrue(query_relation(result, "bob", "carol"))
         self.assertFalse(query_relation(result, "alice", "bob"))
+
+    def test_tl_rule_parse_rejects_invalid_syntax(self):
+        self.assertIsNone(parse_rule("no tag here"))
+        self.assertIsNone(parse_rule('<tl_rule head="!bad(X, Y)" body="parent(X, Y)"></tl_rule>'))
+        self.assertIsNone(parse_rule('<tl_rule head="bad(X, Y)" body=""></tl_rule>'))
+        self.assertIsNone(parse_rule('<tl_rule head="bad(X, Y)" body="parent(X, Y) garbage"></tl_rule>'))
+        self.assertIsNone(parse_rule('<tl_rule head="bad(X, Y)" body="parent(X, Y),"></tl_rule>'))
+
+    def test_tl_rule_evaluate_reports_unknown_relation(self):
+        rule = parse_rule('<tl_rule head="derived(X, Y)" body="missing(X, Y)"></tl_rule>')
+        result, err = evaluate_rule(GRAPH, rule)
+        self.assertIsNone(result)
+        self.assertEqual(err, "unknown body relation: missing")
+
+    def test_tl_rule_evaluate_reports_unknown_negated_relation(self):
+        rule = parse_rule('<tl_rule head="derived(X, Y)" body="parent(X, Y), !missing(X, Y)"></tl_rule>')
+        result, err = evaluate_rule(GRAPH, rule)
+        self.assertIsNone(result)
+        self.assertEqual(err, "unknown negated relation: missing")
 
     def test_provenance_and_ranking(self):
         rules = [


### PR DESCRIPTION
## Summary
- Routes `<tl_rule>` parsing through canonical `tensor_logic.program.Atom` / `Rule`.
- Adds `Atom.negated` plus compatibility aliases for existing binary evaluator/provenance callers.
- Preserves current `evaluate_rule()` behavior while adding stricter body parsing and focused invalid syntax/unknown relation tests.

## Validation
- `python3 -m pytest tests/test_tensor_logic_core.py -q` -> 50 passed
- `python3 -m pytest tests/ -q` -> 125 passed
- `git diff --cached --check` before commit

Closes #20