### PR TITLE
SYM-136: document support stability run hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ python -m pip install -e ".[dev]"
 python -m pytest tests/ -v
 ```
 
+Support/stability fast path:
+
+```bash
+python -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v
+python experiments/exp86_support_baselines.py --quick
+```
+
+`exp86` is a neural baseline smoke run and should stay out of CI unless it is
+kept quick and deterministic.
+
 ## Run
 
 ```bash

--- a/docs/SYMPHONY_RUN_PROTOCOL.md
+++ b/docs/SYMPHONY_RUN_PROTOCOL.md
@@ -7,12 +7,44 @@ This document defines the repo-local run protocol for Symphony/Jules-style worke
 When executing an issue in this repository, follow these rules strictly:
 
 1. **Task Contract**: Treat the Linear issue as the complete and final task contract.
-2. **Branch Naming**: Create or use a git branch named exactly after the issue key (e.g., `SYM-25`).
+2. **Branch Naming**: Create or use a git branch named from the issue key, e.g. `codex/SYM-25-short-title`.
 3. **Execution Notes**: Write local execution notes or use a workpad if the repository has an established place for that (e.g., in `notes/` directory or a designated task file).
 4. **Scope Constraint**: Keep one issue to one branch and one Pull Request. Do not bundle multiple issues.
 5. **Validation**: Validate your changes with the smallest, most direct command that proves the acceptance criteria have been met.
 6. **Documentation of Results**: Record the PR URL, commit SHA, validation command used, and any blockers encountered during execution.
 7. **Status Management**: Do not mark the Linear issue as Done until the PR is fully merged or explicitly accepted by a maintainer.
+
+## PR Publishing Contract
+
+Implementation work is not complete until it is visible as a real GitHub PR.
+
+- Commit scoped changes.
+- Push the issue branch to `origin`.
+- Open a GitHub PR against `main`.
+- Comment on the Linear issue with the PR URL, branch name, commit SHA, validation command, and result.
+- Do not stop at local commits, task summaries, `make_pr` metadata, or a local-only branch. The PR must be visible to `gh pr view`.
+- If pushing or PR creation is blocked, comment on Linear with the exact blocker, branch name, commit SHA, and failed command.
+
+## Support/Stability Fast Path
+
+The current Tensor research lane is support/stability. After a clean checkout install:
+
+```bash
+python -m pip install -e ".[dev]"
+python -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v
+```
+
+Neural baseline smoke validation stays out of CI, but should be run by workers touching `exp86`:
+
+```bash
+python experiments/exp86_support_baselines.py --quick
+```
+
+Full validation remains:
+
+```bash
+python -m pytest tests/ -v
+```
 
 ## Notes for Agents
 

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -40,3 +40,15 @@ def test_readme_documents_worker_validation_commands():
 
     assert 'python -m pip install -e ".[dev]"' in readme
     assert "python -m pytest tests/ -v" in readme
+    assert "tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v" in readme
+    assert "python experiments/exp86_support_baselines.py --quick" in readme
+
+
+def test_symphony_protocol_requires_real_github_prs_and_support_fast_path():
+    protocol = (REPO_ROOT / "docs" / "SYMPHONY_RUN_PROTOCOL.md").read_text()
+
+    assert "codex/SYM-25-short-title" in protocol
+    assert "real GitHub PR" in protocol
+    assert "gh pr view" in protocol
+    assert "tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v" in protocol
+    assert "python experiments/exp86_support_baselines.py --quick" in protocol


### PR DESCRIPTION
## Summary

- Update Symphony run protocol to require real GitHub PRs visible to `gh pr view`.
- Align branch naming with the active `codex/SYM-...` issue branch pattern.
- Document support/stability fast-path commands in README and Symphony protocol.
- Add packaging tests that lock the PR publishing contract and support/stability validation commands.

## Validation

- python3 -m pytest tests/test_packaging_ci.py -v
- python3 -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v
- python3 experiments/exp86_support_baselines.py --quick
- python3 -m pytest tests/ -v

Linear: SYM-136