### PR TITLE
SYM-51: build deterministic support stack generator

### DIFF
--- a/experiments/exp84_support_data.py
+++ b/experiments/exp84_support_data.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from random import Random
+from typing import Literal
+
+Label = Literal["stable", "falls"]
+Split = Literal["id", "ood"]
+InterventionKind = Literal["none", "remove"]
+
+
+@dataclass(frozen=True)
+class ObjectState:
+    id: str
+    x: int
+    y: int
+    w: int
+    h: int
+
+
+@dataclass(frozen=True)
+class Intervention:
+    kind: InterventionKind
+    object_id: str | None = None
+
+
+@dataclass(frozen=True)
+class Scene:
+    objects: list[ObjectState]
+    intervention: Intervention
+    labels: dict[str, Label]
+
+
+def _is_supported_by(child: ObjectState, parent: ObjectState) -> bool:
+    child_bottom = child.y
+    parent_top = parent.y + parent.h
+    if child_bottom != parent_top:
+        return False
+    child_left, child_right = child.x, child.x + child.w
+    parent_left, parent_right = parent.x, parent.x + parent.w
+    overlap = min(child_right, parent_right) - max(child_left, parent_left)
+    return overlap > 0
+
+
+def _rectangles_overlap(a: ObjectState, b: ObjectState) -> bool:
+    ax2, ay2 = a.x + a.w, a.y + a.h
+    bx2, by2 = b.x + b.w, b.y + b.h
+    x_overlap = min(ax2, bx2) - max(a.x, b.x)
+    y_overlap = min(ay2, by2) - max(a.y, b.y)
+    return x_overlap > 0 and y_overlap > 0
+
+
+def _compute_labels(objects: list[ObjectState], intervention: Intervention) -> dict[str, Label]:
+    removed = intervention.object_id if intervention.kind == "remove" else None
+    id_to_obj = {obj.id: obj for obj in objects}
+
+    stable: dict[str, bool] = {}
+    changed = True
+    while changed:
+        changed = False
+        for obj in objects:
+            if obj.id == removed or obj.id in stable:
+                continue
+            if obj.y == 0:
+                stable[obj.id] = True
+                changed = True
+                continue
+            for parent in objects:
+                if parent.id == removed or parent.id == obj.id:
+                    continue
+                if parent.id not in stable:
+                    continue
+                if _is_supported_by(obj, parent):
+                    stable[obj.id] = True
+                    changed = True
+                    break
+
+    labels: dict[str, Label] = {}
+    for object_id in id_to_obj:
+        if object_id == removed:
+            continue
+        labels[object_id] = "stable" if object_id in stable else "falls"
+    return labels
+
+
+def _generate_scene(rng: Random, split: Split, intervention: InterventionKind) -> Scene:
+    if split == "id":
+        n = rng.randint(2, 3)
+        widths = [rng.randint(2, 4) for _ in range(n)]
+        heights = [rng.randint(1, 2) for _ in range(n)]
+    else:
+        n = rng.randint(4, 8)
+        widths = [rng.randint(1, 6) for _ in range(n)]
+        heights = [rng.randint(1, 4) for _ in range(n)]
+
+    # Build a deterministic support tree: each object above ground has exactly one parent.
+    objects: list[ObjectState] = []
+    for i in range(n):
+        object_id = f"o{i}"
+        w = widths[i]
+        h = heights[i]
+        if i == 0:
+            x = 0
+            y = 0
+        else:
+            parent_idx = rng.randint(0, i - 1)
+            parent = objects[parent_idx]
+            min_x = parent.x - w + 1
+            max_x = parent.x + parent.w - 1
+            y = parent.y + parent.h
+            placed = False
+            for _ in range(24):
+                x = rng.randint(min_x, max_x)
+                candidate = ObjectState(id=object_id, x=x, y=y, w=w, h=h)
+                if all(not _rectangles_overlap(candidate, existing) for existing in objects):
+                    objects.append(candidate)
+                    placed = True
+                    break
+            if not placed:
+                x = parent.x
+                while True:
+                    candidate = ObjectState(id=object_id, x=x, y=y, w=w, h=h)
+                    if all(not _rectangles_overlap(candidate, existing) for existing in objects):
+                        objects.append(candidate)
+                        break
+                    x += 1
+                continue
+            continue
+        objects.append(ObjectState(id=object_id, x=x, y=y, w=w, h=h))
+
+    scene_intervention = Intervention(kind="none")
+    if intervention == "remove":
+        removable = [obj.id for obj in objects if obj.y != 0]
+        remove_id = rng.choice(removable) if removable else objects[0].id
+        scene_intervention = Intervention(kind="remove", object_id=remove_id)
+
+    labels = _compute_labels(objects, scene_intervention)
+    return Scene(objects=objects, intervention=scene_intervention, labels=labels)
+
+
+def generate_dataset(
+    n_scenes: int,
+    split: Split,
+    intervention: InterventionKind = "none",
+    seed: int = 0,
+) -> list[dict[str, object]]:
+    """Generate deterministic support scenes with exact stable/falls labels."""
+    if split not in {"id", "ood"}:
+        raise ValueError(f"Unknown split: {split}")
+    if intervention not in {"none", "remove"}:
+        raise ValueError(f"Unknown intervention: {intervention}")
+
+    rng = Random(seed)
+    dataset: list[dict[str, object]] = []
+    for _ in range(n_scenes):
+        scene = _generate_scene(rng, split, intervention)
+        dataset.append(
+            {
+                "objects": [obj.__dict__.copy() for obj in scene.objects],
+                "intervention": scene.intervention.__dict__.copy(),
+                "labels": scene.labels.copy(),
+            }
+        )
+    return dataset

--- a/tests/test_exp84_support_data.py
+++ b/tests/test_exp84_support_data.py
@@ -1,0 +1,66 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from experiments.exp84_support_data import generate_dataset
+
+
+def _interior_overlap(a, b) -> bool:
+    ax2, ay2 = a["x"] + a["w"], a["y"] + a["h"]
+    bx2, by2 = b["x"] + b["w"], b["y"] + b["h"]
+    x_overlap = min(ax2, bx2) - max(a["x"], b["x"])
+    y_overlap = min(ay2, by2) - max(a["y"], b["y"])
+    return x_overlap > 0 and y_overlap > 0
+
+
+def test_id_split_shape_and_reproducibility():
+    d1 = generate_dataset(n_scenes=12, split="id", intervention="none", seed=11)
+    d2 = generate_dataset(n_scenes=12, split="id", intervention="none", seed=11)
+    assert d1 == d2
+
+    for scene in d1:
+        objs = scene["objects"]
+        assert 2 <= len(objs) <= 3
+        for obj in objs:
+            assert set(obj.keys()) == {"id", "x", "y", "w", "h"}
+            assert obj["w"] >= 2 and obj["w"] <= 4
+            assert obj["h"] >= 1 and obj["h"] <= 2
+
+
+def test_ood_split_shape_and_unseen_sizes():
+    data = generate_dataset(n_scenes=40, split="ood", intervention="none", seed=3)
+    saw_large_width = False
+    saw_large_height = False
+
+    for scene in data:
+        objs = scene["objects"]
+        assert 4 <= len(objs) <= 8
+        for obj in objs:
+            if obj["w"] > 4:
+                saw_large_width = True
+            if obj["h"] > 2:
+                saw_large_height = True
+
+    assert saw_large_width
+    assert saw_large_height
+
+
+def test_remove_intervention_produces_consistent_labels():
+    data = generate_dataset(n_scenes=20, split="ood", intervention="remove", seed=7)
+    for scene in data:
+        iv = scene["intervention"]
+        assert iv["kind"] == "remove"
+        assert iv["object_id"] is not None
+        removed = iv["object_id"]
+        object_ids = {o["id"] for o in scene["objects"]}
+        assert removed in object_ids
+        assert removed not in scene["labels"]
+        assert set(scene["labels"].values()) <= {"stable", "falls"}
+
+
+def test_rectangles_do_not_overlap_interiorly():
+    data = generate_dataset(n_scenes=60, split="ood", intervention="none", seed=99)
+    for scene in data:
+        objs = scene["objects"]
+        for i in range(len(objs)):
+            for j in range(i + 1, len(objs)):
+                assert not _interior_overlap(objs[i], objs[j])


### PR DESCRIPTION
### Motivation
- Provide a deterministic, seedable object-table scene generator for the support/stability V1 experiment that emits exact `stable`/`falls` labels from toy-clean support rules.
- Support both ID and OOD generation regimes and interventions so downstream TL and baseline experiments can rely on reproducible, non-overlapping rectangle stacks with exact counterfactual labels.

### Description
- Added `experiments/exp84_support_data.py` implementing `generate_dataset(...)` that returns scenes as dicts with `objects` (`id,x,y,w,h`), `intervention` (`kind,object_id`), and per-object `labels` (`stable`|`falls`), and is deterministic via a `seed` argument.
- Implemented ID vs OOD sampling (ID: 2–3 objects, constrained widths/heights; OOD: 4–8 objects, wider/height ranges) and a placement routine that avoids interior overlaps by attempting random placements then a linear scan fallback.
- Encoded exact, deterministic label computation via a simple fixpoint using `on_ground` (`y==0`) and a toy `supports` test (`touching` = exact top/bottom contact and horizontal overlap), and implemented an intervention mode `remove(object_id)` that omits removed objects from labels.
- Added `tests/test_exp84_support_data.py` with checks for reproducibility, ID/OOD schema and unseen sizes, remove-intervention invariants, and a rectangle non-overlap invariant.

### Testing
- Ran the unit tests with `pytest tests/test_exp84_support_data.py -v`.
- Result: all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f45a8538832c8fe941c57be2f519)