### PR TITLE
SYM-52: add support stability TL engine

### DIFF
--- a/experiments/exp85_support_tl.py
+++ b/experiments/exp85_support_tl.py
@@ -1,0 +1,253 @@
+"""Deterministic support/stability engine over primitive geometry facts.
+
+This is the Tensor Logic substrate slice for the support/stability V1
+experiment: perfect object tables in, primitive relations extracted from
+geometry, fixpoint support closure out.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional, Sequence, Tuple
+
+
+EPS = 1e-9
+Fact = Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ProofTrace:
+    fact: Fact
+    rule: str
+    body: Tuple["ProofTrace", ...] = ()
+
+    def lines(self, indent: int = 0) -> list[str]:
+        pad = "  " * indent
+        head = f"{self.fact[0]}({', '.join(self.fact[1:])})"
+        out = [f"{pad}{head}  [{self.rule}]"]
+        for child in self.body:
+            out.extend(child.lines(indent + 1))
+        return out
+
+    def format(self) -> str:
+        return "\n".join(self.lines())
+
+
+@dataclass(frozen=True)
+class PrimitiveRelations:
+    touching: frozenset[tuple[str, str]] = frozenset()
+    above: frozenset[tuple[str, str]] = frozenset()
+    horiz_overlap: frozenset[tuple[str, str]] = frozenset()
+    on_ground: frozenset[str] = frozenset()
+    removed: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class StabilityResult:
+    labels: dict[str, str]
+    stable: frozenset[str]
+    falls: frozenset[str]
+    supports: frozenset[tuple[str, str]]
+    primitives: PrimitiveRelations
+    proofs: dict[tuple[str, str], ProofTrace] = field(default_factory=dict)
+
+    def proof_for(self, relation: str, object_id: str) -> ProofTrace:
+        return self.proofs[(relation, object_id)]
+
+
+def _interval(obj: dict[str, object]) -> tuple[float, float]:
+    x = float(obj["x"])
+    return x, x + float(obj["w"])
+
+
+def _overlap_interval(a: dict[str, object], b: dict[str, object]) -> tuple[float, float] | None:
+    a0, a1 = _interval(a)
+    b0, b1 = _interval(b)
+    lo = max(a0, b0)
+    hi = min(a1, b1)
+    if hi <= lo:
+        return None
+    return lo, hi
+
+
+def _merge_intervals(intervals: Iterable[tuple[float, float]]) -> list[tuple[float, float]]:
+    ordered = sorted(intervals)
+    if not ordered:
+        return []
+    merged = [ordered[0]]
+    for lo, hi in ordered[1:]:
+        mlo, mhi = merged[-1]
+        if lo <= mhi:
+            merged[-1] = (mlo, max(mhi, hi))
+        else:
+            merged.append((lo, hi))
+    return merged
+
+
+def _covers_width(intervals: Iterable[tuple[float, float]], left: float, right: float) -> bool:
+    pos = left
+    for lo, hi in _merge_intervals(intervals):
+        if lo > pos + EPS:
+            return False
+        pos = max(pos, hi)
+        if pos >= right - EPS:
+            return True
+    return pos >= right - EPS
+
+
+def _removed_id(intervention: Optional[dict[str, str]]) -> str | None:
+    if not intervention or intervention.get("type") == "none":
+        return None
+    if intervention.get("type") != "remove":
+        raise ValueError(f"unknown intervention type: {intervention.get('type')!r}")
+    return intervention.get("object_id")
+
+
+def _objects_by_id(objects: Sequence[dict[str, object]]) -> dict[str, dict[str, object]]:
+    by_id: dict[str, dict[str, object]] = {}
+    for obj in objects:
+        oid = str(obj["id"])
+        if oid in by_id:
+            raise ValueError(f"duplicate object id: {oid}")
+        by_id[oid] = dict(obj)
+    return by_id
+
+
+def extract_primitives(
+    objects: Sequence[dict[str, object]],
+    intervention: Optional[dict[str, str]] = None,
+) -> PrimitiveRelations:
+    """Extract primitive relations from perfect object geometry.
+
+    Relation argument order follows the rule sketch in the plan:
+    `touching(upper, lower)` and `above(upper, lower)`.
+    """
+
+    by_id = _objects_by_id(objects)
+    removed = _removed_id(intervention)
+    if removed is not None and removed not in by_id:
+        raise ValueError(f"unknown remove target: {removed}")
+
+    active = [obj for oid, obj in by_id.items() if oid != removed]
+    touching: set[tuple[str, str]] = set()
+    above: set[tuple[str, str]] = set()
+    horiz_overlap: set[tuple[str, str]] = set()
+    on_ground: set[str] = set()
+
+    for obj in active:
+        oid = str(obj["id"])
+        if abs(float(obj["y"])) <= EPS:
+            on_ground.add(oid)
+
+    for upper in active:
+        upper_id = str(upper["id"])
+        for lower in active:
+            lower_id = str(lower["id"])
+            if upper_id == lower_id:
+                continue
+            if _overlap_interval(upper, lower) is not None:
+                horiz_overlap.add((upper_id, lower_id))
+            if float(upper["y"]) >= float(lower["y"]) + float(lower["h"]) - EPS:
+                above.add((upper_id, lower_id))
+            lower_top = float(lower["y"]) + float(lower["h"])
+            if abs(float(upper["y"]) - lower_top) <= EPS and _overlap_interval(upper, lower) is not None:
+                touching.add((upper_id, lower_id))
+
+    return PrimitiveRelations(
+        touching=frozenset(touching),
+        above=frozenset(above),
+        horiz_overlap=frozenset(horiz_overlap),
+        on_ground=frozenset(on_ground),
+        removed=frozenset({removed} if removed is not None else set()),
+    )
+
+
+def infer_stability(
+    objects: Sequence[dict[str, object]],
+    intervention: Optional[dict[str, str]] = None,
+) -> StabilityResult:
+    by_id = _objects_by_id(objects)
+    removed = _removed_id(intervention)
+    if removed is not None and removed not in by_id:
+        raise ValueError(f"unknown remove target: {removed}")
+
+    primitives = extract_primitives(objects, intervention)
+    active_ids = [oid for oid in by_id if oid not in primitives.removed]
+    stable: set[str] = set()
+    supports: set[tuple[str, str]] = set()
+    proofs: dict[tuple[str, str], ProofTrace] = {}
+
+    changed = True
+    while changed:
+        changed = False
+        for oid in active_ids:
+            if oid in stable:
+                continue
+            obj = by_id[oid]
+            if oid in primitives.on_ground:
+                stable.add(oid)
+                proofs[("stable", oid)] = ProofTrace(
+                    ("stable", oid),
+                    "stable(X) :- on_ground(X), not removed(X)",
+                    (ProofTrace(("on_ground", oid), "geometry primitive"),),
+                )
+                changed = True
+                continue
+
+            intervals = []
+            support_children: list[ProofTrace] = []
+            for sid in stable:
+                supporter = by_id[sid]
+                if (oid, sid) not in primitives.touching:
+                    continue
+                if (oid, sid) not in primitives.above:
+                    continue
+                if (oid, sid) not in primitives.horiz_overlap:
+                    continue
+                overlap = _overlap_interval(obj, supporter)
+                if overlap is None:
+                    continue
+                intervals.append(overlap)
+                supports.add((sid, oid))
+                support_proof = ProofTrace(
+                    ("supports", sid, oid),
+                    "supports(Y, X) from primitive contact with stable(Y)",
+                    (
+                        ProofTrace(("touching", oid, sid), "geometry primitive"),
+                        ProofTrace(("above", oid, sid), "geometry primitive"),
+                        ProofTrace(("horiz_overlap", oid, sid), "geometry primitive"),
+                        proofs[("stable", sid)],
+                    ),
+                )
+                proofs[("supports", f"{sid}->{oid}")] = support_proof
+                support_children.append(support_proof)
+
+            left, right = _interval(obj)
+            if _covers_width(intervals, left, right):
+                stable.add(oid)
+                proofs[("stable", oid)] = ProofTrace(
+                    ("stable", oid),
+                    "stable(X) :- stable supporters cover full horizontal width",
+                    tuple(support_children),
+                )
+                changed = True
+
+    labels: Dict[str, str] = {}
+    falls: set[str] = set()
+    for oid in by_id:
+        if oid in stable:
+            labels[oid] = "stable"
+        else:
+            labels[oid] = "falls"
+            falls.add(oid)
+            reason = "falls(X) because X is removed" if oid in primitives.removed else "falls(X) :- not stable(X)"
+            proofs[("falls", oid)] = ProofTrace(("falls", oid), reason)
+
+    return StabilityResult(
+        labels=labels,
+        stable=frozenset(stable),
+        falls=frozenset(falls),
+        supports=frozenset(supports),
+        primitives=primitives,
+        proofs=proofs,
+    )

--- a/tests/test_exp85_support_tl.py
+++ b/tests/test_exp85_support_tl.py
@@ -1,0 +1,89 @@
+from experiments.exp84_support_data import compute_labels, generate_dataset
+from experiments.exp85_support_tl import extract_primitives, infer_stability
+
+
+def test_relation_extractor_hand_built_near_misses():
+    objects = [
+        {"id": "ground", "x": 0.0, "y": 0.0, "w": 2.0, "h": 1.0},
+        {"id": "top", "x": 0.0, "y": 1.0, "w": 2.0, "h": 1.0},
+        {"id": "gap", "x": 0.0, "y": 2.1, "w": 2.0, "h": 1.0},
+        {"id": "side", "x": 3.0, "y": 1.0, "w": 1.0, "h": 1.0},
+    ]
+
+    rels = extract_primitives(objects)
+
+    assert "ground" in rels.on_ground
+    assert ("top", "ground") in rels.touching
+    assert ("top", "ground") in rels.above
+    assert ("top", "ground") in rels.horiz_overlap
+    assert ("gap", "top") not in rels.touching
+    assert ("side", "ground") not in rels.horiz_overlap
+    assert ("side", "ground") not in rels.touching
+
+
+def test_single_block_on_ground_is_stable():
+    objects = [{"id": "o0", "x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0}]
+
+    result = infer_stability(objects)
+
+    assert result.labels == {"o0": "stable"}
+    assert "on_ground" in result.proof_for("stable", "o0").format()
+
+
+def test_simple_vertical_stack_and_deeper_chain_are_stable():
+    objects = [
+        {"id": "o0", "x": 0.0, "y": 0.0, "w": 2.0, "h": 1.0},
+        {"id": "o1", "x": 0.0, "y": 1.0, "w": 2.0, "h": 1.0},
+        {"id": "o2", "x": 0.0, "y": 2.0, "w": 2.0, "h": 1.0},
+    ]
+
+    result = infer_stability(objects)
+
+    assert result.labels == {"o0": "stable", "o1": "stable", "o2": "stable"}
+    assert ("o0", "o1") in result.supports
+    assert ("o1", "o2") in result.supports
+    assert "supports" in result.proof_for("stable", "o2").format()
+
+
+def test_unsupported_floating_block_falls():
+    objects = [{"id": "o0", "x": 0.0, "y": 2.0, "w": 1.0, "h": 1.0}]
+
+    result = infer_stability(objects)
+
+    assert result.labels == {"o0": "falls"}
+    assert "not stable" in result.proof_for("falls", "o0").format()
+
+
+def test_branching_support_requires_full_width_union():
+    objects = [
+        {"id": "o0", "x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0},
+        {"id": "o1", "x": 1.0, "y": 0.0, "w": 1.0, "h": 1.0},
+        {"id": "o2", "x": 0.0, "y": 1.0, "w": 2.0, "h": 1.0},
+    ]
+
+    result = infer_stability(objects)
+    retracted = infer_stability(objects, {"type": "remove", "object_id": "o1"})
+
+    assert result.labels["o2"] == "stable"
+    assert {("o0", "o2"), ("o1", "o2")} <= result.supports
+    assert retracted.labels["o2"] == "falls"
+    assert retracted.labels["o1"] == "falls"
+
+
+def test_generator_parity_for_id_and_ood_samples():
+    for split in ("id", "ood"):
+        scenes = generate_dataset(num_scenes=8, split=split, seed=17)
+        for scene in scenes:
+            result = infer_stability(scene["objects"], scene["intervention"])
+            assert result.labels == scene["labels"]
+
+
+def test_generator_parity_on_removal_retraction_samples():
+    scenes = generate_dataset(num_scenes=6, split="ood", seed=23, interventions=("remove",))
+    for scene in scenes:
+        result = infer_stability(scene["objects"], scene["intervention"])
+        expected = compute_labels(scene["objects"], scene["intervention"])
+        assert result.labels == expected
+        removed_id = scene["intervention"]["object_id"]
+        assert removed_id in result.primitives.removed
+        assert result.labels[removed_id] == "falls"


### PR DESCRIPTION
## Summary

- Add exp85 deterministic support/stability engine over primitive geometry relations.
- Extract touching/above/horiz_overlap/on_ground/removed facts from object tables.
- Run fixpoint support/stable/falls inference with proof traces and counterfactual removal handling.
- Add tests for relation extraction, vertical stacks, branching support, floating blocks, retraction, and generator parity.

## Validation

- python3 -m pytest tests/test_exp85_support_tl.py -v
- python3 -m pytest tests/test_exp84_support_data.py -v

Linear: SYM-52