### PR TITLE
[codex] Add overnight review reports

### DIFF
--- a/docs/overnight/2026-05-07-30min-extension-b/tensor-experiments-validation-queue-plan.md
+++ b/docs/overnight/2026-05-07-30min-extension-b/tensor-experiments-validation-queue-plan.md
@@ -1,0 +1,111 @@
+# tensor-experiments Validation Queue Plan
+
+Date: 2026-05-07
+Branch: `codex/goal-tensor-experiments-validation-queue-plan`
+Repo: `tensor-experiments` / `tensor-logic`
+Scope: read-only validation and queue-readiness audit; no product code edited.
+
+## Summary
+
+The repo is queue-ready for normal implementation work if workers use the CI-equivalent `python3 -m pytest tests/ -v` command in this local environment. The full suite passed under `/usr/local/bin/python3` with Python 3.12.8: `140 passed in 32.74s`.
+
+There are two handoff risks to fix before broadening the queue:
+
+1. The repo docs and CI assert `python -m ...`, but this local shell has no `python` executable. `python3` works locally; GitHub Actions setup-python normally provides `python`.
+2. The `rtk pytest tests/ -v` wrapper used a different interpreter path and reported `139 passed, 1 failed` on `tests/test_exp81.py::test_make_proposer_returns_valid_json`, while the same test and the full suite passed with `python3`. Treat this as an environment-selection risk, not a confirmed product failure.
+
+No first-pass extension report, `runs/*/result.json`, `runs/*/handoff.md`, `CODEX_WORKPAD.md`, or repo-local queue `ISSUE.md` was present in this worktree. The JSON queue item named `items/tensor-experiments-validation-queue-plan/ISSUE.md`, but that path is missing here; the issue body was available from the Goal Pack prompt.
+
+## Validation Commands Run
+
+| Command | Result | Notes |
+|---|---:|---|
+| `git status --short --branch` | pass | Initial output only showed branch `codex/goal-tensor-experiments-validation-queue-plan`. |
+| `rtk pytest tests/ -v` | fail | Wrapper reported `139 passed, 1 failed`; failing test was `tests/test_exp81.py::test_make_proposer_returns_valid_json`, with `httpx` / connection-pool stack in output. |
+| `python -m pytest tests/test_exp81.py::test_make_proposer_returns_valid_json -vv -s` | blocked | Exit 127: `/opt/homebrew/bin/bash: line 1: python: command not found`. |
+| `python3 -m pytest tests/test_exp81.py::test_make_proposer_returns_valid_json -vv -s` | pass | `1 passed in 5.62s` under Python 3.12.8. |
+| `python3 -m pytest tests/ -v` | pass | `140 passed in 32.74s` under Python 3.12.8. |
+| `git status --short --ignored` | pass with ignored artifacts | After tests: only ignored `.pytest_cache/` and `tools/index.json`. |
+
+Queue validation command for this queue item:
+
+```bash
+git status --short
+```
+
+## Concrete File-Path Observations
+
+1. `README.md` documents the worker validation contract as:
+   `python -m pip install -e ".[dev]"` and `python -m pytest tests/ -v`. Locally, `python` is missing, so worker instructions should either require setup-python-like environments or include a `python3` fallback.
+2. `.github/workflows/ci.yml` runs on Ubuntu with Python 3.11, installs `.[dev]`, and runs only `python -m pytest tests/ -v`; there is no lint, type check, docs artifact check, or experiment-result consistency check.
+3. `pyproject.toml` declares runtime dependency `torch>=2.0` and dev extras `matplotlib`, `numpy`, and `pytest`; it does not pin versions or declare `transformers`/`mlx_lm`, even though LM-backed experiment paths import them opportunistically.
+4. `pyproject.toml` only configures pytest `testpaths = ["tests"]`; the repo has no `tool.ruff`, `tool.mypy`, `tox`, `nox`, or Makefile validation surface.
+5. `tests/test_packaging_ci.py` usefully locks the README, CI, and pyproject validation contract, but it asserts command strings rather than proving the local shell can run `python`.
+6. `tests/test_code_index.py` rebuilds `tools/index.json` during validation. `tests/test_code_index.py::test_index_json_is_gitignored` guards that this generated artifact stays ignored, which matched the observed `git status --short --ignored`.
+7. `CLAUDE.md` says to run `python tools/code_index.py --lookup <RelevantSymbol>` before plans that touch `tensor_logic/`; this report does not plan a direct `tensor_logic/` code edit, but future implementation tasks touching that package should follow it.
+8. `experiments/exp78_rule_induction.py` falls back to all relations when `transformers` is unavailable, but if `transformers` is installed it may load `Qwen/Qwen2.5-0.5B-Instruct` via `AutoTokenizer.from_pretrained` and `AutoModelForCausalLM.from_pretrained`; that path can need network/cache and is not isolated in CI.
+9. `experiments/exp81_optimize_rule_induction.py` wraps `lm_prune()` in `make_proposer()`, so `tests/test_exp81.py::test_make_proposer_returns_valid_json` is sensitive to whether the default model is locally cached under the interpreter used by the test runner.
+10. `tests/test_exp81.py` only smoke-tests proposer JSON shape; it does not pin offline mode, model-cache expectations, or deterministic fallback behavior for environments without model access.
+11. `docs/RUN_PROTOCOL.md` requires remote experiment runs to persist `manifest.json`, `failures.jsonl`, adapter pointers, and committed `experiments/expN_data/results.json`; this repo currently has committed results JSON for exp78, exp79, and exp83 only.
+12. `experiments/exp78_data/results.json` supports the README/notes claim for rule induction: all listed targets have `f1: 1.0`, `semantic_equiv: 1.0`, and `rule_found: true`.
+13. `experiments/exp79_data/results.json` records easy and medium modes at 10/10 answered, hard at 4/10 answered, very_hard at 7/10 answered, and adversarial attempts correctly rejected; this is good queue context but not enforced by pytest.
+14. `experiments/exp83_slot_data/results.json` has `gates.probe: false`, `gates.tl_only: true`, and `gates.e2e: true`; any future claim that exp83 passed all gates would be stale.
+15. `notes/EXPERIMENTS.md` says exp80 external official worked-example validation is still pending, despite internal synthetic invariants passing; this is a product-judgment blocker for using FAFSA numbers as an external benchmark.
+16. `experiments/exp80_validate_synthetic.py` writes `experiments/exp80_spot_check_cases.json`, and that JSON is committed with named cases. Tests cover 25 seeded families, not the full 1,015-family synthetic run or external aid-estimator spot checks.
+17. `docs/SYMPHONY_RUN_PROTOCOL.md` asks workers to record PR URL, commit SHA, validation command, and blockers. This queue item forbids pushes/PR creation, so the correct handoff is this committed report plus local commit SHA.
+18. `items/tensor-experiments-validation-queue-plan/ISSUE.md` is absent from the worktree. If future workers are launched from repo files rather than Goal Pack prompts, this queue item cannot be reproduced from local files alone.
+
+## Validation Gaps
+
+- Local docs/CI portability gap: `python` is assumed but not available in this shell. Use `python3` locally or ensure a managed environment supplies `python`.
+- Interpreter drift gap: `rtk pytest` selected a different Python stack than `python3 -m pytest`; one stack failed the LM-proposer smoke while Python 3.12.8 passed.
+- Offline determinism gap: LM-backed paths in `exp78`/`exp81` can depend on local model caches, `transformers`, and network availability.
+- Research artifact gap: committed result JSON is present for exp78/79/83, but the run protocol expects richer remote manifests/failure logs/adapter pointers for remote jobs.
+- Claim enforcement gap: pytest enforces API behavior and packaging/CI strings, but not README headline tables, notes claims, exp79 JSON summaries, or exp83 gate status.
+- External validation gap: exp80 remains internally validated only; official FAFSA worked examples or aid-estimator spot checks are still pending.
+- Handoff gap: the queue issue file referenced by the runner is missing from this worktree.
+
+## Known Blockers
+
+- No external services, pushes, PR creation, or tracker updates were allowed for this queue item.
+- `python -m ...` cannot run locally because `python` is missing from PATH.
+- `rtk pytest` currently does not provide a reliable pass/fail signal for this repo unless its interpreter selection is pinned or documented.
+- The absence of `items/tensor-experiments-validation-queue-plan/ISSUE.md` means this worktree is not self-contained for future replay.
+- Exp80 cannot be promoted to an external benchmark without human/product judgment on official validation sources.
+
+## Safe Next Implementation Tasks
+
+1. **Make local validation command portable**
+   - Owned files: `README.md`, `CLAUDE.md`, `.github/workflows/ci.yml`, `tests/test_packaging_ci.py`.
+   - Acceptance criteria: docs mention the canonical CI command and a local fallback when `python` is absent; packaging test asserts both without weakening CI.
+   - Smallest useful validation: `python3 -m pytest tests/test_packaging_ci.py -v`.
+
+2. **Pin or document the `rtk pytest` interpreter path**
+   - Owned files: `CLAUDE.md`, `README.md`, optionally a repo-local script such as `tools/validate.py` if the repo wants one command.
+   - Acceptance criteria: `rtk pytest` ambiguity is documented or replaced by a deterministic local command; no product behavior changes.
+   - Smallest useful validation: run `rtk pytest tests/test_exp81.py::test_make_proposer_returns_valid_json -v` and `python3 -m pytest tests/test_exp81.py::test_make_proposer_returns_valid_json -v`, then record expected behavior.
+
+3. **Add offline fallback coverage for LM proposer paths**
+   - Owned files: `experiments/exp78_rule_induction.py`, `experiments/exp81_optimize_rule_induction.py`, `tests/test_exp81.py`.
+   - Acceptance criteria: tests prove `make_proposer()` returns valid JSON when `transformers` is missing or model loading fails, without needing network/model cache.
+   - Smallest useful validation: `python3 -m pytest tests/test_exp81.py -v`.
+
+4. **Add experiment-result consistency checks**
+   - Owned files: `tests/test_experiment_results.py`, `experiments/exp78_data/results.json`, `experiments/exp79_data/results.json`, `experiments/exp83_slot_data/results.json`.
+   - Acceptance criteria: tests assert the minimum gates that docs rely on, including exp78 all targets found, exp79 easy/medium success, adversarial rejection, and exp83 `probe` gate status documented as false.
+   - Smallest useful validation: `python3 -m pytest tests/test_experiment_results.py -v`.
+
+5. **Make queue handoff replayable from repo-local files**
+   - Owned files: `docs/overnight/2026-05-07-30min-extension-b/`, optionally `docs/overnight/README.md` or a queue manifest if this repo adopts one.
+   - Acceptance criteria: future workers can find queue reports, validation commands, blockers, and source issue text without the hidden Goal Pack prompt.
+   - Smallest useful validation: `git status --short` plus a grep check such as `rg "tensor-experiments-validation-queue-plan" docs/overnight`.
+
+## Handoff
+
+- Files changed: `docs/overnight/2026-05-07-30min-extension-b/tensor-experiments-validation-queue-plan.md`.
+- Product code changed: none.
+- Current base commit before this report: `5565791a8c888511bbbff1107d2d357164f88baa`.
+- Local commit: not created. `git add docs/overnight/2026-05-07-30min-extension-b/tensor-experiments-validation-queue-plan.md` failed because the git worktree index is outside the writable sandbox: `fatal: Unable to create '/Users/jwalinshah/projects/tensor/experiments/.git/worktrees/tensor-experiments-validation-queue-plan/index.lock': Operation not permitted`.
+- PR URL: none; PR creation is out of scope for this queue item.
+- Final validation command: `git status --short`.
+- Final validation result: exit 0 with output `?? docs/overnight/`, because git staging/commit is sandbox-blocked and the report remains untracked.

--- a/docs/overnight/2026-05-07-30min-extension/tensor-experiments-action-plan.md
+++ b/docs/overnight/2026-05-07-30min-extension/tensor-experiments-action-plan.md
@@ -1,0 +1,441 @@
+# tensor-experiments 30-minute extension action plan
+
+Date: 2026-05-07
+Queue item: `tensor-experiments-30min-action-plan`
+Branch: `codex/goal-tensor-experiments-30min-action-plan`
+Repo: `tensor-experiments`
+Starting HEAD: `5565791a8c888511bbbff1107d2d357164f88baa`
+
+## Scope
+
+This was read-only planning/synthesis with one allowed write: this report.
+I did not edit product code, generated experiment data, tests, CI, external
+trackers, deployments, remote jobs, pushes, or PRs.
+
+The purpose of this extension was not to repeat the broad overnight audits. The
+useful next move is to reconcile those reports and convert their repeated risks
+into implementation-ready slices with owned files, proof commands, and stop
+conditions.
+
+## Prior overnight reconciliation
+
+Previous tensor-experiments reports exist outside this checkout under the
+2026-05-07 overnight-marathon worktrees:
+
+- `tensor-experiments-architecture-map.md` mapped the reusable package layers:
+  `tensor_logic/language.py`, `tensor_logic/program.py`,
+  `tensor_logic/proofs.py`, `tensor_logic/file_format.py`,
+  `tensor_logic/execution.py`, `tensor_logic/http_api.py`,
+  `tensor_logic/research/*`, and the web workbench. It already covered the
+  canonical rule-language direction and the broad module ownership map.
+- `tensor-experiments-docs-claims.md` identified stale README claims, missing
+  frozen result artifacts for headline exp53/54 numbers, the `python` vs
+  `python3` local mismatch, and exp79/exp83 status ambiguity.
+- `tensor-experiments-workflow-handoff.md` identified the exp79 artifact
+  collision, missing experiment workflow manifest, optional dependency gaps, and
+  the need for no-write experiment smoke commands.
+- `tensor-experiments-validation-map.md` proved the full local suite under
+  `python3` and documented that the advertised `python` command fails in this
+  worker shell.
+- `tensor-experiments-risk-register.md` covered local HTTP/workbench exposure,
+  unrestricted `.tl` includes, archive extraction, FAFSA user-facing wording,
+  and run-protocol enforcement gaps.
+- `tensor-experiments-dependency-surface.md` mapped declared vs observed
+  dependencies, generated artifacts, ignored state, and missing optional extras.
+
+What those reports already covered well: repository architecture, validation
+surface, dependency drift, docs drift, local security risks, and runner
+handoff risks.
+
+What was still missing: an explicit implementation queue that picks the first
+few work slices, defines file ownership, acceptance criteria, and local proof
+commands. This report fills that gap. The repeated findings below should move
+into implementation work instead of producing more general audit reports.
+
+## Concrete file observations
+
+1. `README.md:85-92` documents worker validation with
+   `python -m pip install -e ".[dev]"` and `python -m pytest tests/ -v`, but
+   `python` is absent in this local shell. `python3 -m pytest tests/ -v` passed.
+
+2. `.github/workflows/ci.yml:18-30` pins CI to Python 3.11 and uses `python`.
+   The local run used Python 3.12.8, so the docs need to distinguish CI Python
+   from local macOS `python3`.
+
+3. `tests/test_packaging_ci.py:16-42` asserts the current packaging/CI/README
+   validation contract. Any validation-doc change must update this test, not
+   only README prose.
+
+4. `README.md:71-73` says the repo contains `experiments/exp1` through
+   `exp54`, while the worktree contains experiment scripts through
+   `experiments/exp83_slot_attention.py`. This is stale navigation for future
+   agents.
+
+5. `README.md:111-114` says `demos/` has five headline runnable demos, while
+   `README.md:59-68` lists eight demo files. The five-item conceptual ladder at
+   `README.md:118-124` is different from the runnable demo inventory.
+
+6. `docs/RUN_PROTOCOL.md:65-85` requires committed `results.json` plus
+   `ADAPTER.md` pointers for remote-trained artifacts, and
+   `docs/RUN_PROTOCOL.md:87-103` makes `ADAPTER.md` a structure invariant.
+   `git ls-files 'experiments/exp*_data/ADAPTER.md'` found no adapter pointers.
+
+7. `experiments/exp78_rule_induction.py:7-10` states the TL-only induction gate:
+   recover gold rules from <=20 positive and <=20 negative examples in <=1s per
+   target. A default local run with `--out /tmp/tensor-exp78-default-extension-results.json`
+   recovered all rules and semantic equivalence, but distractor targets took
+   about 3.66s each and the script printed `family search <=1s : FAIL`.
+
+8. `experiments/exp78_rule_induction.py:170-179` runs brute-force induction and
+   semantic equivalence after optional LM pruning. The distractor split at
+   `experiments/exp78_rule_induction.py:219-220` expands the candidate cost to
+   14,424 per target in the observed run.
+
+9. `experiments/exp79_self_play_loop.py:436-482` defaults `--out` to
+   `experiments/exp79_data/results.json`. The easy-mode no-write redirected run
+   passed when output was sent to `/tmp`.
+
+10. `experiments/exp79_lewm_tl.py:49`, `experiments/exp79_lewm_tl.py:519`, and
+    `experiments/exp79_lewm_tl.py:594-596` also write into
+    `experiments/exp79_data/`. This is the artifact namespace collision already
+    identified by the workflow-handoff audit.
+
+11. `experiments/exp83_slot_attention.py:10-11` sets a 90% probe gate, and
+    `experiments/exp83_slot_attention.py:488-517` records `probe`, `tl_only`,
+    and `e2e` gates. The checked-in `experiments/exp83_slot_data/results.json`
+    fails the probe gate in prior audit evidence; the docs should not imply Slot
+    Attention solved the exp79 limitation.
+
+12. `experiments/exp83_slot_attention.py:113-114` imports
+    `tensor_logic.research.slot_attention` and `scipy.optimize.linear_sum_assignment`;
+    `pyproject.toml` declares `torch` runtime and only `matplotlib`, `numpy`,
+    and `pytest` dev extras. `scipy` is an undeclared lane dependency.
+
+13. `experiments/exp79_lewm_tl.py:53-110` and
+    `experiments/exp83_slot_attention.py:53-110` duplicate the same scene and
+    relation generation logic. The same duplication exists again for TL wiring:
+    `experiments/exp79_lewm_tl.py:335-401` and
+    `experiments/exp83_slot_attention.py:267-333`.
+
+14. `tensor_logic/program.py:12-34` now has canonical `Atom` and `Rule` with
+    variadic args and `negated=False` by default. `tensor_logic/rules.py:5-26`
+    imports those canonical dataclasses for `<tl_rule>` parsing, so the
+    2026-05-04 rule-language spec is partly implemented.
+
+15. `tensor_logic/rules.py:60-155` still has an explicitly binary evaluator and
+    head-variable restrictions for negated atoms. That is fine as a current
+    boundary, but follow-up rule-language work must preserve this as a consumer
+    limit, not redefine the canonical shape.
+
+16. `tensor_logic/proofs.py:44-81` exposes binary positive and negative proof
+    entrypoints, and `tensor_logic/proofs.py:249-305` binds exactly two head
+    args. The arbitrary-arity design remains future work even though the
+    canonical `Atom` is variadic.
+
+17. `experiments/exp80_fafsa_kb.py:11-15` scopes FAFSA to the 2024-25 guide,
+    Formula A dependent students, with Formula B/C marked TODO.
+
+18. `experiments/exp80_fafsa_wizard.py:197-207` prints user-facing Pell
+    qualification language. The current tests in `tests/test_exp80.py:15-77`
+    cover synthetic invariants and regressions, not official ED worked examples.
+
+19. `experiments/exp80_validate_synthetic.py:290-306` rewrites
+    `experiments/exp80_spot_check_cases.json` as part of validation. In this
+    run the file did not dirty the worktree, but future validation commands
+    should note that this script writes a tracked artifact path.
+
+20. `CLAUDE.md:1-16` tells agents to run `python tools/code_index.py --lookup`
+    before planning changes under `tensor_logic/`. In this local shell that
+    command fails because `python` is missing; `python3 tools/code_index.py
+    --dump` and `--status` worked.
+
+## Validation evidence
+
+Commands run locally:
+
+| Command | Result | Notes |
+|---|---:|---|
+| `llm-tldr tree .` | Pass | Mapped repo structure. |
+| `python3 tools/code_index.py --dump` | Pass | Required before planning tasks touching `tensor_logic/`. |
+| `python tools/code_index.py --dump` | Fail, exit 127 | `python` is not on PATH in this worker shell. |
+| `python3 -m pytest tests/ -v` | Pass | `140 passed in 38.05s`. |
+| `python3 experiments/exp80_validate_synthetic.py` | Pass | `1015/1015` families, invariants pass; writes spot-check JSON path. |
+| `python3 experiments/exp78_rule_induction.py --out /tmp/tensor-exp78-default-extension-results.json` | Script exited 0 but falsification gate failed | All rules/equiv passed; `family search <=1s` failed due distractor targets around 3.66s. |
+| `python3 experiments/exp79_self_play_loop.py --mode easy --out /tmp/tensor-exp79-easy-extension-results.json` | Pass | Easy mode answered 10/10 and printed `Overall: ALL PASS`. |
+| `python3 experiments/exp78_rule_induction.py --help` | Pass | Supports `--out`, `--n-pos`, `--n-neg`, `--n-entities`, `--max-len`, `--lm`. |
+| `python3 experiments/exp79_self_play_loop.py --help` | Pass | Supports safe `--out` and `--mode`. |
+| `python3 experiments/exp83_slot_attention.py --help` | Pass after Matplotlib cache delay | Warned that user Matplotlib/font caches are not writable; help says `--skip-train` is not supported in this PoC. |
+| `python3 -m tensor_logic --help` | Pass | CLI subcommands are present. |
+| `python3 tools/code_index.py --status` | Pass | `tools/index.json` is fresh, ignored local state. |
+
+The queue-required validation command is still `git status --short`; that is
+recorded in the handoff below after this report write.
+
+## Known blockers and risks
+
+- No external verification was performed. Official FAFSA worked examples,
+  current paper links, PyPI package-version reproduction, and remote adapter
+  pointers remain non-local work.
+- No remote jobs, model downloads, package downloads, deploys, pushes, or PRs
+  were in scope.
+- The local shell lacks `python`; docs and tests currently assert `python`
+  command strings even though `python3` is the usable local interpreter.
+- Committing from these worktrees may be blocked by git metadata outside the
+  writable root, as previous tensor-experiments overnight reports observed.
+- `exp78` currently exits 0 even when its printed falsification verdict is
+  `FAIL`. Implementation work should decide whether that is intentional
+  research behavior or whether a `--strict`/test gate is needed.
+- `exp83 --help` imports Matplotlib and SciPy-era dependencies before showing
+  help. In this sandbox it had to build a temporary Matplotlib cache because the
+  default user cache directories were not writable.
+
+## Implementation-ready follow-up tasks
+
+### Task 1: Normalize the validation contract and local Python commands
+
+Problem: local workers following README/CLAUDE literally hit `python: command
+not found`, while CI uses `python` from `actions/setup-python`. The mismatch is
+small but repeatedly blocks handoffs and code-index instructions.
+
+Owned files:
+
+- `README.md`
+- `CLAUDE.md`
+- `tests/test_packaging_ci.py`
+- `.github/workflows/ci.yml` only if maintainers want CI wording updated
+
+Acceptance criteria:
+
+- README keeps the CI command but also documents a local macOS-safe `python3`
+  command block.
+- `CLAUDE.md` says to use `python3 tools/code_index.py --lookup <Symbol>` when
+  `python` is absent.
+- `tests/test_packaging_ci.py` asserts the intended dual contract instead of
+  only checking the old `python` strings.
+- No product code changes.
+
+Validation:
+
+```bash
+python3 -m pytest tests/test_packaging_ci.py -q
+python3 tools/code_index.py --status
+git status --short
+```
+
+Stop condition: if maintainers want to require a venv that supplies `python`,
+document that explicitly instead of switching examples wholesale to `python3`.
+
+### Task 2: Add an experiment workflow and result provenance manifest
+
+Problem: the repo has enough active experiments that future workers need a
+single non-chat contract for entrypoints, default outputs, dependencies,
+tracked artifacts, and safe smoke commands. The run protocol requires adapter
+pointers, but current data directories do not have them.
+
+Owned files:
+
+- New `docs/EXPERIMENT_WORKFLOW.md` or `docs/experiment-manifest.md`
+- `README.md` link to the manifest
+- `docs/RUN_PROTOCOL.md` only for pointer/checker wording
+- Optional `tests/test_packaging_ci.py` or new docs test
+
+Acceptance criteria:
+
+- Manifest lists at least exp53, exp54, exp60d, exp76c, exp78,
+  exp79_self_play_loop, exp79_lewm_tl, exp80, exp81, and exp83.
+- Each row includes entrypoint, default output path, safe `/tmp` output form,
+  tracked artifacts, optional dependencies, external/network/model risk, and
+  validation command.
+- Existing `experiments/*_data/` dirs are annotated as one of: local data,
+  checked-in result snapshot, remote-adapter pointer required, or legacy/no
+  adapter expected.
+- The manifest explicitly states that audit workers should not run experiments
+  that write tracked result paths unless the issue asks for result refresh.
+
+Validation:
+
+```bash
+python3 -m pytest tests/test_packaging_ci.py -q
+git ls-files 'experiments/exp*_data/results.json' 'experiments/exp*_data/ADAPTER.md'
+git status --short
+```
+
+Stop condition: if maintainers need to decide whether old `results.json` files
+are canonical or historical snapshots, capture that as an open decision and do
+not rewrite artifacts in this task.
+
+### Task 3: Fix exp79/exp83 artifact and scene-utility drift
+
+Problem: `exp79_self_play_loop.py` and `exp79_lewm_tl.py` share
+`experiments/exp79_data/results.json`, while exp79 LeWM and exp83 duplicate
+scene generation and TL wiring. That creates both artifact-overwrite risk and
+test drift.
+
+Owned files:
+
+- `experiments/exp79_self_play_loop.py`
+- `experiments/exp79_lewm_tl.py`
+- `experiments/exp83_slot_attention.py`
+- New or existing module under `tensor_logic/research/`
+- `tests/test_exp79.py`
+- New focused tests if output-path checks do not fit `test_exp79.py`
+- Manifest/docs from Task 2, if already present
+
+Acceptance criteria:
+
+- Self-play and LeWM defaults no longer write the same `results.json`.
+- Any migrated or renamed tracked results are documented; existing data is not
+  silently overwritten.
+- Shared scene constants, `generate_sequence`, `compute_relations`,
+  `generate_labeled_frames`, `build_tl_state`, `remove_object`, and
+  `compute_gt_derived` live in one `tensor_logic.research` module if both exp79
+  LeWM and exp83 still use them.
+- Tests assert default output paths are distinct without training.
+- `exp83 --help` remains cheap and does not require training.
+
+Validation:
+
+```bash
+python3 -m pytest tests/test_exp79.py -q
+python3 experiments/exp79_self_play_loop.py --mode easy --out /tmp/exp79-self-play-smoke.json
+python3 experiments/exp83_slot_attention.py --help
+git status --short --ignored
+```
+
+Stop condition: if historical links require `experiments/exp79_data/results.json`
+to stay as the self-play artifact, preserve that path and move only the LeWM
+default.
+
+### Task 4: Make exp78 falsification and performance actionable
+
+Problem: the default TL-only exp78 run exits 0 but prints a failed falsification
+verdict in this environment because distractor targets exceed the <=1s search
+gate. This is exactly the kind of research result that should turn into either
+an optimization slice or an explicit revised gate.
+
+Owned files:
+
+- `experiments/exp78_rule_induction.py`
+- `tensor_logic/research/utils.py`
+- `tests/test_exp81.py` or a new `tests/test_exp78.py`
+- `docs/exp78_rule_induction_spec.md`
+- `notes/EXPERIMENTS.md` only if the claim/gate is intentionally revised
+
+Acceptance criteria:
+
+- Add a test or script-level strict mode that makes the falsification verdict
+  machine-checkable without parsing human text.
+- Either optimize/prune TL-only distractor search so the default run satisfies
+  the <=1s gate on a normal local machine, or update the spec/results to state
+  the current gate honestly and define the next optimization target.
+- Preserve semantic-equivalence checks; do not trade correctness for speed.
+- The safe validation command writes results to `/tmp`, not the tracked
+  `experiments/exp78_data/results.json`.
+
+Validation:
+
+```bash
+python3 experiments/exp78_rule_induction.py --out /tmp/exp78-default-results.json
+python3 -m pytest tests/test_exp81.py -q
+python3 -m pytest tests/test_tensor_logic_core.py -k "rule or proof" -q
+git status --short
+```
+
+Stop condition: if timing depends too heavily on machine class, make the test
+assert candidate cost or relative speedup instead of wall-clock seconds, then
+record the decision in the spec.
+
+### Task 5: Add FAFSA safety and official-parity gate before user-facing claims
+
+Problem: exp80 is a useful real-world proof-engine prototype, but the wizard is
+worded like an estimator and tells users whether they likely qualify for Pell
+aid. Current tests prove internal invariants and synthetic cases, not official
+ED worked-example parity.
+
+Owned files:
+
+- `experiments/exp80_fafsa_kb.py`
+- `experiments/exp80_fafsa_wizard.py`
+- `experiments/exp80_validate_synthetic.py`
+- `tests/test_exp80.py`
+- New docs file under `docs/` if a validation matrix is added
+
+Acceptance criteria:
+
+- Wizard output clearly states research/demo status, 2024-25 only, Formula A
+  dependent-student only, and not financial-aid advice.
+- User-facing "likely qualify" wording is softened or gated behind an explicit
+  official-parity status.
+- Add a validation matrix distinguishing synthetic invariants, named
+  spot-check cases, and official ED worked examples.
+- Add at least one test that locks the disclaimer/boundary text if the wizard
+  remains interactive.
+- Do not add Formula B/C in this task; the scope is safety and validation
+  boundary, not coverage expansion.
+
+Validation:
+
+```bash
+python3 -m pytest tests/test_exp80.py -q
+python3 experiments/exp80_validate_synthetic.py
+git status --short
+```
+
+Stop condition: if official ED examples must be fetched from the web or manually
+transcribed, stop at the validation matrix and create a separate data-gathering
+task with source citations.
+
+## Work that should not move into this implementation queue yet
+
+- Re-running exp53/exp54 headline package downloads. Those need frozen package
+  versions, safe extraction, and network approval first.
+- Remote/Kaggle SFT or adapter runs. The run protocol is not yet enforced and
+  adapter pointers are missing.
+- Exp83 full training. It is exploratory, has an undeclared SciPy dependency,
+  and its checked-in result already shows the probe gate did not pass.
+- Arbitrary-arity proof expansion. The canonical `Atom` shape supports it, but
+  the proof and evaluator consumers are still explicitly binary.
+- Public serving of the HTTP API or workbench. The risk register's include and
+  timeout guardrails should land first.
+
+## Handoff
+
+Changed files:
+
+- `docs/overnight/2026-05-07-30min-extension/tensor-experiments-action-plan.md`
+
+Product code changed: no.
+
+External services used: no.
+
+PR created: no, out of scope.
+
+Commit created: no. Current HEAD remains
+`5565791a8c888511bbbff1107d2d357164f88baa`.
+
+Required validation command:
+
+```bash
+git status --short
+```
+
+Observed result after the report write:
+
+```text
+?? docs/overnight/
+```
+
+The exact untracked file is:
+
+```text
+?? docs/overnight/2026-05-07-30min-extension/tensor-experiments-action-plan.md
+```
+
+Blockers:
+
+- No blocker to writing the report.
+- Local docs-only commit was attempted and blocked by sandbox permissions:
+  `git add docs/overnight/2026-05-07-30min-extension/tensor-experiments-action-plan.md`
+  failed with `fatal: Unable to create
+  '/Users/jwalinshah/projects/tensor/experiments/.git/worktrees/tensor-experiments-30min-action-plan/index.lock':
+  Operation not permitted`.

--- a/docs/overnight/tensor-experiments-architecture-map.md
+++ b/docs/overnight/tensor-experiments-architecture-map.md
@@ -1,0 +1,510 @@
+# tensor-experiments architecture-map audit
+
+Date: 2026-05-07
+Queue item: `tensor-experiments-architecture-map`
+Branch: `codex/goal-tensor-experiments-architecture-map`
+
+## Scope and constraints
+
+This audit is read-only with one allowed write: this report at
+`docs/overnight/tensor-experiments-architecture-map.md`. I did not edit product
+code, generated data, secrets, external services, deploys, pushes, PRs, or
+external trackers.
+
+Initial dirty state:
+
+```text
+$ git status --short
+```
+
+No output. The worktree started clean.
+
+## Commands run
+
+Architecture and repo mapping:
+
+```bash
+llm-tldr tree .
+rtk read CLAUDE.md
+rtk read README.md
+rtk read pyproject.toml
+rtk read docs/agents/domain.md
+rg --files -g 'CONTEXT.md' -g 'CONTEXT-MAP.md' -g 'docs/adr/**'
+llm-tldr search "if __name__|def main|argparse|uvicorn|FastAPI|Flask|click" .
+llm-tldr search "from tensor_logic|import tensor_logic" .
+python tools/code_index.py --dump
+python3 tools/code_index.py --dump
+rg --files tensor_logic tests demos web_workbench tools | sort
+llm-tldr search "class |def " tensor_logic
+python3 -m tensor_logic ingest-python tensor_logic
+python3 -m tensor_logic ingest-python tensor_logic/research
+python3 -m tensor_logic ingest-python web_workbench
+```
+
+Targeted source reads:
+
+```bash
+rtk read tensor_logic/__init__.py
+rtk read tensor_logic/core.py
+rtk read tensor_logic/program.py
+rtk read tensor_logic/language.py
+rtk read tensor_logic/file_format.py
+rtk read tensor_logic/execution.py
+rtk read tensor_logic/proofs.py
+rtk read tensor_logic/provenance.py
+rtk read tensor_logic/rules.py
+rtk read tensor_logic/closure.py
+rtk read tensor_logic/ingest.py
+rtk read tensor_logic/repo_graph_view.py
+rtk read tensor_logic/http_api.py
+rtk read tensor_logic/optimize.py
+rtk read tensor_logic/reason.py
+rtk read tensor_logic/research/utils.py
+rtk read tensor_logic/research/constants.py
+rtk read tensor_logic/research/slot_attention.py
+rtk read tools/code_index.py
+rtk read web_workbench/server.py
+rtk read docs/superpowers/specs/2026-05-04-rule-language-shape.md
+rtk read .github/workflows/ci.yml
+```
+
+Test and usage evidence:
+
+```bash
+llm-tldr search "def test_" tests
+rtk read tests/test_tensor_logic_core.py
+rtk read tests/test_reason.py
+rtk read tests/test_web_workbench.py
+rtk read tests/test_code_index.py
+rtk read tests/test_packaging_ci.py
+rg "from experiments|import experiments|from phase_training|import phase_training" -n .
+rg "from tensor_logic.research|import tensor_logic.research" experiments tests
+rg "from tensor_logic import|from tensor_logic\\." experiments demos tests web_workbench
+rg "^def |^class |if __name__ ==" experiments/exp79_lewm_tl.py experiments/exp80_fafsa_kb.py experiments/exp81_optimize_rule_induction.py experiments/exp83_slot_attention.py
+rg "^def |^class |if __name__ ==" phase_training
+rg "_execute_command|execute_command\\(" tensor_logic tests web_workbench experiments demos -n
+rg "tensor_logic\\.core|from tensor_logic.core|import tensor_logic.core" .
+rg "sys\\.path\\.insert|sys\\.path\\.append" experiments demos tests web_workbench phase_training tensor_logic -n
+rg "from scipy|import scipy|transformers|mlx|sklearn|numpy|matplotlib" experiments tensor_logic tests pyproject.toml -n
+rg "parse_rule\\(|RuleParser|<tl_rule|rule .*:=" -n tensor_logic demos experiments tests docs
+```
+
+Notes:
+
+- `python tools/code_index.py --dump` failed because `python` is not available in this local shell.
+- `python3 tools/code_index.py --dump` succeeded and produced the symbol dump used below.
+- `rg --files docs/overnight` failed before this report was created because the directory did not exist.
+
+## Domain docs and decisions found
+
+`docs/agents/domain.md` says to read `CONTEXT.md`, `CONTEXT-MAP.md`, and
+`docs/adr/` when present. The targeted `rg --files` command found none of those
+files in this checkout, so this audit used `README.md`, `CLAUDE.md`,
+`notes/EXPERIMENTS.md`, and `docs/superpowers/specs/*` as the available domain
+and decision evidence.
+
+The most directly relevant design doc is
+`docs/superpowers/specs/2026-05-04-rule-language-shape.md`. It defines
+`tensor_logic.program.Atom` and `tensor_logic.program.Rule` as the canonical rule
+shape, while treating `<tl_rule ...>` parsing as an adapter surface.
+
+## Architecture map
+
+### Reusable package surface
+
+The reusable library lives under `tensor_logic/` and is packaged by
+`pyproject.toml` with `tool.setuptools.packages.find.include = ["tensor_logic*"]`.
+Runtime dependency is only `torch>=2.0`; dev extras include `pytest`, `numpy`,
+and `matplotlib`.
+
+Current package root:
+
+- `tensor_logic/__init__.py` re-exports core semantics, proof APIs, file loading,
+  execution, HTTP helpers, ingest helpers, provenance helpers, proof-tree viewer,
+  and repo-graph helpers.
+- `tensor_logic/core.py` exists as a documented narrow import surface for
+  "programs, proofs, closure" without HTTP, ingest, or repo-graph adapters.
+- `rg "tensor_logic\\.core|from tensor_logic.core|import tensor_logic.core" .`
+  returned no users, so the narrow surface is available but not adopted locally.
+
+Important boundary: importing from `tensor_logic` pulls in adapter modules such
+as `http_api`, `ingest`, and `repo_graph_view` through `__init__.py`. That is
+convenient for demos, but it makes the package root a full-toolkit interface,
+not a minimal reasoning-core interface.
+
+### Core semantic layer
+
+Core tensor-logic semantics are concentrated in:
+
+- `tensor_logic/language.py`: finite `Domain`, tensor `Relation`, expression AST
+  nodes, `evaluate_expr`, `Relation.eval`, and `Relation.fixpoint`.
+- `tensor_logic/program.py`: mutable `Program`, canonical `Atom`, `Rule`,
+  `FactSource`, and `RuleParser` for human-authored `.tl` rule syntax.
+- `tensor_logic/closure.py`: dense and BFS reachability implementations.
+- `tensor_logic/semirings.py`: boolean, GF(2), and reliability matmul helpers.
+
+The core is small and readable. `Program.rule()` currently does two jobs: it
+installs an executable tensor expression on the target relation and also stores
+one or more canonical `Rule` values for proof search. That matches the
+2026-05-04 rule-language design: expression operators remain evaluation syntax,
+while proof search consumes logical atom conjunctions.
+
+### Rule adapter and provenance layer
+
+There are two rule syntax surfaces:
+
+- `.tl` program syntax, parsed in `tensor_logic/program.py` and
+  `tensor_logic/file_format.py`, for statements like
+  `rule ancestor(x,z) := (parent(x,z) + ancestor(x,y) * parent(y,z)).step()`.
+- LM/tool tag syntax, parsed in `tensor_logic/rules.py`, for
+  `<tl_rule head="..." body="..."></tl_rule>`.
+
+`tensor_logic/rules.py` now imports `Atom` and `Rule` from
+`tensor_logic.program`, which is consistent with the canonical-rule design. Older
+experiments still contain local copies of `<tl_rule>` parsing logic, including
+`experiments/exp65_rule_chain_joins.py`, `experiments/exp66_datalog_negation.py`,
+and `experiments/exp67_provenance.py`. Those are historical experiment records,
+not necessarily active architecture, but they are a stale-assumption source when
+future agents search examples.
+
+`tensor_logic/provenance.py` is graph-dict based and consumes `Rule` values from
+the adapter parser. `tensor_logic/proofs.py` is `Program` based and consumes
+rules stored on `Program.rules`. These are related proof surfaces but not the
+same execution path.
+
+### File, execution, CLI, and HTTP adapters
+
+Adapter layering is mostly clean:
+
+- `tensor_logic/file_format.py` loads `.tl` files into `LoadedProgram` and
+  `Command` values.
+- `tensor_logic/execution.py` executes `Command` values against a `Program` and
+  renders `CommandResult`.
+- `tensor_logic/__main__.py` implements `python -m tensor_logic` subcommands:
+  `run`, `query`, `prove`, `ingest-python`, `repl`, `repo-graph`, and `serve`.
+- `tensor_logic/http_api.py` exposes in-process helpers plus a
+  `ThreadingHTTPServer` handler.
+- `web_workbench/server.py` serves static files and shells out to
+  `python -m tensor_logic` for local workbench actions.
+
+The cleanest ownership line is:
+
+```text
+file_format -> execution -> CLI/HTTP/workbench adapters
+```
+
+There is one small duplication: `tensor_logic/__main__.py` has a private
+`_execute_command()` wrapper, and `tensor_logic/http_api.py` has another private
+`_execute_command()` wrapper. `rg` found the HTTP version is not referenced by
+tests or other modules. The public shared function is already
+`tensor_logic.execution.execute_command()`.
+
+### Repo-ingest and repo-graph view
+
+`tensor_logic/ingest.py` converts local Python imports into a `.tl` dependency
+program. `python3 -m tensor_logic ingest-python tensor_logic` produced a graph
+with direct imports such as:
+
+- `__main__` -> `execution`, `file_format`, `http_api`, `ingest`,
+  `program`, `repo_graph_view`
+- `execution` -> `file_format`, `program`, `proof_result`
+- `http_api` -> `execution`, `file_format`, `ingest`
+- `proof_result` -> `proofs`
+- `proofs` -> `program`
+- `rules` -> `program`
+- `research_constants` -> `research_utils`
+
+This import graph supports the observed layering: core modules point inward to
+language/program/proofs; CLI and HTTP point outward to adapters.
+
+`tensor_logic/repo_graph_view.py` is an adapter over `.tl` dependency programs,
+not a core proof engine. It loads a file, builds adjacency, and delegates proofs
+to `tensor_logic.proofs.prove()`.
+
+### Optimization and reasoning loop
+
+`tensor_logic/optimize.py` is a generic propose/evaluate/accept loop with an
+`EvalResult` dataclass and Pareto frontier helpers. It has a tight test file
+(`tests/test_optimize.py`) and no direct dependency on experiments.
+
+`tensor_logic/reason.py` is an application of that optimize loop for EAV-style
+observation facts. It also has its own subprocess entrypoint:
+`python -m tensor_logic.reason --query ... --facts-file ...`. This module is
+inside the reusable package, but its docstring names `memjuice reason`, which is
+external to this repo. That is a real ownership crossing: the tensor package
+contains an adapter intended for another workspace tool.
+
+### Research helpers and experiments
+
+`tensor_logic/research/` is the emerging shared research layer:
+
+- `research/utils.py`: `Schema`, random world generation, rule enumeration,
+  body application, F1, semantic equivalence, and induction helpers.
+- `research/constants.py`: toy schemas and gold rules.
+- `research/slot_attention.py`: `SlotAttention` and `VisualEncoder`.
+
+Active experiments consume this layer:
+
+- `experiments/exp78_rule_induction.py`
+- `experiments/exp79_lewm_tl.py`
+- `experiments/exp79_self_play_loop.py`
+- `experiments/exp81_optimize_rule_induction.py`
+- `experiments/exp83_slot_attention.py`
+- `tests/test_exp81.py`
+
+This is a useful extraction: repeated induction and schema utilities are no
+longer only copied between scripts. The newer perception/TL experiments have not
+been fully extracted, though. `experiments/exp79_lewm_tl.py` and
+`experiments/exp83_slot_attention.py` duplicate scene constants, frame
+generation, relation computation, TL state building, object removal, and
+derived-relation evaluation. `exp83` imports `SlotAttention` and `VisualEncoder`
+from `tensor_logic.research.slot_attention`, but keeps most scene/TL wiring
+local.
+
+### Script islands
+
+The repo still has many standalone script islands:
+
+- `experiments/`: 99 files from early one-off probes through later exp80+ work.
+- `phase_training/`: embodied/object-permanence training scripts.
+- `demos/`: runnable examples for the package and older learning demos.
+- `web_workbench/`: local browser shell.
+- `tools/code_index.py`: stdlib AST indexer for `tensor_logic/`.
+
+The script island pattern is intentional for a learning/research repo, but it
+means module ownership is not uniform. `tests/test_exp79.py`, `tests/test_exp80.py`,
+and `tests/test_exp81.py` import selected experiment scripts directly, promoting
+those scripts from disposable notebooks to semi-owned modules.
+
+## Entrypoints
+
+Primary local entrypoints:
+
+- `python3 -m tensor_logic run <file.tl>`
+- `python3 -m tensor_logic query <file.tl> <relation> <arg> <arg> [--recursive]`
+- `python3 -m tensor_logic prove <file.tl> <relation> <arg> <arg> [--recursive] [--why-not] [--format tree|json]`
+- `python3 -m tensor_logic ingest-python <path>`
+- `python3 -m tensor_logic repl`
+- `python3 -m tensor_logic repo-graph <file.tl>`
+- `python3 -m tensor_logic serve --host 127.0.0.1 --port 8000`
+- `python3 -m tensor_logic.reason --query ... --facts-file ...`
+- `python3 web_workbench/server.py --host 127.0.0.1 --port 8080`
+- `python3 tools/code_index.py --dump|--lookup|--status|--rebuild`
+- Many `python3 experiments/exp*.py` and `python3 demos/*.py` scripts.
+
+Local shell note: plain `python` was not available here. Commands that use
+`sys.executable` or CI's configured Python are fine, but local docs that say
+`python` may need a shell with that alias or a switch to `python3`.
+
+## Validation surface observed
+
+The repo-level test contract appears in three places:
+
+- `CLAUDE.md`: `pytest tests/ -v`
+- `README.md`: `python -m pip install -e ".[dev]"` and
+  `python -m pytest tests/ -v`
+- `.github/workflows/ci.yml`: installs `".[dev]"` and runs
+  `python -m pytest tests/ -v`
+
+Test ownership is broad:
+
+- `tests/test_tensor_logic_core.py` covers closure, rule parsing, program rules,
+  file loading, proofs, negative proofs, source-backed facts, REPL, includes,
+  CLI/HTTP parity, repo ingest, repo-graph helpers, proof-tree rendering, and
+  command execution.
+- `tests/test_optimize.py` covers the generic optimize loop.
+- `tests/test_reason.py` covers the EAV reason adapter.
+- `tests/test_web_workbench.py` covers workbench subprocess behavior and parity
+  with `tensor_logic.http_api`.
+- `tests/test_code_index.py` covers the local AST indexer.
+- `tests/test_exp79.py`, `tests/test_exp80.py`, and `tests/test_exp81.py` cover
+  selected experiment modules.
+
+The requested validation for this queue item is only:
+
+```bash
+git status --short
+```
+
+Full pytest was not run because this was a read-only architecture audit and the
+Goal Pack supplied `git status --short` as the required validation.
+
+## Stale assumptions and ownership risks
+
+1. Package-root ownership is broad.
+
+   Evidence: `tensor_logic/__init__.py` re-exports HTTP, ingest, repo-graph, and
+   proof-tree helpers, while `tensor_logic/core.py` advertises a narrow surface.
+   No local code imports `tensor_logic.core`. Future library consumers may
+   import the full toolkit when they only need core semantics.
+
+2. Rule language is mostly consolidated, but historical examples can mislead.
+
+   Evidence: `docs/superpowers/specs/2026-05-04-rule-language-shape.md` says
+   `program.Atom` and `program.Rule` are canonical. Current
+   `tensor_logic/rules.py` imports those canonical dataclasses. Older
+   experiments still contain local `<tl_rule>` parser/evaluator copies, so code
+   search surfaces stale parser shapes beside the canonical adapter.
+
+3. `tensor_logic/reason.py` crosses repo ownership.
+
+   Evidence: its docstring calls it the `memjuice reason` subprocess entrypoint,
+   but it lives in the `tensor_logic` package and is packaged with the reusable
+   library. That may be correct as a dependency, but the owner and compatibility
+   contract should be explicit.
+
+4. Research helpers are only partially extracted.
+
+   Evidence: exp78/79/81/83 use `tensor_logic.research.utils`, and exp83 uses
+   `tensor_logic.research.slot_attention`, but exp79 and exp83 duplicate most of
+   the synthetic-scene and TL-derived-relation wiring. If exp83 becomes active,
+   this duplication is likely to drift.
+
+5. Experiment dependency surface is wider than package metadata.
+
+   Evidence: `pyproject.toml` declares runtime `torch` and dev
+   `pytest/numpy/matplotlib`; experiments also import `scipy`, `transformers`,
+   `mlx_lm`, `peft`, `datasets`, `accelerate`, and other optional packages. This
+   is fine for historical scripts, but not for scripts promoted into tests or
+   reusable workflows.
+
+6. Script-mode path mutation remains common.
+
+   Evidence: `rg "sys.path.insert|sys.path.append"` found path insertion in
+   demos, tests, and several experiment scripts. This supports direct local
+   script execution, but it blurs whether modules should be run after editable
+   install, from repo root, or as standalone files.
+
+7. Docs lag the current experiment shape.
+
+   Evidence: README's repo layout says `experiments/ exp1..exp54`; the checkout
+   has 99 files under `experiments/` and experiments through exp83. README also
+   describes `demos/` as "5 headline runnable demos" while the directory has 8
+   demo scripts. This is not a code defect, but it is stale navigation for future
+   architecture work.
+
+8. The workbench and HTTP API are sibling adapters, not one shared server.
+
+   Evidence: `web_workbench/server.py` shells out to `python -m tensor_logic`,
+   while `tensor_logic/http_api.py` provides direct in-process helpers and a JSON
+   HTTP server. Tests assert parity for important proof behavior, which mitigates
+   the split. The architectural decision is still implicit.
+
+## Next safe work
+
+1. Document and adopt the import-surface split.
+
+   Acceptance criteria:
+
+   - README or `docs/agents/domain.md` states when consumers should use
+     `tensor_logic.core` versus `tensor_logic`.
+   - At least one pure core demo or test imports from `tensor_logic.core`.
+   - Package root remains backwards compatible.
+
+   Validation:
+
+   ```bash
+   python3 -m pytest tests/test_tensor_logic_core.py -v
+   python3 -m pytest tests/test_packaging_ci.py -v
+   ```
+
+2. Mark historical `<tl_rule>` parser copies as legacy or route active examples
+   to `tensor_logic.rules.parse_rule`.
+
+   Acceptance criteria:
+
+   - Active docs point future agents to `tensor_logic.rules.parse_rule` and
+     `tensor_logic.program.Rule`.
+   - Historical experiment-local parsers are either explicitly labeled as
+     archived experiment code or no longer used by active tests.
+   - The 2026-05-04 rule-language spec remains the canonical contract.
+
+   Validation:
+
+   ```bash
+   python3 -m pytest tests/test_tensor_logic_core.py -k "rule or provenance or proof" -v
+   ```
+
+3. Extract shared scene/TL wiring for exp79 and exp83 only if exp83 continues.
+
+   Acceptance criteria:
+
+   - Shared constants, `generate_sequence`, `compute_relations`,
+     `generate_labeled_frames`, `build_tl_state`, `remove_object`, and
+     `compute_gt_derived` live in a `tensor_logic.research` module.
+   - Exp79 and exp83 keep experiment-specific model/training code local.
+   - No generated data files are touched.
+
+   Validation:
+
+   ```bash
+   python3 -m pytest tests/test_exp79.py -v
+   python3 -m pytest tests/test_tensor_logic_core.py -v
+   ```
+
+4. Make the `tensor_logic.reason` ownership contract explicit.
+
+   Acceptance criteria:
+
+   - A short doc or module comment states whether `tensor_logic.reason` is a
+     stable package feature or a memjuice adapter kept here for locality.
+   - If stable, README includes the subprocess entrypoint.
+   - If adapter-local, tests still cover it but package exports do not imply a
+     broader public API.
+
+   Validation:
+
+   ```bash
+   python3 -m pytest tests/test_reason.py tests/test_optimize.py -v
+   ```
+
+5. Normalize local Python command examples.
+
+   Acceptance criteria:
+
+   - Local docs consistently use `python3` or explain that `python` is provided
+     by the activated environment.
+   - CI can keep `python` because `actions/setup-python` provides it.
+
+   Validation:
+
+   ```bash
+   python3 tools/code_index.py --status
+   python3 -m pytest tests/test_code_index.py -v
+   ```
+
+## Handoff
+
+Files changed by this queue item:
+
+- `docs/overnight/tensor-experiments-architecture-map.md`
+
+Commit/PR status:
+
+- HEAD SHA at handoff: `5565791a8c888511bbbff1107d2d357164f88baa`
+- No commit created.
+- No PR created.
+
+Required validation:
+
+```bash
+git status --short
+```
+
+Result: exited 0 with expected untracked report output:
+
+```text
+?? docs/overnight/
+```
+
+Scoped status confirms the only changed file:
+
+```text
+?? docs/overnight/tensor-experiments-architecture-map.md
+```
+
+Blockers:
+
+- None for the requested audit.
+- Full test validation was intentionally not run; the queue item requested
+  `git status --short`.

--- a/docs/overnight/tensor-experiments-dependency-surface.md
+++ b/docs/overnight/tensor-experiments-dependency-surface.md
@@ -1,0 +1,252 @@
+# tensor-experiments dependency-surface audit
+
+Queue item: `tensor-experiments-dependency-surface`  
+Date: 2026-05-07  
+Branch: `codex/goal-tensor-experiments-dependency-surface`  
+Starting HEAD: `5565791`
+
+## Scope and method
+
+This was a read-only dependency-surface audit. I did not change product code,
+generated data, secrets, external services, deploys, pushes, or PR state. The
+only intended tracked change is this report.
+
+Commands and observations used as local evidence:
+
+- `git status --short --branch` reported `## codex/goal-tensor-experiments-dependency-surface` with no tracked dirty files at the start.
+- `llm-tldr tree .` showed a Python research repo with `tensor_logic/`, `experiments/`, `demos/`, `phase_training/`, `tests/`, `tools/`, `web_workbench/`, and committed experiment data.
+- `rg --files -g 'requirements*.txt' -g 'poetry.lock' -g 'uv.lock' -g 'Pipfile*' -g 'environment*.yml' -g 'conda*.yml' -g '.python-version' -g '.env*' -g 'setup.py' -g 'setup.cfg' -g 'tox.ini' -g 'noxfile.py' -g '.github/**'` found `.github/workflows/ci.yml` but no lockfile, requirements file, env file, setup file, tox file, or nox file.
+- `python3 --version` returned `Python 3.12.8`; CI pins Python `3.11`.
+- `python3 -m pytest tests/test_packaging_ci.py -q` passed: `3 passed in 0.01s`.
+- `python3 -m pytest tests/test_web_workbench.py -q` passed: `2 passed in 4.57s`.
+- `python3 -m pytest tests/ -q` passed: `140 passed in 34.41s`.
+- `python3 tools/code_index.py --status` initially returned exit 1 with `stale: index.json is missing or older than source files`; after the full test suite it returned exit 0 with `fresh: .../tools/index.json`, because tests generated the ignored index.
+- `git status --short --ignored` after tests showed ignored local artifacts: `.pytest_cache/` and `tools/index.json`.
+
+## Repo purpose
+
+`tensor-experiments` is a Python 3.11+ tensor-logic research repo. The reusable
+package is `tensor_logic/`; the rest of the repo is a mix of demos, experiment
+scripts, phase-training prototypes, run protocols, notes, and tracked result
+artifacts. `README.md` explicitly says the repo now also serves as the shared
+`tensor_logic` library dependency for sibling projects such as `fafsa-engine`
+and future `officeqa-*` projects.
+
+## Declared dependency surface
+
+The declared install surface is intentionally small:
+
+- `pyproject.toml` declares build requirements `setuptools>=69` and `wheel`.
+- `pyproject.toml` declares runtime `torch>=2.0`.
+- `pyproject.toml` declares dev extras `matplotlib>=3.7`, `numpy>=1.24`, and `pytest>=8.0`.
+- `pyproject.toml` uses `setuptools` package discovery for `tensor_logic*` only, so `demos/`, `experiments/`, `phase_training/`, `tools/`, and `web_workbench/` are repo scripts, not installed packages.
+- `.github/workflows/ci.yml` installs `python -m pip install -e ".[dev]"` and runs `python -m pytest tests/ -v`.
+- `README.md` documents the same worker validation commands.
+- `tests/test_packaging_ci.py` asserts the current packaging contract: `torch` runtime, `pytest`/`numpy`/`matplotlib` dev, package include `tensor_logic*`, CI validation, and README validation docs.
+
+There is no lockfile or constraints file in this worktree. Dependency versions
+are lower-bounded only, so current reproducibility depends on PyPI state and the
+local/CI Python version.
+
+## Observed imports
+
+An AST import scan across `tensor_logic`, `demos`, `experiments`,
+`phase_training`, `tests`, `web_workbench`, and `tools` found:
+
+- `torch`: 101 files.
+- `numpy`: 4 files.
+- `matplotlib`: 2 files.
+- `transformers`: 5 files.
+- `peft`: 1 file.
+- `datasets`: 1 file.
+- `mlx_lm`: 1 file.
+- `scipy`: 1 file.
+- `tqdm`: 1 file.
+
+Non-stdlib modules not declared in `pyproject.toml` and not obvious local imports:
+
+- `transformers`: `experiments/exp32_attention_compose.py`, `experiments/exp36_code_dependency.py`, `experiments/exp60d_sft.py`, `experiments/exp77_schema_rule_construction.py`, `experiments/exp78_rule_induction.py`.
+- `peft`, `datasets`, `tqdm`: `experiments/exp60d_sft.py`.
+- `mlx_lm`: `experiments/exp78_rule_induction.py`.
+- `scipy`: `experiments/exp83_slot_attention.py`.
+
+This split is mostly experiment-only, but it is not encoded as optional extras,
+so future agents cannot install the right surface from package metadata alone.
+
+## Runtime entrypoints and scripts
+
+Important local entrypoints:
+
+- `tensor_logic/__main__.py` provides CLI commands: `run`, `query`, `prove`, `ingest-python`, `repl`, `repo-graph`, and `serve`.
+- `tensor_logic/http_api.py` uses only stdlib HTTP server primitives and exposes JSON POST handlers for ingest/run/query/prove operations.
+- `web_workbench/server.py` serves static files and shells out to `[sys.executable, "-m", "tensor_logic"]` using a temporary `.tl` file.
+- `web_workbench/README.md` documents `python web_workbench/server.py --host 127.0.0.1 --port 8080`.
+- `tensor_logic/reason.py` is a subprocess entrypoint for `python -m tensor_logic.reason --query ... --facts-file ...`, but the current proposer is a deterministic keyword fallback and does not call an LLM despite accepting `--model`.
+- `tools/code_index.py` is a stdlib AST indexer that writes `tools/index.json`; `.gitignore` ignores that file.
+- `experiments/exp60d_sft.py` is a LoRA SFT runner with explicit install guidance: `pip install torch transformers peft datasets accelerate`.
+- `experiments/exp78_rule_induction.py` is TL-only by default and uses `transformers` or `mlx_lm` only behind `--lm`.
+- `experiments/exp53_real_imports.py` and `experiments/exp54_big_imports.py` run `python -m pip download --no-deps --no-binary :all:` against PyPI and unpack third-party archives into temp dirs.
+- `experiments/exp79_lewm_tl.py` and `experiments/exp83_slot_attention.py` write experiment outputs under `experiments/exp79_data/` and `experiments/exp83_slot_data/`.
+
+## Generated artifacts, caches, and local-only state
+
+Tracked artifacts already in git:
+
+- `experiments/exp60_data/train.jsonl`, `eval.jsonl`, and `eval_hard.jsonl`.
+- `experiments/exp76_data/train.jsonl`, `eval.jsonl`, `eval_hard.jsonl`, and `train_paraphrased.jsonl`.
+- `experiments/exp78_data/results.json`.
+- `experiments/exp79_data/results.json` and `complexity_curve.png`.
+- `experiments/exp80_spot_check_cases.json`.
+- `experiments/exp83_slot_data/results.json` and `complexity_curve.png`.
+
+Ignored/generated local state:
+
+- `.gitignore` ignores `.pytest_cache/`, `.ruff_cache/`, `.venv/`, `.uv/`, `*.pt`, `*.pth`, `/.cocoindex_code/`, `tools/index.json`, `dist/`, `build/`, and `*.egg-info/`.
+- `tests/test_code_index.py` includes a CLI test that runs `python tools/code_index.py --rebuild`; running the full suite generates ignored `tools/index.json`.
+- `tools/code_index.py --status` exits 1 on a clean checkout until the ignored index has been generated. `--lookup` and `ensure_fresh()` rebuild it automatically.
+- `experiments/exp79_lewm_tl.py` saves `encoder.pt` and `probe.pt`; those are ignored by `*.pt` and are local-only state.
+- `experiments/exp60d_sft.py` defaults `--out` to `experiments/exp60_data/lora_adapter` and writes adapter files plus `manifest.json`. `.gitignore` does not currently ignore `*.safetensors`, adapter directories, or tokenizer/config JSON created by `save_pretrained()`.
+- `docs/RUN_PROTOCOL.md` says weights should not be committed and that local git should contain result pointers/metrics, not adapters.
+
+## Environment variables and credentials
+
+The code surface I inspected does not require repo-local `.env` files, and the
+lock/env-file search found none. Current credential/API-key references are in
+planning docs, not active package code:
+
+- `docs/superpowers/specs/2026-04-28-fafsa-engine-design.md` and
+  `docs/superpowers/plans/2026-04-28-fafsa-engine.md` mention `FAFSA_LLM`,
+  `FAFSA_LLM_MODEL`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and Ollama URLs for
+  a sibling project design.
+- `experiments/exp78_rule_induction.py` and `experiments/exp60d_sft.py` can
+  trigger Hugging Face model downloads through `from_pretrained()`, but no
+  token variable is hard-coded.
+- `docs/RUN_PROTOCOL.md` describes Kaggle persistence and adapter datasets; no
+  Kaggle credential is stored in the repo.
+
+## Risks and stale assumptions
+
+1. Optional experiment dependencies are not installable by contract. `README.md`
+   and CI validate only `.[dev]`, while active experiments require
+   `transformers`, `peft`, `datasets`, `accelerate`, `tqdm`, `mlx_lm`, and
+   `scipy`. A worker can pass CI and still be unable to reproduce exp60, exp78
+   LM mode, or exp83.
+
+2. There is no lockfile or constraints file. `torch>=2.0`, `numpy>=1.24`,
+   `matplotlib>=3.7`, and `pytest>=8.0` are lower bounds only. CI uses Python
+   3.11, this local run used Python 3.12.8, and model-loading stacks are known
+   to be sensitive to dependency drift.
+
+3. Adapter outputs are under-ignored. `docs/RUN_PROTOCOL.md` says not to commit
+   LoRA weights, but `.gitignore` ignores `*.pt`/`*.pth` and not
+   `*.safetensors` or `experiments/*_data/lora_adapter/`. Running
+   `experiments/exp60d_sft.py` could leave large or sensitive model artifacts
+   visible to `git status`.
+
+4. External-download experiments are not hermetic. `experiments/exp53_real_imports.py`
+   and `experiments/exp54_big_imports.py` shell out to `pip download` and unpack
+   third-party archives from PyPI. This couples results to network/PyPI state
+   and gives future workers a larger external-service and archive-handling
+   surface than the core tests exercise.
+
+5. `tools/code_index.py --status` has clean-checkout ambiguity. A fresh checkout
+   reports "stale" with exit 1 because `tools/index.json` is ignored. That is
+   expected for generated local state, but can look like a failure unless the
+   worker knows to run `--lookup` or `--rebuild`.
+
+6. The web workbench subprocess has no timeout. `web_workbench/server.py` invokes
+   `python -m tensor_logic` synchronously. A hung or expensive command can tie
+   up a request thread; tests cover happy-path behavior, not timeout policy.
+
+7. README demo claims depend on `uv` and a local runtime not declared in
+   `pyproject.toml`. The README uses `uv run --with torch ...` for demos, but
+   `uv` itself is not part of the repo contract.
+
+8. `experiments/exp83_slot_attention.py` exposes `--skip-train` but documents it
+   as "not supported in this PoC yet"; the CLI surface looks more stable than
+   the implementation.
+
+## Validation commands
+
+Commands run during this audit:
+
+- `python3 -m pytest tests/test_packaging_ci.py -q` -> passed, expected pass for packaging/docs/CI contract.
+- `python3 -m pytest tests/test_web_workbench.py -q` -> passed, expected pass for local workbench command wrapper.
+- `python3 -m pytest tests/ -q` -> passed, expected pass for full local suite; generated ignored `.pytest_cache/` and `tools/index.json`.
+- `python3 tools/code_index.py --status` -> expected fail on clean checkout until `tools/index.json` exists; expected pass after `--rebuild` or after the full suite generates it.
+
+Validation candidates for future workers:
+
+- `git status --short` -> expected pass/exit 0; should show only intentional report/doc changes during an audit or be clean after commit.
+- `python -m pip install -e ".[dev]"` -> expected pass in a network-enabled clean environment; not run here because the local suite already had dependencies and this queue item did not authorize external package changes.
+- `python -m pytest tests/ -v` -> expected pass; CI canonical command.
+- `python3 tools/code_index.py --lookup Program` -> expected pass and may generate ignored `tools/index.json`.
+- `python3 tools/code_index.py --status` -> expected fail on fresh checkout if `tools/index.json` is missing, expected pass after lookup/rebuild.
+- `python experiments/exp78_rule_induction.py --max-len 3` -> expected pass without LM extras.
+- `python experiments/exp78_rule_induction.py --lm` -> expected to require `transformers` or use fallback; may download models if dependencies are installed.
+- `python experiments/exp83_slot_attention.py --help` -> expected pass; full run expected to require undeclared `scipy` and nontrivial CPU/MPS time.
+- `python experiments/exp60d_sft.py --skip-train --n-eval 1` -> expected to require undeclared `transformers`/`peft` stack and a model/cache unless guarded.
+
+## Next safe work
+
+1. Add explicit optional extras for experiment families.
+   - Scope: `pyproject.toml`, `README.md`, `tests/test_packaging_ci.py`.
+   - Acceptance: define extras such as `lm`, `sft`, `slot`, and maybe `all-experiments`; README maps exp60/78/83 to extras; packaging test asserts the new contract.
+   - Validation: `python3 -m pytest tests/test_packaging_ci.py -q`.
+
+2. Harden output ignore rules for model artifacts.
+   - Scope: `.gitignore`, `docs/RUN_PROTOCOL.md`, maybe a small packaging/ignore test.
+   - Acceptance: `*.safetensors`, adapter output dirs, tokenizer/model generated files, and known local run outputs are ignored or routed to documented artifact pointers.
+   - Validation: `python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py::test_index_json_is_gitignored -q` plus `git check-ignore` examples for representative adapter files.
+
+3. Make external package-download experiments reproducible/offline-friendly.
+   - Scope: `experiments/exp53_real_imports.py`, `experiments/exp54_big_imports.py`, tests around helper functions.
+   - Acceptance: add `--package-dir` or fixture input mode, record package versions/source archive names, and add safe archive extraction guards.
+   - Validation: unit tests with local temp archives; no network required.
+
+4. Clarify or change code-index status semantics.
+   - Scope: `tools/code_index.py`, `CLAUDE.md`, `tests/test_code_index.py`.
+   - Acceptance: either document that `--status` exits 1 on fresh checkout, or add a `--status --ensure` mode that rebuilds before checking.
+   - Validation: `python3 -m pytest tests/test_code_index.py -q`.
+
+5. Add timeout handling to web workbench subprocesses.
+   - Scope: `web_workbench/server.py`, `tests/test_web_workbench.py`.
+   - Acceptance: `subprocess.run(..., timeout=<small configurable default>)` returns structured timeout JSON and always unlinks the temp `.tl` file.
+   - Validation: `python3 -m pytest tests/test_web_workbench.py -q`.
+
+## Non-goals
+
+- No dependency upgrades or lockfile generation were performed.
+- No experiment was launched, trained, downloaded, or uploaded.
+- No model weights, adapter artifacts, Kaggle datasets, Hugging Face downloads,
+  or PyPI downloads were created intentionally.
+- No product/library code was modified.
+- No external tracker, PR, deployment, or remote job was changed.
+
+## Unknowns
+
+- Whether sibling repos consume `tensor_logic` through editable installs,
+  path dependencies, or copied source.
+- Whether the intended dependency policy is "minimal core only" or "installable
+  reproducible experiment families."
+- Whether `uv` is assumed globally available for all workers.
+- Whether old committed experiment result files are authoritative outputs or
+  just historical snapshots.
+- Whether `.cocoindex_code/` is still used in practice; it is ignored and was
+  not present in this worktree listing.
+- Whether current external model IDs in exp60/77/78 are pinned enough for
+  reproducible morning review.
+
+## Handoff
+
+- Changed tracked file: `docs/overnight/tensor-experiments-dependency-surface.md`.
+- Product code changed: no.
+- Commit: not created; current HEAD remains `5565791`.
+- Push/PR: no, out of scope for this queue item.
+- Blockers: writing the report succeeded, but local commit creation was blocked
+  by sandbox permissions. `git add docs/overnight/tensor-experiments-dependency-surface.md`
+  failed because git could not create
+  `/Users/jwalinshah/projects/tensor/experiments/.git/worktrees/tensor-experiments-dependency-surface/index.lock`.
+  Ignored local artifacts from validation remained after tests (`.pytest_cache/`,
+  `tools/index.json`) because the sandbox policy rejected `rm -rf`; they do not
+  appear in `git status --short`.

--- a/docs/overnight/tensor-experiments-docs-claims.md
+++ b/docs/overnight/tensor-experiments-docs-claims.md
@@ -1,0 +1,310 @@
+# tensor-experiments docs-claims audit
+
+Queue item: `tensor-experiments-docs-claims`
+Branch: `codex/goal-tensor-experiments-docs-claims`
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/tensor-experiments-docs-claims`
+Audit focus: README/docs claims, supported evidence, unsupported claims, and next safe docs work.
+
+## Decision summary
+
+This repo is a Python research workspace plus reusable `tensor_logic` package. The docs are useful and unusually candid about failed experiments, but several claims are now stale or depend on non-local evidence. I made no product-code changes and did not run external downloads, model loads, deploys, pushes, or PR creation.
+
+I wrote only this report. Local validation and demo smoke checks used `python3` because this shell has no `python` command.
+
+## Repo state
+
+- Purpose from `README.md:1-7`: a learning/research project around Tensor Logic and cognition, not a product.
+- Shared-library claim from `README.md:3`: the repo now serves as a shared `tensor_logic` dependency for other workspace projects.
+- Current branch observation: `git status --short --branch` initially printed `## codex/goal-tensor-experiments-docs-claims` with no dirty files.
+- Current HEAD observation: `git rev-parse HEAD` printed `5565791a8c888511bbbff1107d2d357164f88baa`.
+- Remote observation: `git remote -v` points to `https://github.com/jwalin-shah/tensor-logic.git` for fetch and push.
+- Recent history observation: `git log --oneline -5` starts with `5565791 Refactor: shared prove path, exp78 dedupe, reason helpers, core module (#31)`.
+- Structure observation: `llm-tldr tree .` found package code in `tensor_logic/`, many scripts in `experiments/`, demos in `demos/`, test files in `tests/`, and docs under `docs/`, `notes/`, `benchmarks/`, and `web_workbench/`.
+- Experiment surface observation: `git ls-files 'experiments/exp*.py' | wc -l` printed `85`, and `git ls-files 'experiments/exp*.py' | tail -20` includes scripts through `experiments/exp83_slot_attention.py`.
+- Docs planning surface observation: `git ls-files 'docs/superpowers/specs/*.md' 'docs/superpowers/plans/*.md' | wc -l` printed `13`.
+- Dirty-state observation before writing this report: `git status --short` printed nothing.
+
+## Supported claims
+
+These docs claims have direct local support from files and/or commands I ran.
+
+1. `tensor_logic/` is an importable, reusable package.
+   - `pyproject.toml:23-24` packages `tensor_logic*`.
+   - `tensor_logic/__main__.py:13-41` exposes CLI subcommands for `run`, `query`, `prove`, `ingest-python`, `repl`, `repo-graph`, and `serve`.
+   - Command: `python3 -m tensor_logic --help` exited 0 and listed the CLI subcommands.
+
+2. Worker validation is encoded in README, CI, and a packaging test.
+   - `README.md:85-92` documents `python -m pip install -e ".[dev]"` and `python -m pytest tests/ -v`.
+   - `.github/workflows/ci.yml:24-30` runs the same install and test commands on GitHub Actions.
+   - `tests/test_packaging_ci.py:16-42` asserts the pyproject, CI workflow, and README validation contract.
+   - Command: `python3 -m pytest tests/test_packaging_ci.py -q` passed: `3 passed in 0.01s`.
+
+3. The `tensor_logic` core has real local test coverage.
+   - `tests/test_tensor_logic_core.py` covers queries, proof trees, negative proof behavior, includes, recursion, and source locations.
+   - Command: `python3 -m pytest tests/test_tensor_logic_core.py -q` passed: `54 passed in 14.73s`.
+
+4. The web workbench docs match the server shape, with one portability caveat noted below.
+   - `web_workbench/README.md:1-13` describes a local browser shell that writes editor contents to a temp `.tl` file and invokes `python -m tensor_logic`.
+   - `web_workbench/server.py:53-83` writes a temporary `.tl` file and uses `sys.executable -m tensor_logic`.
+   - Command: `python3 -m pytest tests/test_web_workbench.py -q` passed: `2 passed in 9.83s`.
+
+5. The main README's demo inventory is mostly runnable locally with `python3`.
+   - `README.md:94-107` lists eight demos and says they run on CPU in seconds to a few minutes.
+   - Commands run successfully: `python3 demos/transitive_closure.py`, `python3 demos/tensor_language.py`, `python3 demos/program_rules.py`, `python3 demos/provenance_kb.py`, `python3 demos/train_kg.py`, `python3 demos/joint_lm_kg.py`, `python3 demos/throwing.py`, and `python3 demos/catastrophic_forgetting.py`.
+   - Sample outputs included transitive-closure fixpoint output, program-rule queries, provenance proof trees, KG training to 1.000 accuracy, throwing final MSE `0.0218`, joint LM+KG final cell-wise accuracy `1.000`, and EWC retaining Task A at `0.998`.
+
+6. The proof/reasoning feature claims are grounded in code, not only prose.
+   - `tensor_logic/program.py:33-90` implements domains, relations, facts, rules, queries, and fixpoints.
+   - `tensor_logic/proofs.py:35-85` implements positive and negative proof entrypoints.
+   - `tensor_logic/closure.py:6-46` implements dense and BFS reachability closures.
+   - `README.md:73` claims named-index language, dense/sparse closure, Datalog-style joins, stratified negation, provenance proof trees, and semiring helpers; this is directionally supported by package files and tests.
+
+7. The exp78 spec and checked-in results are mostly aligned.
+   - `docs/exp78_rule_induction_spec.md:21-29` defines the TL-only and LM-pruner falsification criteria.
+   - `docs/exp78_rule_induction_spec.md:103-109` lists expected deliverables including `experiments/exp78_rule_induction.py` and `experiments/exp78_data/results.json`.
+   - `experiments/exp78_rule_induction.py:51-142` implements `lm_prune()` with MLX/transformers fallback behavior.
+   - `experiments/exp78_data/results.json` exists and shows `f1: 1.0`, `semantic_equiv: 1.0`, and search times under 1 second for the listed targets; the distractor `uncle` row reports `pruner_speedup: 14.07`.
+
+8. The exp79 implementation exists despite one stale design-doc status line.
+   - `docs/superpowers/specs/2026-04-28-exp79-lewm-tl-design.md:1-6` says status is "pending implementation".
+   - `experiments/exp79_lewm_tl.py:1-14` exists and describes the implemented experiment.
+   - `experiments/exp79_lewm_tl.py:528-599` contains a runnable `main()` that writes `experiments/exp79_data/results.json`.
+   - `experiments/exp79_data/results.json` exists.
+
+9. A broad local suite, excluding one model-dependent proposer smoke test, passes.
+   - Command: `python3 -m pytest tests/ -q -k 'not make_proposer'` passed: `139 passed, 1 deselected in 33.22s`.
+   - The deselected test is `tests/test_exp81.py::test_make_proposer_returns_valid_json`, which calls the LM proposer path through `make_proposer()`.
+
+## Partially supported or stale claims
+
+1. README's headline numeric tables are plausible but not locally reproducible from checked-in result artifacts alone.
+   - `README.md:11-25` claims a 3-scalar recurrence generalizes to eight OSS import graphs, with package-level F1 numbers.
+   - `README.md:27-40` claims larger-package F1 numbers up to `n=1,532`.
+   - `experiments/exp53_real_imports.py:1-20` and `experiments/exp54_big_imports.py:1-15` describe pipelines that download package source tarballs with `pip download`, train models, and compute those tables.
+   - There is no checked-in `experiments/exp53_data/results.json` or `experiments/exp54_data/results.json`; `git ls-files 'experiments/exp*_data/results.json'` returned only exp78, exp79, and exp83 results.
+   - Risk: the README presents fixed numeric claims whose reproduction depends on current package versions and network downloads unless frozen manifests are added.
+
+2. README's "Repo layout" is stale.
+   - `README.md:111-115` says `experiments/ exp1..exp54`.
+   - Local command output shows 85 `experiments/exp*.py` files, including scripts through `exp83`.
+   - `notes/EXPERIMENTS.md:9-11` logs recent experiment rows 80, 79, and 78, so the stale layout is isolated mostly to README.
+
+3. README describes "5 headline runnable demos" while its table lists eight demo files.
+   - `README.md:57-69` lists eight demo files.
+   - `README.md:111-113` says `demos/` contains "5 headline runnable demos".
+   - Interpretation: five may be the conceptual ladder in `README.md:118-124`, but the wording can confuse workers deciding what is canonical.
+
+4. The exp79 design-doc gate does not match current code and results.
+   - Design doc gate: `docs/superpowers/specs/2026-04-28-exp79-lewm-tl-design.md:63-64` says above/left_of validation accuracy must be at least 90%.
+   - Current code gate: `experiments/exp79_lewm_tl.py:568-570` uses at least 70% for above/left_of and prints a Slot Attention suggestion below that.
+   - Result file exists, but the design status line still says pending implementation at `docs/superpowers/specs/2026-04-28-exp79-lewm-tl-design.md:6`.
+
+5. exp83 results include a failed probe gate that is easy to miss from docs.
+   - `experiments/exp83_slot_attention.py:7-11` states the Slot Attention claim and falsification criteria.
+   - `experiments/exp83_slot_attention.py:488-517` writes gates into `experiments/exp83_slot_data/results.json`.
+   - `experiments/exp83_slot_data/results.json` reports `gates.probe: false`, with `above_acc` about `0.858` and `left_of_acc` about `0.872`, while TL-only and end-to-end gates are true.
+   - Risk: morning readers may infer Slot Attention solved the exp79 limitation unless docs explicitly say the probe gate failed.
+
+6. Run-protocol provenance invariants are not fully followed by existing data dirs.
+   - `docs/RUN_PROTOCOL.md:65-85` says local mirrors should commit `results.json` plus `ADAPTER.md`.
+   - `docs/RUN_PROTOCOL.md:87-103` repeats `ADAPTER.md` as a repo-structure invariant.
+   - Command: `git ls-files 'experiments/exp*_data/ADAPTER.md'` printed nothing.
+   - Existing data dirs include `experiments/exp60_data/`, `experiments/exp76_data/`, `experiments/exp78_data/`, `experiments/exp79_data/`, and `experiments/exp83_slot_data/`; only exp78/79/83 have checked-in `results.json`.
+
+7. Local command portability is weaker than the docs imply.
+   - `README.md:89-91`, `.github/workflows/ci.yml:26-30`, and `web_workbench/README.md:7-13` use `python`.
+   - Command: `command -v python` exited 1 with no output.
+   - Command: `python -m pytest tests/test_packaging_ci.py -q` failed locally with exit 127: `/opt/homebrew/bin/bash: line 1: python: command not found`.
+   - Command: `command -v python3` printed `/usr/local/bin/python3`, and the equivalent `python3` test commands passed.
+   - CI may be fine because `actions/setup-python` usually provides `python`, but local docs should account for this worktree shell.
+
+8. Optional model/backend claims need dependency framing.
+   - `CLAUDE.md:21-28` says `lm_prune()` supports MLX and transformers, with a known VLM limitation.
+   - `pyproject.toml:12-21` declares only `torch` plus dev dependencies `matplotlib`, `numpy`, and `pytest`; it does not declare `transformers`, `mlx_lm`, `scipy`, `peft`, `datasets`, or `accelerate`.
+   - `experiments/exp78_rule_induction.py:60-63` handles missing `transformers` by falling back to all relations.
+   - `experiments/exp83_slot_attention.py:113-115` imports `scipy.optimize.linear_sum_assignment`, but `scipy` is not in `pyproject.toml`.
+   - Risk: model-backed docs claims are true only in enriched environments, not from the documented base install.
+
+## Unsupported or non-local claims
+
+These claims may be true, but I did not find enough local evidence to treat them as self-contained.
+
+- External paper/citation claims in `README.md:5`, `README.md:155-176`, and related notes were not web-verified during this local audit.
+- README's exp53/exp54 package-level F1 tables are supported by scripts, not immutable checked-in run outputs.
+- Notes rows describing remote SFT/Kaggle/Colab outcomes, especially exp60d and exp76-related data, do not have local adapter pointers or manifests in the repo. The report should treat them as log claims until the run protocol is applied retroactively.
+- `README.md:107` says each listed demo runs in seconds to a few minutes. I verified all eight demos with `python3` in this environment, but I did not run the exact `uv run --with torch python ...` commands from the README.
+- `README.md:3` says `fafsa-engine` and later `officeqa-*` consume this repo as a shared dependency. I did not inspect sibling repos because this queue item is scoped to the current repo and branch.
+
+## Risks and stale assumptions
+
+1. Numeric headline claims can drift with network state.
+   - exp53/54 download package tarballs at run time, so package versions and source layouts can change unless results are frozen with input package versions and manifests.
+
+2. Provenance policy is stricter than repo reality.
+   - The run protocol requires `ADAPTER.md` pointers, but none are tracked. Morning review should not assume all remote-trained claims are reproducible from this checkout.
+
+3. README is behind the experiment surface.
+   - It still describes exp1..exp54 even though local files and notes reach exp83. New agents may miss later work or duplicate already-run experiments.
+
+4. Exp79/exp83 status is ambiguous.
+   - Exp79's design doc says pending implementation and uses a 90% probe gate; current code uses 70%. Exp83 appears to be the object-centric follow-up, but its checked-in results show the probe gate failed.
+
+5. The default install contract is too small for some documented experiments.
+   - Base/dev dependencies do not cover `transformers`, `mlx_lm`, `scipy`, or SFT tooling mentioned in docs and experiment scripts.
+
+6. Local validation docs assume a `python` executable.
+   - This shell has only `python3`, so copied worker commands fail locally even though CI likely passes.
+
+7. Large experiment scripts are not cheap proof commands.
+   - exp53/54 retrain and download external packages. They are not suitable as overnight validation commands without network approval and frozen expected outputs.
+
+8. Checked-in result files lack a uniform schema.
+   - exp78, exp79, and exp83 all have `results.json`, but shapes differ and only some include gates. A review script cannot yet summarize them consistently.
+
+## Next safe work
+
+These are independently grabbable, docs-first tasks. None require product-code changes unless the assignee chooses to add docs tests.
+
+1. Reconcile README scope and current experiment surface.
+   - Acceptance criteria: `README.md` accurately states that experiments now run through exp83; the demos wording distinguishes the eight runnable demos from the five-item conceptual ladder; headline tables explicitly say whether results are frozen artifacts or reproducible script outputs.
+   - Validation: `python3 -m pytest tests/test_packaging_ci.py -q`; `python3 demos/transitive_closure.py`; `git diff -- README.md`.
+
+2. Add a result provenance index for headline experiments.
+   - Acceptance criteria: create or update a docs file that maps exp44/47/52/53/54/60d/78/79/80/83 claims to script path, checked-in artifact path, exact command, external inputs, and whether the run is locally reproducible without network/model access.
+   - Validation: `git ls-files 'experiments/exp*_data/results.json'`; `python3 -m pytest tests/test_packaging_ci.py -q`; optional docs test that required headline result rows include artifact status.
+
+3. Normalize local Python command documentation.
+   - Acceptance criteria: README, web workbench docs, and agent docs either use `python3` for local commands or state that `python` means the active virtualenv interpreter; docs mention `python3 -m pip install -e ".[dev]"` as the macOS-safe local form.
+   - Validation: `command -v python3`; `python3 -m tensor_logic --help`; `python3 -m pytest tests/test_packaging_ci.py -q`.
+
+4. Resolve exp79 and exp83 status docs.
+   - Acceptance criteria: exp79 design/spec docs state implemented status and explain the current 70% probe gate; exp83 docs or notes explicitly record `gates.probe=false` and what that means for the Slot Attention claim.
+   - Validation: `python3 -m pytest tests/test_exp79.py -q`; `python3 -m pytest tests/ -q -k 'not make_proposer'`; inspect `experiments/exp79_data/results.json` and `experiments/exp83_slot_data/results.json`.
+
+5. Backfill remote-run provenance pointers or mark non-applicable.
+   - Acceptance criteria: every `experiments/exp*_data/` directory has either an `ADAPTER.md`/manifest pointer or a short `PROVENANCE.md` explaining why no adapter is expected; exp60/76 remote-training claims link to durable artifact references if available.
+   - Validation: `git ls-files 'experiments/exp*_data/ADAPTER.md' 'experiments/exp*_data/PROVENANCE.md'`; no external download required.
+
+6. Define optional dependency groups for model-heavy experiments.
+   - Acceptance criteria: docs clearly separate base package install, dev/test install, web/workbench install, LM-pruner install, SFT install, and Slot Attention/scipy install; experiments with optional deps fail with actionable messages.
+   - Validation: `python3 -m pytest tests/test_packaging_ci.py -q`; targeted import smoke tests for base package still pass without optional extras.
+
+## Validation command candidates
+
+| Command | Status observed or expected | Notes |
+|---|---|---|
+| `git status --short` | Required queue validation; exits 0. After this report is written, expected output is the report path as untracked/modified. | This is the queue item's required validation command. |
+| `python -m pytest tests/test_packaging_ci.py -q` | Observed fail locally, exit 127. | `python` is not on PATH in this shell. |
+| `python3 -m pytest tests/test_packaging_ci.py -q` | Observed pass: `3 passed in 0.01s`. | Validates README/CI/package validation docs. |
+| `python3 -m pytest tests/test_tensor_logic_core.py -q` | Observed pass: `54 passed in 14.73s`. | Cheap core proof/package confidence. |
+| `python3 -m pytest tests/test_web_workbench.py -q` | Observed pass: `2 passed in 9.83s`. | Supports web workbench docs. |
+| `python3 -m pytest tests/ -q -k 'not make_proposer'` | Observed pass: `139 passed, 1 deselected in 33.22s`. | Avoids one LM/model-dependent proposer smoke test. |
+| `python3 -m tensor_logic --help` | Observed pass. | Confirms CLI surface. |
+| `python3 demos/*.py` individually | Observed pass for all eight README demos when run as individual commands. | I did not use the exact `uv run --with torch python ...` wrapper. |
+| `python3 experiments/exp53_real_imports.py` | Expected not safe for this queue item. | Downloads package source tarballs and retrains models; external network/provenance work. |
+| `python3 experiments/exp54_big_imports.py` | Expected not safe for this queue item. | Same external/download issue, plus larger package compute. |
+| `python3 experiments/exp83_slot_attention.py --skip-train` | Expected not useful. | Code help says skip-train is not supported in this PoC yet. |
+
+## Commands run
+
+- `pwd`
+- `git status --short --branch`
+- `git status --short`
+- `git rev-parse --show-toplevel`
+- `git rev-parse HEAD`
+- `git remote -v`
+- `git log --oneline -5`
+- `llm-tldr tree .`
+- `rg --files`
+- `fd -a 'AGENTS.md|CLAUDE.md|README|docs|pyproject|package.json|requirements|Makefile|Dockerfile|compose|.env|ISSUE.md' .`
+- `rtk read CLAUDE.md`
+- `rtk read README.md`
+- `rtk read pyproject.toml`
+- `rtk read benchmarks/README.md`
+- `rtk read web_workbench/README.md`
+- `rtk read docs/RUN_PROTOCOL.md`
+- `rtk read docs/SYMPHONY_RUN_PROTOCOL.md`
+- `rtk read docs/exp78_rule_induction_spec.md`
+- `rtk read docs/agents/domain.md`
+- `rtk read docs/agents/issue-tracker.md`
+- `rtk read docs/agents/triage-labels.md`
+- `rtk grep "TODO|FIXME|Known limitation|Out of scope|not implemented|skip|xfail|TODO|requires|Kaggle|external|weights|results.json|ADAPTER|python -m pytest|uv run|pip install" .`
+- `rg -n "^#|python -m|uv run|pytest|pip install|results|F1|accuracy|seconds|minutes|Kaggle|Out of scope|Known limitation|TODO|FIXME|not implemented|does not|fails|failed|unsupported|stable|runnable|should|must" README.md docs notes benchmarks web_workbench tests pyproject.toml CLAUDE.md`
+- `rtk read experiments/exp53_real_imports.py`
+- `rtk read experiments/exp54_big_imports.py`
+- `rtk read experiments/exp52_mlp_capacity.py`
+- `rtk read notes/EXPERIMENTS.md`
+- `git ls-files 'experiments/*_data/*'`
+- `git ls-files '*ADAPTER.md'`
+- `rtk read experiments/exp78_data/results.json`
+- `rtk read experiments/exp79_data/results.json`
+- `rtk read experiments/exp83_slot_data/results.json`
+- `rg -n "exp53|exp54|exp52|exp78|exp79|exp83|ADAPTER|manifest|results\\.json|validation|Worker validation|Run|Repo layout|demos/|experiments/" README.md notes/EXPERIMENTS.md docs/RUN_PROTOCOL.md docs/exp78_rule_induction_spec.md docs/superpowers/specs docs/superpowers/plans CLAUDE.md tests`
+- `rg --files -g '.github/**' -g '!.git/**'`
+- `rtk read tests/test_packaging_ci.py`
+- `rtk read .github/workflows/ci.yml`
+- `python -m pytest tests/test_packaging_ci.py -q`
+- `python -m pytest tests/test_tensor_logic_core.py -q`
+- `python3 --version`
+- `python3 -m pytest tests/test_packaging_ci.py -q`
+- `python3 -m pytest tests/test_tensor_logic_core.py -q`
+- `python3 -m pytest tests/test_web_workbench.py -q`
+- `python3 -m pytest tests/ -q -k 'not make_proposer'`
+- `rtk read tensor_logic/__main__.py`
+- `rtk read tensor_logic/program.py`
+- `rtk read tensor_logic/proofs.py`
+- `rtk read tensor_logic/closure.py`
+- `rtk read web_workbench/server.py`
+- `rtk read tensor_logic/http_api.py`
+- `nl -ba README.md`
+- `nl -ba docs/RUN_PROTOCOL.md`
+- `nl -ba CLAUDE.md`
+- `nl -ba docs/exp78_rule_induction_spec.md`
+- `nl -ba experiments/exp83_slot_attention.py`
+- `nl -ba docs/superpowers/specs/2026-04-28-exp79-lewm-tl-design.md`
+- `nl -ba experiments/exp79_lewm_tl.py`
+- `nl -ba experiments/exp78_rule_induction.py`
+- `nl -ba experiments/exp81_sweep.py`
+- `nl -ba tests/test_exp79.py`
+- `nl -ba tests/test_exp81.py`
+- `rtk read experiments/exp81_optimize_rule_induction.py`
+- `git ls-files 'experiments/exp*.py' | wc -l`
+- `git ls-files 'experiments/exp*.py' | tail -20`
+- `git ls-files 'docs/superpowers/specs/*.md' 'docs/superpowers/plans/*.md' | wc -l`
+- `git ls-files 'docs/superpowers/specs/*.md' 'docs/superpowers/plans/*.md'`
+- `git ls-files 'experiments/exp*_data/results.json'`
+- `git ls-files 'experiments/exp*_data/ADAPTER.md'`
+- `nl -ba notes/EXPERIMENTS.md | sed -n '1,35p'`
+- `nl -ba .github/workflows/ci.yml`
+- `nl -ba tests/test_packaging_ci.py`
+- `nl -ba web_workbench/README.md`
+- `nl -ba web_workbench/server.py | sed -n '1,120p'`
+- `command -v python`
+- `command -v python3`
+- `command -v uv`
+- `python3 -m tensor_logic --help`
+- `python3 demos/transitive_closure.py`
+- `python3 demos/program_rules.py`
+- `python3 demos/tensor_language.py`
+- `python3 demos/provenance_kb.py`
+- `python3 demos/train_kg.py`
+- `python3 demos/throwing.py`
+- `python3 demos/joint_lm_kg.py`
+- `python3 demos/catastrophic_forgetting.py`
+
+## Non-goals
+
+- I did not edit source code, tests, README, package metadata, run protocol docs, or experiment artifacts.
+- I did not install packages, run `pip download`, launch remote jobs, use Kaggle, use model providers, create external artifacts, push, or open a PR.
+- I did not inspect sibling repos such as `fafsa-engine`; sibling validation is out of scope for this queue item.
+- I did not mark any external tracker done.
+- I did not rerun expensive or network-dependent experiment scripts like exp53/54.
+
+## Unknowns
+
+- Whether the README's exp53/exp54 numeric tables still reproduce with current PyPI source tarballs.
+- Whether remote-trained exp60/76 adapters still exist and where their canonical datasets live.
+- Whether GitHub Actions currently passes on `origin/main`; local CI metadata is present, but I did not query GitHub.
+- Whether the external paper and reference links are current and correctly cited.
+- Whether downstream repos actually consume `tensor_logic` from this checkout or from a package/pinned commit.
+- Whether `python` is available in the maintainer's normal interactive shell; it is absent in this worker shell.

--- a/docs/overnight/tensor-experiments-risk-register.md
+++ b/docs/overnight/tensor-experiments-risk-register.md
@@ -1,0 +1,581 @@
+# tensor-experiments risk-register audit
+
+Queue item: `tensor-experiments-risk-register`  
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/tensor-experiments-risk-register`  
+Branch: `codex/goal-tensor-experiments-risk-register`  
+Starting HEAD: `5565791a8c888511bbbff1107d2d357164f88baa`  
+Focus area: security, credentials, data, deployment, destructive-command, and external-service risks.
+
+## Scope and decisions
+
+This was a read-only audit plus this single report file. I did not change product code, generated experiment data, tests, CI, external trackers, deploys, Kaggle artifacts, model artifacts, or PR state.
+
+The repo is a research codebase plus a reusable `tensor_logic` Python package. The main live surfaces are:
+
+- `tensor_logic/`: reusable library, CLI, parser, HTTP API, proof/reasoning helpers.
+- `experiments/`: numbered research scripts, some pure local, some remote-download/model-training oriented.
+- `web_workbench/`: local browser workbench that shells out to `python -m tensor_logic`.
+- `docs/` and `notes/`: run protocols, specs, research memos, and long transcripts.
+- `tests/`: pytest coverage for core tensor logic, packaging/CI, web workbench, exp79/80/81, optimize, reason, and code index.
+
+## Command evidence
+
+Commands run during the audit:
+
+- `git status --short --branch`: observed clean branch `codex/goal-tensor-experiments-risk-register` before this report.
+- `git rev-parse --show-toplevel && git branch --show-current && git rev-parse HEAD`: confirmed repo root, branch, and starting HEAD `5565791a8c888511bbbff1107d2d357164f88baa`.
+- `llm-tldr tree .`: mapped package, experiments, docs, tests, web workbench, examples, and phase training files.
+- `rtk read CLAUDE.md`, `rtk read pyproject.toml`, `rtk read README.md`, `rtk read docs/RUN_PROTOCOL.md`, `rtk read docs/SYMPHONY_RUN_PROTOCOL.md`: gathered local conventions, dependencies, and run protocol.
+- `rtk grep "os\\.environ|os\\.getenv|OPENAI|ANTHROPIC|HF_|HUGGING|KAGGLE|TOKEN|API_KEY|SECRET|password" .`: found API-key examples only in docs/plans, plus non-secret token constants in an experiment.
+- `rtk grep "subprocess|shell=True|os\\.system|shutil\\.rmtree|rm -rf|unlink\\(|Path\\([^)]*\\)\\.write|write_text|open\\([^)]*, ['\\\"]w|NamedTemporaryFile|mkdtemp" .`: found subprocess/temp-file/write surfaces in `web_workbench`, `tensor_logic`, `tools`, tests, and remote experiment scripts.
+- `rtk grep "requests|urllib|httpx|FastAPI|uvicorn|HTTPServer|BaseHTTPRequestHandler|webbrowser|fetch\\(|localhost|0\\.0\\.0\\.0" .`: found local HTTP servers in `tensor_logic/http_api.py` and `web_workbench/server.py`.
+- `rtk grep "torch\\.load|pickle|safetensors|from_pretrained|AutoModel|mlx_lm|huggingface|kaggle|dataset|download|url" .`: found remote model/download surfaces and Kaggle artifact references.
+- `rg --files -g '.*' -g '!/.git'`: found `.gitignore`.
+- `rg --files .github . 2>/dev/null | rg '(^|/)\\.github/|(^|/)requirements|uv.lock|poetry.lock|Pipfile|environment\\.yml|conda|Dockerfile|docker-compose|Makefile|justfile|noxfile|tox.ini|setup.cfg|ruff.toml|mypy.ini|pre-commit'`: found only `.github/workflows/ci.yml` among workflow/lock/build config candidates.
+- `git ls-files | wc -l`: observed 197 tracked files.
+- `git ls-files -o --exclude-standard`: no untracked non-ignored files before this report.
+- `git ls-files -o -i --exclude-standard`: no ignored files before code-index lookup.
+- `du -sh . experiments notes docs tensor_logic tests web_workbench`: repo size was about 5.5M, with `experiments/` about 4.3M.
+- `find experiments -maxdepth 2 -type f (...)`: found committed JSON/JSONL/PNG experiment artifacts, no committed `.pt` or `.safetensors` files.
+- `wc -l experiments/exp60_data/*.jsonl experiments/exp76_data/*.jsonl experiments/exp80_spot_check_cases.json`: observed 6,221 total lines across those data/check files.
+- `python tools/code_index.py --lookup load_tl`: failed because `python` is not present in this shell.
+- `python3 tools/code_index.py --lookup load_tl`: succeeded; signature `tensor_logic.file_format.load_tl(path: str) -> LoadedProgram`.
+- `python3 tools/code_index.py --lookup ingest_python`: succeeded; signature `tensor_logic.ingest.ingest_python(root: str | Path) -> PythonImportGraph`.
+- `python3 tools/code_index.py --lookup execute_query`: succeeded; signature `tensor_logic.execution.execute_query(program: Program, relation: str, args: list[str] | tuple[str, ...], recursive: bool) -> dict[str, Any]`.
+- `python3 --version`: Python 3.12.8.
+- `python3 -m pytest --version`: pytest 9.0.3.
+- Python import availability check: `torch`, `numpy`, `matplotlib`, `pytest`, `scipy`, and `tqdm` are importable; `transformers`, `peft`, `datasets`, and `mlx_lm` are not importable in this environment.
+
+Note: the `python3 tools/code_index.py --lookup ...` commands created ignored `tools/index.json` as designed by `tools/code_index.py`; I removed that ignored generated file after the lookup so this worktree keeps exactly one intentional output file. Normal `git status --short` remains scoped to this report.
+
+## Local evidence map
+
+1. `README.md` documents this as a learning/research project and a shared `tensor_logic` library dependency for sibling projects. It also advertises worker validation as `python -m pip install -e ".[dev]"` and `python -m pytest tests/ -v`.
+2. `CLAUDE.md` repeats the full-test command and documents LM backend support in `experiments/exp78_rule_induction.py`, including MLX/transformers fallback and a known VLM incompatibility.
+3. `pyproject.toml` declares only `torch` as a runtime dependency and `matplotlib`, `numpy`, and `pytest` as dev dependencies.
+4. `.github/workflows/ci.yml` installs `.[dev]` and runs `python -m pytest tests/ -v` on push to `main` and pull requests.
+5. `.gitignore` excludes caches, virtualenvs, `*.pt`, `*.pth`, `.cocoindex_code/`, `tools/index.json`, `dist/`, `build/`, and `*.egg-info/`.
+6. `tensor_logic/__main__.py` exposes CLI commands `run`, `query`, `prove`, `ingest-python`, `repl`, `repo-graph`, and `serve`; `serve` defaults to `127.0.0.1:8000`.
+7. `tensor_logic/http_api.py` exposes POST endpoints `/ingest-python`, `/run`, `/query`, and `/prove` using `ThreadingHTTPServer`; `ingest-python` accepts a caller-provided path and generic exceptions are returned as error strings.
+8. `web_workbench/server.py` exposes local POST `/api/*`, writes editor source to a temp `.tl` file, and invokes `[sys.executable, "-m", "tensor_logic", ...]` with `subprocess.run(..., check=False)` and no timeout.
+9. `tensor_logic/file_format.py` implements `include "path"` by joining the include with the current file's base dir and recursively loading it; there is cycle detection but no sandbox/root restriction and absolute paths are not rejected.
+10. `tensor_logic/execution.py` writes caller-supplied source to a temp `.tl` file, loads it, and unlinks it.
+11. `tensor_logic/ingest.py` recursively walks `*.py` files under an arbitrary root, skips common cache/venv directories, parses Python via `ast`, and renders a TL import graph.
+12. `experiments/exp53_real_imports.py` and `experiments/exp54_big_imports.py` use `pip download --no-deps --no-binary :all:` for fixed public packages, then `tarfile.extractall()` or `zipfile.extractall()`.
+13. `experiments/exp60d_sft.py` imports transformers/PEFT/datasets lazily, loads model IDs via `AutoTokenizer.from_pretrained` and `AutoModelForCausalLM.from_pretrained`, writes failure dumps, saves LoRA adapters/tokenizers, and writes a manifest in the output directory.
+14. `experiments/exp78_rule_induction.py` optionally uses transformers or `mlx_lm` to load a model for LM pruning; if transformers is missing it falls back to all relations instead of blocking.
+15. `experiments/exp79_lewm_tl.py` loads `encoder.pt` and `probe.pt` via `torch.load` when `--skip-train` is passed.
+16. `experiments/exp83_slot_attention.py` imports `scipy.optimize.linear_sum_assignment`, `matplotlib`, `numpy`, and `torch`, while those non-core requirements are not all declared as runtime dependencies.
+17. `docs/RUN_PROTOCOL.md` documents a previous lost Kaggle adapter and requires future runs to write `adapter/`, `manifest.json`, and `failures.jsonl`, then create a Kaggle dataset pointer instead of committing weights.
+18. `experiments/exp80_fafsa_kb.py` implements a 2024-25 FAFSA SAI Formula A estimator with cited computation steps and real financial-aid claims.
+19. `experiments/exp80_fafsa_wizard.py` is an interactive estimator that tells users they likely qualify for maximum/partial Pell Grant based on computed SAI.
+20. `tests/test_exp80.py` covers invariants, citations, counterfactual monotonicity, named synthetic cases, and seeded synthetic families, but not external ED worked-example parity.
+
+## Risk register
+
+### R1. Local HTTP APIs can become unsafe if bound beyond localhost
+
+Severity: high if exposed beyond the developer machine; medium for localhost-only use.
+
+Evidence:
+
+- `tensor_logic/__main__.py` exposes `serve --host --port`, defaulting to `127.0.0.1:8000`.
+- `tensor_logic/http_api.py` uses `ThreadingHTTPServer` and accepts caller input for `/ingest-python`, `/run`, `/query`, and `/prove`.
+- `web_workbench/server.py` accepts `--host`, defaulting to `127.0.0.1`, but does not prevent `0.0.0.0`.
+
+Why it matters:
+
+The APIs are designed for local development. If a user binds them to a LAN/public interface, there is no authentication, no CSRF protection, no request-size limit, and no explicit compute timeout. The `/ingest-python` path and TL execution paths can read local source structure or run expensive recursive/proof computations.
+
+Current mitigating evidence:
+
+- Defaults are localhost.
+- Tests cover helper parity and workbench smoke behavior, not network exposure.
+
+Next safe work:
+
+- Add host-binding warnings or explicit `--unsafe-public` opt-in for non-loopback hosts.
+- Add request-size limits and timeout/step limits for API execution.
+- Add tests for oversized JSON bodies and non-loopback host guard behavior.
+
+### R2. TL `include` can read outside an intended workspace
+
+Severity: high if TL input comes from an exposed API or untrusted user.
+
+Evidence:
+
+- `tensor_logic/file_format.py` parses `include "path"`.
+- `_load_into()` resolves includes with `os.path.realpath(os.path.join(base_dir, include_path))`.
+- It detects include cycles but does not reject absolute include paths or `..` traversal.
+- `tensor_logic/execution.py` writes caller-provided source to a temp file and calls `load_tl(path)`.
+
+Why it matters:
+
+A TL file can include paths outside the source directory. If `run_source()` or `web_workbench` ever accepts untrusted TL text, the include mechanism can read arbitrary readable local files, at least far enough to leak parse-error paths/content shape or load any file that happens to parse as TL. Even in local-only use, accidental includes can couple experiments to machine-local paths.
+
+Current mitigating evidence:
+
+- The workbench stores submitted source in a temp `.tl` file and unlinks it.
+- Cycle detection prevents infinite include recursion.
+- Existing tests cover normal includes and include cycles.
+
+Next safe work:
+
+- Add a `base_dir` or `allow_includes` policy to `load_tl`.
+- Reject absolute includes and traversal outside the root by default.
+- Add tests for absolute path rejection, `../` rejection, and opt-in trusted includes.
+
+### R3. Web workbench subprocess execution has no timeout or size limit
+
+Severity: medium for local development; high if exposed.
+
+Evidence:
+
+- `web_workbench/server.py` writes request source to a temp file, builds a command, and runs `subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT.parent), check=False)` with no timeout.
+- `web_workbench/static/app.js` posts arbitrary editor content to `/api/<action>`.
+- `web_workbench/README.md` explicitly states the server writes editor contents to a temp `.tl` file and invokes `python -m tensor_logic`.
+
+Why it matters:
+
+Malformed or intentionally expensive TL programs can consume CPU/memory or hang the browser flow. `capture_output=True` also buffers stdout/stderr in memory. A local-only tool can tolerate more risk, but the server interface makes it easy to accidentally expose a denial-of-service surface.
+
+Current mitigating evidence:
+
+- The command list is fixed and uses `shell=False`.
+- Tests cover normal query and why-not flows.
+
+Next safe work:
+
+- Add `timeout=` to `subprocess.run`.
+- Bound request source size and stdout/stderr returned to the browser.
+- Add tests for timeout mapping to HTTP 408/400 and bounded output.
+
+### R4. Remote package download experiments extract archives without path filtering
+
+Severity: medium because package names are fixed; high if generalized or run in a shared workspace.
+
+Evidence:
+
+- `experiments/exp53_real_imports.py` downloads source archives for fixed packages via `pip download`.
+- `experiments/exp54_big_imports.py` does the same for larger packages.
+- Both scripts call `tarfile.extractall()` and `zipfile.extractall()` without checking archive member paths.
+- Both scripts remove/recreate package directories under a temp destination with `shutil.rmtree()`.
+
+Why it matters:
+
+Archive extraction without member filtering is a known path traversal footgun. The current packages are hardcoded and fetched from PyPI via pip, but the script structure invites reuse with other package names. If a package archive is malicious or the source is compromised, extraction could write outside the intended temp directory.
+
+Current mitigating evidence:
+
+- The package lists are constants, not user CLI args.
+- Extraction happens under a temp directory during normal script execution.
+
+Next safe work:
+
+- Add safe tar/zip extraction helpers that reject absolute paths and paths escaping the destination.
+- Add unit tests using synthetic malicious tar/zip entries.
+- Add an explicit `--allow-network-downloads` flag if these scripts gain CLI package selection.
+
+### R5. Optional model/download dependencies are not declared or locked
+
+Severity: medium for reproducibility; high for overnight/remote workers that assume docs are complete.
+
+Evidence:
+
+- `pyproject.toml` declares `torch` runtime and only `matplotlib`, `numpy`, `pytest` dev extras.
+- `experiments/exp60d_sft.py` requires transformers, PEFT, datasets, accelerate, and often tqdm, but these are only documented in the file docstring.
+- `experiments/exp78_rule_induction.py` optionally imports transformers and `mlx_lm`.
+- Local import check found `transformers`, `peft`, `datasets`, and `mlx_lm` unavailable here.
+- There is no lockfile, requirements file, Dockerfile, tox/nox config, or pre-commit config.
+
+Why it matters:
+
+Core CI can pass while important experiment entrypoints fail on a clean worker. Remote model loading can download large artifacts and may vary over time if model revisions are not pinned.
+
+Current mitigating evidence:
+
+- LM functionality in `exp78` falls back when transformers is unavailable.
+- CI covers the reusable package tests rather than every research experiment.
+
+Next safe work:
+
+- Add optional extras such as `[project.optional-dependencies].lm`, `.remote`, and `.vision`.
+- Pin or record model revisions in manifests for experiment runs.
+- Add a dependency smoke test that imports modules for each documented extra without launching downloads.
+
+### R6. Kaggle/adapter persistence is documented but not enforced
+
+Severity: medium to high for expensive/long-running training work.
+
+Evidence:
+
+- `docs/RUN_PROTOCOL.md` says an exp76c adapter was lost because Kaggle `/kaggle/working/` was wiped.
+- The protocol requires each run to write `adapter/`, `manifest.json`, and `failures.jsonl`.
+- It instructs users not to commit weights and instead commit `results.json` plus `ADAPTER.md`.
+- Current committed experiment artifacts include JSON/JSONL/PNG files, but no `ADAPTER.md` files were found under `experiments/*_data/`.
+- `.gitignore` excludes `*.pt` and `*.pth`, but not every possible model artifact extension or adapter directory shape.
+
+Why it matters:
+
+The repo already had a lost-artifact incident. Without enforcement, a future worker can produce metrics without a durable adapter pointer, or preserve adapter files only in a remote notebook session.
+
+Current mitigating evidence:
+
+- `exp60d_sft.py` writes a `manifest.json` into its output dir.
+- `docs/RUN_PROTOCOL.md` clearly states the intended manual workflow.
+
+Next safe work:
+
+- Add a manifest/pointer validator for committed `experiments/exp*_data/results.json` and `ADAPTER.md` where applicable.
+- Add a checklist to CI or a docs-only test that fails if a run result references an adapter without a pointer.
+- Extend `.gitignore` for common adapter/checkpoint directories while keeping pointer files trackable.
+
+### R7. FAFSA estimator is a real-world financial-aid risk surface
+
+Severity: high if presented outside research/demo context.
+
+Evidence:
+
+- `experiments/exp80_fafsa_kb.py` says it implements the 2024-25 FAFSA SAI guide, Formula A dependent student coverage.
+- `experiments/exp80_fafsa_wizard.py` asks plain-English financial questions and tells users they likely qualify for maximum or partial Pell Grant based on SAI.
+- `tests/test_exp80.py` validates invariants and synthetic cases, but does not prove parity with official ED worked examples.
+- `experiments/exp80_validate_synthetic.py` says spot-check cases should be manually verified against `studentaid.gov/aid-estimator/`.
+
+Why it matters:
+
+Financial-aid calculations are policy and year specific. The code uses 2024-25 constants and explicitly omits independent-student Formula B/C coverage. The wizard wording can sound user-facing and advisory despite validation being synthetic and incomplete.
+
+Current mitigating evidence:
+
+- The module docstring states Formula A only and cites the guide version.
+- Tests check internal invariants and traces carry citations/formulas.
+
+Next safe work:
+
+- Add a visible disclaimer in the wizard and README that this is research, 2024-25 only, dependent Formula A only, not financial advice.
+- Add official worked-example parity tests or a tracked validation matrix.
+- Rename/guard demo outputs that say "likely qualify" until official parity is proven.
+
+### R8. Documentation commands assume `python`, but this local shell only has `python3`
+
+Severity: low to medium, but it blocks exact worker instructions.
+
+Evidence:
+
+- `README.md`, `CLAUDE.md`, `.github/workflows/ci.yml`, and tests expect commands starting with `python`.
+- Running `python tools/code_index.py --lookup load_tl` failed with `python: command not found`.
+- Running `python3 tools/code_index.py --lookup load_tl` succeeded.
+- Local Python is 3.12.8, while CI declares Python 3.11.
+
+Why it matters:
+
+The repo's documented validation and planning commands are not portable to this local environment as written. A worker following docs literally will fail before reaching tests or code-index lookup.
+
+Current mitigating evidence:
+
+- CI uses GitHub's Python setup, where `python` is usually available.
+- `python3` works locally.
+
+Next safe work:
+
+- Document `python3` as the local fallback or use `python -m` only where the environment guarantees it.
+- Add a tiny `make`/`just`/script wrapper if this repo is expected to be run across macOS shells.
+- Update `CLAUDE.md` code-index instruction to mention `python3` fallback.
+
+### R9. Experiment scripts overwrite committed result artifacts by default
+
+Severity: medium for worktree hygiene and reproducibility.
+
+Evidence:
+
+- `experiments/exp78_rule_induction.py` defaults `--out` to `experiments/exp78_data/results.json` and writes it.
+- `experiments/exp79_self_play_loop.py` writes JSON to its selected output path.
+- `experiments/exp60d_sft.py` defaults `--out` to `experiments/exp60_data/lora_adapter` and writes model/manifest artifacts there.
+- `experiments/exp80_validate_synthetic.py` writes `experiments/exp80_spot_check_cases.json`.
+- `.gitignore` excludes some generated artifacts but not every JSON result path.
+
+Why it matters:
+
+Running experiments from the repo root can mutate committed results or create large ignored artifacts. That is fine for intentional experiment work, but unsafe for audit workers or validation scripts unless output paths are redirected to `/tmp`.
+
+Current mitigating evidence:
+
+- Many scripts expose `--out` or path arguments.
+- `docs/RUN_PROTOCOL.md` explains run output structure and artifact persistence.
+
+Next safe work:
+
+- Standardize a `--out` default outside tracked paths for exploratory runs, or require explicit `--overwrite-committed-results`.
+- Add README guidance for smoke tests using `/tmp`.
+- Add tests that result-writing helpers create parent dirs and do not overwrite without opt-in.
+
+### R10. Long transcripts and notes can accumulate sensitive operational history
+
+Severity: low in the current scan; can become medium over time.
+
+Evidence:
+
+- `notes/SESSION_TRANSCRIPT.md` includes a local working directory and commands involving `alphaxiv auth set-api-key`.
+- Grep found API-key examples in docs/plans, but they use placeholder `sk-...` values.
+- No untracked non-ignored files were present before this report.
+
+Why it matters:
+
+Research repos with copied transcripts often accumulate local paths, tool names, account workflows, or pasted credentials. The current scan did not find live secrets, but the note structure invites future leakage unless review discipline exists.
+
+Current mitigating evidence:
+
+- No actual secret-looking values were found by the keyword scan.
+- `.gitignore` excludes common local files and logs.
+
+Next safe work:
+
+- Add a lightweight secret scan command to ship-check/workflow docs.
+- Add note hygiene guidance for transcripts before committing.
+- Consider excluding raw transcripts or storing redacted summaries when the transcript is not needed for reproducibility.
+
+## Stale assumptions and unsupported claims
+
+- The docs and CI assume `python` exists. This local worker shell only has `python3`.
+- `pyproject.toml` does not represent the full experiment dependency surface. Several experiment scripts require packages outside declared runtime/dev extras.
+- `docs/RUN_PROTOCOL.md` says adapter pointers should be committed, but no `ADAPTER.md` files were found under current experiment data dirs.
+- `experiments/exp80_fafsa_kb.py` comments mention asset-exempt concepts in sample families, but the visible Formula A implementation does not expose a full asset-exemption branch in the inspected section.
+- The FAFSA wizard's user-facing wording is stronger than the committed validation evidence.
+- Remote download/model-loading scripts are research scripts, not production entrypoints, but the README headline claims rely on outputs from some of those scripts.
+
+## Validation command candidates
+
+Required queue validation:
+
+- `git status --short`
+  - Expected: exits 0. Before this report it printed nothing. After this report and before any commit it should show only `?? docs/overnight/tensor-experiments-risk-register.md`.
+  - Purpose: proves scope of filesystem mutation.
+
+Cheap local validation candidates:
+
+- `python3 -m pytest tests/test_packaging_ci.py -q`
+  - Expected: pass in this environment.
+  - Purpose: checks pyproject, README worker validation text, and GitHub Actions validation text.
+
+- `python3 -m pytest tests/test_web_workbench.py -q`
+  - Expected: pass in this environment.
+  - Purpose: covers workbench subprocess path and HTTP/API helper parity without starting a server.
+
+- `python3 -m pytest tests/test_tensor_logic_core.py::TestTensorLogicCore::test_include_directive tests/test_tensor_logic_core.py::TestTensorLogicCore::test_include_cycle_raises -q`
+  - Expected: pass in this environment.
+  - Purpose: baseline for include behavior before sandbox hardening.
+
+- `python3 -m pytest tests/test_exp80.py -q`
+  - Expected: pass in this environment.
+  - Purpose: covers current FAFSA invariants and synthetic cases; does not prove official parity.
+
+Full validation candidate:
+
+- `python3 -m pytest tests/ -v`
+  - Expected: likely pass if the local package is installed/editable and dependencies are importable. This audit did not run it because the queue validation is `git status --short` and the task is report-only.
+  - Risk: repo docs say `python -m pytest`, but this shell lacks `python`.
+
+External or potentially mutating validation candidates:
+
+- `python3 experiments/exp53_real_imports.py`
+  - Expected: blocked/unsafe for this audit because it performs network downloads and archive extraction.
+
+- `python3 experiments/exp54_big_imports.py`
+  - Expected: blocked/unsafe for this audit for the same reason, with larger packages.
+
+- `python3 experiments/exp60d_sft.py`
+  - Expected: fail/block in this environment without optional `transformers`, `peft`, and `datasets`; also writes model/adapter artifacts.
+
+- `python3 experiments/exp78_rule_induction.py --out /tmp/exp78-results.json`
+  - Expected: likely pass locally without LM; safe if output is redirected to `/tmp`.
+
+- `python3 experiments/exp78_rule_induction.py --lm --out /tmp/exp78-lm-results.json`
+  - Expected: should fall back when transformers is unavailable, but does not validate real LM-pruner behavior.
+
+## Independently grabbable next tasks
+
+### Task 1: Sandbox TL include loading
+
+Problem:
+
+`load_tl()` allows includes outside the caller's intended root. This is acceptable for trusted local files but risky for HTTP/workbench execution.
+
+Acceptance criteria:
+
+- `include "local.tl"` in the same directory still works.
+- Absolute include paths are rejected by default.
+- Includes that resolve outside the configured root via `..` are rejected by default.
+- A trusted opt-in path exists if old local workflows need cross-directory includes.
+- Error messages do not leak unnecessary host path details in HTTP responses.
+
+Validation:
+
+- `python3 -m pytest tests/test_tensor_logic_core.py -k "include" -q`
+- Add focused tests for absolute-path and traversal rejection.
+
+Owned files:
+
+- `tensor_logic/file_format.py`
+- `tensor_logic/execution.py`
+- `tensor_logic/http_api.py`
+- `tests/test_tensor_logic_core.py`
+
+### Task 2: Add API/workbench guardrails
+
+Problem:
+
+The local HTTP APIs and workbench subprocess runner have no auth, size limits, or timeouts. Defaults are localhost, but accidental public binding is too easy.
+
+Acceptance criteria:
+
+- Non-loopback host binding requires an explicit `--unsafe-public` flag or prints a high-visibility warning.
+- POST body/source size is bounded.
+- Workbench subprocess calls have a timeout.
+- stdout/stderr response payloads are bounded.
+- Timeout and oversized-body cases return deterministic HTTP errors.
+
+Validation:
+
+- `python3 -m pytest tests/test_web_workbench.py -q`
+- Add handler/unit tests for timeout and body-size behavior without starting an external server.
+
+Owned files:
+
+- `web_workbench/server.py`
+- `web_workbench/README.md`
+- `tensor_logic/http_api.py`
+- `tests/test_web_workbench.py`
+
+### Task 3: Declare optional experiment dependency extras
+
+Problem:
+
+CI and `.[dev]` cover the reusable package, but several experiments require undeclared optional dependencies.
+
+Acceptance criteria:
+
+- Add documented extras for LM/SFT, vision/slot-attention, and remote/download experiments as appropriate.
+- README documents which commands need which extra.
+- A packaging test asserts the extras include expected package names.
+- No heavy downloads occur in tests.
+
+Validation:
+
+- `python3 -m pytest tests/test_packaging_ci.py -q`
+
+Owned files:
+
+- `pyproject.toml`
+- `README.md`
+- `tests/test_packaging_ci.py`
+
+### Task 4: Make remote package extraction safe
+
+Problem:
+
+`exp53` and `exp54` use archive `extractall()` after remote downloads.
+
+Acceptance criteria:
+
+- Tar and zip extraction reject absolute paths and paths escaping the target directory.
+- Existing hardcoded package flows still work.
+- Tests cover malicious archive member names without network.
+
+Validation:
+
+- Add a focused test file, then run `python3 -m pytest <new-test-file> -q`.
+
+Owned files:
+
+- `experiments/exp53_real_imports.py`
+- `experiments/exp54_big_imports.py`
+- New or existing tests under `tests/`
+
+### Task 5: Add FAFSA safety and parity gate
+
+Problem:
+
+The FAFSA wizard is user-facing enough to need stronger disclaimers and official parity evidence.
+
+Acceptance criteria:
+
+- Wizard clearly states research/demo status, 2024-25 only, Formula A dependent-only, not financial advice.
+- README or docs record the validation boundary.
+- A tracked validation matrix distinguishes synthetic invariants from official worked examples.
+- User-facing "likely qualify" wording is softened or gated behind parity status.
+
+Validation:
+
+- `python3 -m pytest tests/test_exp80.py -q`
+- Add a text/behavior test for the disclaimer if the wizard remains interactive.
+
+Owned files:
+
+- `experiments/exp80_fafsa_wizard.py`
+- `experiments/exp80_fafsa_kb.py`
+- `tests/test_exp80.py`
+- Optional docs file under `docs/`
+
+### Task 6: Enforce run manifest and adapter pointer hygiene
+
+Problem:
+
+Run artifact persistence is documented after a lost adapter incident but not enforced.
+
+Acceptance criteria:
+
+- Add a checker for `experiments/exp*_data/results.json` files that require `git_sha` or explicit "legacy/no-manifest" annotation.
+- If a result references an adapter/checkpoint, require a committed pointer file such as `ADAPTER.md`.
+- CI can run the checker without downloading models or touching Kaggle.
+
+Validation:
+
+- `python3 -m pytest tests/test_packaging_ci.py -q` or a new `tests/test_run_protocol.py -q`.
+
+Owned files:
+
+- `docs/RUN_PROTOCOL.md`
+- `tests/`
+- Optional `tools/validate_run_protocol.py`
+
+## Non-goals for this queue item
+
+- No product-code edits.
+- No generated result rewrites.
+- No test-suite execution beyond environment/version/import probes.
+- No remote downloads.
+- No Kaggle, Hugging Face, Modal, Netlify, GitHub Actions, or other external service calls.
+- No secret scanning beyond local grep patterns.
+- No PR creation, push, merge, or external tracker updates.
+- No attempt to verify scientific claims against external papers or package releases.
+- No sibling-repo comparison; this repo was large enough for a focused local audit.
+
+## Unknowns and blockers
+
+- Whether maintainers intend the HTTP API/workbench to remain localhost-only forever or eventually support shared/team use.
+- Whether `include` is intentionally a trusted local-file feature or should be sandboxed for all entrypoints.
+- Whether committed experiment `results.json` files are canonical or merely snapshots from exploratory runs.
+- Whether older Kaggle adapter datasets exist but are undocumented in this checkout.
+- Whether FAFSA work is still research-only or intended to graduate to a user-facing tool.
+- Whether CI currently passes on GitHub; this audit did not query GitHub or run the full suite.
+- Whether ignored local files outside normal `git status --short` should be part of overnight review.
+
+## Handoff
+
+Files intentionally changed by this audit:
+
+- `docs/overnight/tensor-experiments-risk-register.md`
+
+Validation to run for the queue item:
+
+- `git status --short`
+
+Expected validation status:
+
+- Before commit: one untracked report file under `docs/overnight/`.
+- After an optional local report commit: clean tracked status.
+
+Commit status:
+
+- A local docs-only commit was attempted but blocked by sandbox permissions: `git add docs/overnight/tensor-experiments-risk-register.md` could not create the shared git metadata lock at `/Users/jwalinshah/projects/tensor/experiments/.git/worktrees/tensor-experiments-risk-register/index.lock`.
+- Current commit remains `5565791a8c888511bbbff1107d2d357164f88baa`; the report is present as an untracked working-tree file.

--- a/docs/overnight/tensor-experiments-validation-map.md
+++ b/docs/overnight/tensor-experiments-validation-map.md
@@ -1,0 +1,141 @@
+# tensor-experiments validation-map audit
+
+Date: 2026-05-07
+Queue item: `tensor-experiments-validation-map`
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/tensor-experiments-validation-map`
+Branch: `codex/goal-tensor-experiments-validation-map`
+HEAD observed before report: `5565791a8c888511bbbff1107d2d357164f88baa`
+
+## Purpose and State
+
+`tensor-experiments` is a Python research repository around tensor-logic reasoning, demos, and reusable `tensor_logic` package code. `README.md` frames it as a learning/research project and notes that the extracted `tensor_logic` package is also a shared dependency for sibling projects such as `fafsa-engine`.
+
+Initial state was clean:
+
+- `git status --short --branch` produced `## codex/goal-tensor-experiments-validation-map`.
+- `git rev-parse --abbrev-ref HEAD` produced `codex/goal-tensor-experiments-validation-map`.
+- `git rev-parse HEAD` produced `5565791a8c888511bbbff1107d2d357164f88baa`.
+- Required queue validation command `git status --short` exited 0 with no output before the report write.
+
+After running tests and code-index validation, ignored local state existed:
+
+- `git status --short --ignored` showed `!! .pytest_cache/`.
+- `git status --short --ignored` showed `!! tools/index.json`.
+- `.gitignore` explicitly ignores `.pytest_cache/`, `.ruff_cache/`, `.uv/`, `tools/index.json`, build outputs, Python bytecode, virtualenvs, model weights, and local editor files.
+
+## Declared Validation Contracts
+
+The repo has one canonical automated validation path and several narrower proof commands.
+
+- `pyproject.toml` declares package name `tensor-logic`, Python `>=3.11`, runtime dependency `torch>=2.0`, and dev extras `matplotlib>=3.7`, `numpy>=1.24`, and `pytest>=8.0`.
+- `pyproject.toml` configures pytest with `testpaths = ["tests"]`.
+- `README.md` says Symphony workers should run `python -m pip install -e ".[dev]"` and `python -m pytest tests/ -v`.
+- `CLAUDE.md` gives the local test suite as `pytest tests/ -v`.
+- `.github/workflows/ci.yml` runs on pull requests and pushes to `main`, sets up Python 3.11, installs `python -m pip install -e ".[dev]"`, and runs `python -m pytest tests/ -v`.
+- `tests/test_packaging_ci.py` enforces the packaging/CI/README contract by asserting the pyproject dependency names, workflow triggers, install command, and test command.
+- `docs/SYMPHONY_RUN_PROTOCOL.md` says issue workers should validate with the smallest direct command and record PR URL, commit SHA, validation command, and blockers.
+- `docs/RUN_PROTOCOL.md` covers remote/Kaggle experiment runs and requires manifests, output pointers, and avoiding committed weights.
+
+## Commands Run
+
+Validation and discovery commands run during this audit:
+
+- `llm-tldr tree .` completed and showed the main surfaces: `tensor_logic/`, `tests/`, `experiments/`, `demos/`, `phase_training/`, `web_workbench/`, `tools/`, `docs/`, and `notes/`.
+- `llm-tldr search "pytest|ruff|mypy|lint|python -m|unittest|tox|nox|uv|pip" .` found the README/CI pytest contract, demo `uv run` commands, `.gitignore` cache entries, and many docs plan validation commands.
+- `python --version` failed locally with `/opt/homebrew/bin/bash: line 1: python: command not found`.
+- `python -m pytest tests/ -v` failed locally with `/opt/homebrew/bin/bash: line 1: python: command not found`.
+- `python -m pip show torch pytest numpy matplotlib` failed locally with `/opt/homebrew/bin/bash: line 1: python: command not found`.
+- `python3 --version` passed with `Python 3.12.8`.
+- `python3 -m pytest tests/ -v` passed: `140 passed in 31.83s`.
+- `python3 -m pip show torch pytest numpy matplotlib` found local installs: torch 2.11.0, pytest 9.0.3, numpy 1.26.4, and matplotlib installed under the Python 3.12 framework.
+- `uv --version` passed with `uv 0.11.5 (Homebrew 2026-04-08 aarch64-apple-darwin)`.
+- `python3 tools/code_index.py --status` passed with `fresh: .../tools/index.json`.
+- `rg --files -g 'requirements*.txt' -g 'uv.lock' -g 'poetry.lock' -g 'Pipfile*' -g 'tox.ini' -g 'noxfile.py' -g 'Makefile' -g 'setup.cfg' -g '.pre-commit-config.yaml' -g 'mypy.ini' -g '.flake8'` exited 1 with no matches.
+
+## Test Coverage Map
+
+The current suite is useful and fast enough for every ordinary repo change, but it is not a full experiment reproducibility suite.
+
+- `tests/test_tensor_logic_core.py` is the broadest core package suite. It covers named-index joins, recursive fixpoints, TL file parsing, CLI query/prove/run behavior, positive and negative proof JSON, provenance/ranking, repo graph helpers, HTTP helper parity, source-backed facts, stratified negation, include directives, and error semantics.
+- `tests/test_code_index.py` covers `tools/code_index.py` extraction, staleness checks, CLI lookup/status behavior, and asserts `tools/index.json` is gitignored.
+- `tests/test_packaging_ci.py` is a meta-test for the worker validation contract in `pyproject.toml`, `.github/workflows/ci.yml`, and `README.md`.
+- `tests/test_exp79.py` covers the LeWM/TL experiment helpers from `experiments/exp79_lewm_tl.py`: synthetic frame generation, geometric relations, encoder/predictor shapes, JEPA loss/backward stability, relation probe shape/metrics, and TL retraction wiring.
+- `tests/test_exp80.py` covers FAFSA SAI arithmetic invariants in `experiments/exp80_fafsa_kb.py` and synthetic family cases from `experiments/exp80_validate_synthetic.py`.
+- `tests/test_exp81.py` covers rule-induction optimizer helpers from `experiments/exp81_optimize_rule_induction.py`: artifact parsing, miss explanations, evaluator scoring, ASI population, and proposer JSON shape.
+- `tests/test_optimize.py` covers Pareto frontier logic and the optimize loop in `tensor_logic/optimize.py`.
+- `tests/test_reason.py` covers observation-to-TL fact conversion and `tensor_logic.reason` query evaluation.
+- `tests/test_web_workbench.py` covers workbench request plumbing and JSON parity with `tensor_logic.http_api`.
+- `tests/test_proof_recursion.py` covers positive and negative recursive proof behavior on a small graph.
+
+## Validation Candidate Matrix
+
+| Command | Observed or expected status | Notes |
+|---|---:|---|
+| `git status --short` | Pass, exits 0 | Queue-required command. It was empty before report write; after this report it should show only `?? docs/overnight/tensor-experiments-validation-map.md` unless committed by the runner. |
+| `python -m pip install -e ".[dev]"` | Local fail expected in this shell | `python` is not on PATH locally. CI setup-python should provide it. |
+| `python -m pytest tests/ -v` | Local fail observed | Fails only because `python` is not on PATH. This is a local worker portability issue. |
+| `python3 -m pytest tests/ -v` | Pass observed | `140 passed in 31.83s` on Python 3.12.8. |
+| `python3 -m pytest tests/test_packaging_ci.py -v` | Pass expected | These three tests passed as part of the full suite and should be the cheapest guard for validation contract edits. |
+| `python3 -m pytest tests/test_code_index.py -v` | Pass expected with ignored artifact | Full suite passed. This path may create or refresh ignored `tools/index.json`. |
+| `python3 tools/code_index.py --status` | Pass observed | Reported a fresh ignored `tools/index.json`. Useful before work touching `tensor_logic/`. |
+| `uv run --with torch python demos/transitive_closure.py` | Not run, expected smoke candidate | README lists demo commands, but they are not CI-gated and may use network/package resolution depending on uv cache state. |
+| `python3 -m build` | Unknown/not declared | No build command, lockfile, or build validation target was found. |
+| `ruff`, `mypy`, `black`, `tox`, `nox`, or pre-commit | Not available as repo contracts | No matching config files were found by the lock/tooling search command. |
+
+## Risks and Stale Assumptions
+
+1. The documented local validation command assumes `python` exists. This worktree has `python3` but no `python`, so a local worker following `README.md` exactly gets a false negative even though `python3 -m pytest tests/ -v` passes.
+
+2. The dependency declaration is intentionally small relative to the experiment archive. `pyproject.toml` declares only `torch` at runtime and `matplotlib`, `numpy`, `pytest` for dev. Search evidence shows heavier scripts reference optional or external surfaces such as `transformers`/model loading in `experiments/exp60d_sft.py` and `experiments/exp77_schema_rule_construction.py`, `scipy` in `experiments/exp83_slot_attention.py`, `pip download` in `experiments/exp53_real_imports.py` and `experiments/exp54_big_imports.py`, and external FAFSA/ISIR validation data in `experiments/validate_exp80_isir.py`.
+
+3. CI validates package code and selected experiment helpers, not the full experiment claims. This is a good default for cheap proof, but README headline claims and many `experiments/exp*.py` scripts are not continuously reproduced.
+
+4. There is no declared lint, type, coverage, wheel-build, or import-all validation surface. That keeps validation cheap, but it means syntax/style/import drift outside tested modules can survive until a specific experiment script is run.
+
+5. `tools/code_index.py --lookup` and related tests can create `tools/index.json`. The file is correctly ignored, and `tests/test_code_index.py` asserts that, but local workers should expect ignored state after validation.
+
+6. Remote/long-running experiment discipline is documented in `docs/RUN_PROTOCOL.md`, but it is not enforced by tests. Scripts that write manifests, adapter pointers, or failure dumps can regress without the cheap suite noticing.
+
+## Next Safe Work
+
+1. Make validation docs portable across local shells.
+   Acceptance criteria: `README.md`, `CLAUDE.md`, and `.github/workflows/ci.yml` still agree on the canonical CI command, and README also documents a local `python3` fallback when `python` is absent.
+   Validation: `python3 -m pytest tests/test_packaging_ci.py -v` should pass after updating `tests/test_packaging_ci.py` if it intentionally checks the fallback text.
+
+2. Add a repo-local `docs/VALIDATION.md` matrix.
+   Acceptance criteria: document cheap CI validation, local fallback commands, code-index commands, demo smoke commands, heavyweight/remote experiment commands, expected artifacts, and expected pass/fail assumptions.
+   Validation: `python3 -m pytest tests/test_packaging_ci.py -v` plus `python3 -m pytest tests/test_code_index.py -v`.
+
+3. Split optional experiment dependencies into named extras or explicit docs.
+   Acceptance criteria: heavyweight scripts that require `transformers`, `peft`, `datasets`, `accelerate`, `scipy`, or external downloads are either mapped to optional extras in `pyproject.toml` or listed in `docs/VALIDATION.md` as non-CI dependencies.
+   Validation: `python3 -m pytest tests/ -v` should still pass, and a targeted import smoke should prove the base package remains installable without heavyweight extras.
+
+4. Add a lightweight build/import proof.
+   Acceptance criteria: add one documented command that proves the installable package imports and its CLI starts, without running experiments or external services.
+   Candidate validation: `python3 -m pytest tests/test_packaging_ci.py -v` and `python3 -m tensor_logic --help`.
+
+5. Add explicit slow/remote markers before expanding test coverage.
+   Acceptance criteria: any new tests for demos or experiments that can train models, download packages, hit external data, or require GPU are marked or placed outside the default `tests/` path.
+   Validation: default `python3 -m pytest tests/ -v` remains under one minute on a normal laptop.
+
+## Non-Goals
+
+- Did not change product code, experiments, tests, package metadata, CI, docs outside this report, generated data, secrets, external services, deploys, pushes, or PR state.
+- Did not run remote/Kaggle/hosted jobs.
+- Did not run heavyweight experiment scripts, demo training loops, model downloads, package-download experiments, or external FAFSA validation.
+- Did not create or modify Linear/GitHub tracker state.
+- Did not attempt to clean ignored `.pytest_cache/` or `tools/index.json`; they are validation byproducts and are already ignored.
+
+## Unknowns
+
+- Whether the intended local runner always provides a `python` shim or expects agents to use `python3`.
+- Whether CI should remain Python 3.11 only while local validation passed on Python 3.12.8.
+- Whether the experiment archive should be treated as historical evidence, runnable artifacts, or both.
+- Whether heavyweight optional dependencies should be encoded as install extras, per-script comments, or a separate validation document.
+- Whether headline README claims should get reproducibility smoke tests, recorded result fixtures, or remain manually audited research notes.
+
+## Handoff Notes
+
+Changed file: `docs/overnight/tensor-experiments-validation-map.md`.
+
+No PR was created, no external tracker was updated, and no product code was edited. The useful validation evidence from this audit is that the full suite passes under `python3`, the documented `python` command is not runnable in this local shell, and ignored validation artifacts are expected after code-index/test execution.

--- a/docs/overnight/tensor-experiments-workflow-handoff.md
+++ b/docs/overnight/tensor-experiments-workflow-handoff.md
@@ -1,0 +1,251 @@
+# tensor-experiments workflow-handoff audit
+
+Queue item: `tensor-experiments-workflow-handoff`
+Date: 2026-05-07
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/tensor-experiments-workflow-handoff`
+Focus area: workflow handoff
+
+## Scope and outcome
+
+This audit is read-only against product code. The only intended repository change is this report.
+
+The repo is a research project plus reusable `tensor_logic` package. `README.md` frames it as "a learning project, not a product", while also noting that `tensor_logic/` is now a shared library dependency for sibling projects such as `fafsa-engine` and future `officeqa-*` work. The practical workflow problem is that the repo has moved from one-off demos into a mixed surface: package code, tests, web workbench, local code-index tooling, heavy LM/GPU experiments, generated experiment artifacts, and external run protocols.
+
+Morning-review conclusion: do not hand future workers a broad "continue experiments" task. The next safe work should be split into narrow handoff/validation slices that make experiment ownership, output paths, dependencies, and proof commands explicit before any more experiment code or remote runs happen.
+
+## Local state
+
+- Branch: `codex/goal-tensor-experiments-workflow-handoff`
+- Pre-audit HEAD: `5565791a8c888511bbbff1107d2d357164f88baa`
+- Remote: `origin https://github.com/jwalin-shah/tensor-logic.git`
+- Initial `git status --short`: clean.
+- After local proof commands and before this report, `git status --short`: clean.
+- After local proof commands and before this report, `git status --short --ignored`: ignored `.pytest_cache/` and ignored `tools/index.json`.
+- `docs/overnight/` did not exist before this queue item.
+- Local shell has `python3` (`Python 3.12.8`) but not `python`; `python tools/code_index.py --status` failed with `python: command not found`.
+
+## Evidence ledger
+
+1. `llm-tldr tree .` showed the main surfaces: `tensor_logic/`, `experiments/`, `demos/`, `phase_training/`, `tests/`, `web_workbench/`, `tools/`, `docs/`, and `notes/`.
+2. `README.md` documents purpose, headline experiment claims, worker validation, runnable demos, and the reusable `tensor_logic/` extraction.
+3. `pyproject.toml` declares package name `tensor-logic`, Python `>=3.11`, core dependency `torch>=2.0`, and dev deps `matplotlib`, `numpy`, `pytest`.
+4. `.github/workflows/ci.yml` installs with `python -m pip install -e ".[dev]"` and runs `python -m pytest tests/ -v` on pull requests and pushes to main.
+5. `tests/test_packaging_ci.py` asserts the dependency contract, CI command, and README worker validation command, so validation docs are intentionally under test.
+6. `CLAUDE.md` instructs agents to run `python tools/code_index.py --lookup <RelevantSymbol>` before planning changes under `tensor_logic/`, and records a known MLX/VLM limitation for `experiments/exp78_rule_induction.py`.
+7. `tools/code_index.py` writes `tools/index.json` through `ensure_fresh()` during lookup/dump/rebuild; `.gitignore` excludes `tools/index.json`, so this is intentional local-only state.
+8. `python3 tools/code_index.py --status` returned exit 1 with `stale: index.json is missing or older than source files` before any code-index lookup.
+9. `docs/RUN_PROTOCOL.md` exists because an exp76c Kaggle adapter was lost when `/kaggle/working/` was wiped; it mandates per-run output dirs, manifests, failure dumps, notebook commit, and local pointer files.
+10. `docs/SYMPHONY_RUN_PROTOCOL.md` defines a worker handoff contract: one issue, one branch, one PR, smallest validation, and recorded PR URL/commit SHA/validation/blockers.
+11. `experiments/exp79_self_play_loop.py` defaults `--out` to `experiments/exp79_data/results.json`.
+12. `experiments/exp79_lewm_tl.py` also uses `DATA_DIR = experiments/exp79_data` and writes `results.json`, `complexity_curve.png`, and ignored `.pt` weights there, creating an artifact namespace collision.
+13. `experiments/exp79_data/results.json` currently contains self-play loop output modes (`easy`, `medium`, `hard`, `very_hard`, `adversarial`), not the LeWM+TL result schema from `experiments/exp79_lewm_tl.py`.
+14. `experiments/exp83_slot_attention.py` imports `scipy.optimize.linear_sum_assignment`, but `pyproject.toml` does not declare `scipy` in core or dev dependencies.
+15. `experiments/exp83_slot_data/results.json` records `probe=false`, `tl_only=true`, `e2e=true`; `notes/RESEARCH_NOTES.md` says exp82/exp83 should remain exploratory until they have clean specs and falsification gates.
+16. `experiments/exp80_fafsa_kb.py` states Formula B/C for independent students is TODO; tests cover Formula A synthetic cases only.
+17. `rg -n "os.environ|getenv|OPENAI|ANTHROPIC|HF_|KAGGLE|TOKEN|API_KEY|MODEL|mlx|transformers" .` found external/provider-shaped docs and optional LM paths, but no checked-in secret values.
+18. `rtk pytest tests/test_packaging_ci.py -q`, `rtk pytest tests/test_code_index.py -q`, and `rtk pytest tests/test_web_workbench.py -q` all returned `Pytest: No tests collected`; raw `python3 -m pytest ...` did collect and pass the same files.
+
+## Workflow map
+
+### Package and CLI
+
+`tensor_logic/` is the reusable library. `tensor_logic/__main__.py` provides CLI subcommands for `run`, `query`, `prove`, `ingest-python`, `repl`, `repo-graph`, and `serve`. `tensor_logic/http_api.py` and `web_workbench/server.py` expose browser/API execution paths that eventually call the same local CLI/runtime.
+
+Safe worker rule: any task that touches `tensor_logic/` should start with a code-index lookup using `python3 tools/code_index.py --lookup <symbol>` in this local environment, because `python` is not available here. Expect that lookup to create or refresh ignored `tools/index.json`.
+
+### Tests and cheap validation
+
+The canonical documented full validation is:
+
+```bash
+python -m pip install -e ".[dev]"
+python -m pytest tests/ -v
+```
+
+In this local shell, the equivalent command must use `python3` unless the worker creates a `python` alias or virtualenv. The cheap observed proof commands were:
+
+```bash
+python3 -m pytest tests/test_packaging_ci.py -q
+python3 -m pytest tests/test_code_index.py -q
+python3 -m pytest tests/test_web_workbench.py -q
+```
+
+### Experiment lanes
+
+- `experiments/exp78_rule_induction.py`: TL-only rule induction, optionally LM-pruned. The no-LM path is local and cheap; the `--lm` path may load MLX/transformers models.
+- `experiments/exp79_self_play_loop.py`: validated rule-factory/self-play loop. Writes `experiments/exp79_data/results.json` by default.
+- `experiments/exp79_lewm_tl.py`: pixel/JEPA/probe/TL experiment. Also writes `experiments/exp79_data/`, which currently conflicts with self-play output.
+- `experiments/exp80_fafsa_kb.py`: local Formula A FAFSA SAI proof trace. High-stakes domain; must stay framed as a research prototype and not a complete FAFSA engine.
+- `experiments/exp81_optimize_rule_induction.py`: optimize-loop plus LM-guided proposer. Unit tests cover parse/evaluator pieces, but `test_make_proposer_returns_valid_json` can call `lm_prune()`, which may try model loading unless transformers is unavailable.
+- `experiments/exp83_slot_attention.py`: exploratory slot-attention follow-up. Current tracked result fails the probe gate, and the script requires undeclared `scipy`.
+- `experiments/exp60d_sft.py` and exp60/76 data: heavier SFT/tool-harness lane with optional `transformers`, `peft`, `datasets`, and `accelerate`; use `docs/RUN_PROTOCOL.md` before any remote run.
+
+## Risks and stale assumptions
+
+1. The validated worker command uses `python`, but this local environment only has `python3`. A worker following `README.md`, `.github/workflows/ci.yml`, or `CLAUDE.md` literally will fail before installing or testing.
+2. The global preferred wrapper `rtk pytest` did not collect explicit test files as used here, while raw `python3 -m pytest` did. Future handoffs should name raw pytest commands when exact local proof matters.
+3. `tools/index.json` is gitignored and local-only. `--status` fails on a clean/missing index, but `--lookup` can write ignored state. That is useful for agents, but it means code-index freshness is not represented by git state.
+4. Two different exp79 scripts share the same output path. Running `experiments/exp79_lewm_tl.py` can overwrite the self-play `experiments/exp79_data/results.json` that is currently tracked and cited in `notes/EXPERIMENTS.md`.
+5. Optional/heavy dependencies are not represented in `pyproject.toml`: `scipy` for exp83, `transformers`/`mlx_lm` for exp78/81 LM paths, and `peft`/`datasets`/`accelerate` for exp60d SFT.
+6. Several experiment scripts write tracked result locations by default. A worker can accidentally mutate committed data by running an experiment without `--out /tmp/...` or a namespaced output dir.
+7. README/doc claims have stale edges: repo layout says `experiments/ exp1..exp54` while the repo now contains exp83; the demo count says five headline runnable demos while `demos/` has eight files.
+8. `experiments/exp80_fafsa_kb.py` cites a 2024-25 source and explicitly omits Formula B/C. Any next FAFSA task needs human product/legal framing before it becomes user-facing or claims coverage beyond Formula A.
+9. External run protocol risk is proven by history: `docs/RUN_PROTOCOL.md` exists because a Kaggle adapter was lost. Remote jobs must not be launched without manifest, output path, notebook/dataset persistence, and explicit approval.
+10. `docs/agents/domain.md` says to read `CONTEXT.md`, `CONTEXT-MAP.md`, and `docs/adr/` if present; none were found. Future design decisions are therefore scattered across `notes/` and `docs/superpowers/`, not a central context/ADR layer.
+
+## Next safe Work Pack / issue tasks
+
+### Task 1: Create an experiment workflow manifest
+
+Purpose: give future agents a single, local, non-chat contract for what each active experiment is allowed to run or write.
+
+Owned files:
+- Add `docs/EXPERIMENT_WORKFLOW.md` or `docs/experiment-manifest.md`.
+- Optionally update `README.md` to link to it.
+- Add a small packaging/docs test if the README link becomes a maintained contract.
+
+Acceptance criteria:
+- Manifest lists at least exp78, exp79_self_play_loop, exp79_lewm_tl, exp80, exp81, exp83, exp60d, and exp76c.
+- Each row names entrypoint, default output paths, tracked vs ignored artifacts, local cheap validation, heavy/remote validation, required optional deps, and stop conditions.
+- The manifest tells workers to prefer `/tmp/...` outputs unless the issue explicitly asks to update committed result artifacts.
+- No product code or experiment logic changes.
+
+Validation:
+- `python3 -m pytest tests/test_packaging_ci.py -q`
+- `git status --short`
+
+Stop conditions:
+- If maintainers need to choose a canonical experiment naming scheme first, stop and ask. Do not rename files in this task.
+
+### Task 2: Fix the exp79 artifact namespace collision
+
+Purpose: prevent one experiment run from overwriting another experiment's committed result artifact.
+
+Owned files:
+- `experiments/exp79_lewm_tl.py`
+- `experiments/exp79_self_play_loop.py` only if maintainers choose to rename both sides.
+- `tests/` for a lightweight output-path regression test.
+- `docs/superpowers/plans/2026-04-28-exp79-lewm-tl.md` or the new workflow manifest if it exists.
+
+Acceptance criteria:
+- `exp79_self_play_loop.py` and `exp79_lewm_tl.py` no longer write the same default `results.json`.
+- Existing tracked self-play results remain intact or are migrated with an explicit manifest note.
+- The LeWM `.pt` weights stay ignored and are not committed.
+- A test asserts the two default output directories/files are distinct without running training.
+
+Validation:
+- `python3 -m pytest tests/test_exp79.py tests/test_packaging_ci.py -q`
+- If a new handoff test is added, include it directly in the pytest command.
+- `git status --short --ignored` should show no new tracked generated weights.
+
+Stop conditions:
+- If historical result path compatibility matters for notes/blog posts, ask before migrating committed artifacts.
+
+### Task 3: Split optional dependency extras by workflow lane
+
+Purpose: make local validation predictable and prevent "import surprise" failures in exploratory scripts.
+
+Owned files:
+- `pyproject.toml`
+- `tests/test_packaging_ci.py`
+- New or updated docs in the experiment workflow manifest.
+
+Acceptance criteria:
+- Core package remains minimal.
+- Add explicit extras such as `vision` for exp83 (`scipy`), `lm` for exp78/81 LM proposer paths (`transformers`, maybe `mlx_lm` documented as platform-specific), and `sft` for exp60d (`transformers`, `peft`, `datasets`, `accelerate`).
+- Tests assert the extras exist and that README/manifest names the install command for each lane.
+- Unit tests must not require downloading model weights.
+
+Validation:
+- `python3 -m pytest tests/test_packaging_ci.py -q`
+- `python3 -m pytest tests/test_exp80.py -q`
+- `python3 -m pytest tests/test_web_workbench.py -q`
+
+Stop conditions:
+- If exact LM/MLX version pins require current upstream compatibility research, stop and create a separate dependency-refresh issue.
+
+### Task 4: Normalize worker validation docs for local and CI Python
+
+Purpose: remove the `python` vs `python3` handoff footgun without changing CI behavior unnecessarily.
+
+Owned files:
+- `README.md`
+- `CLAUDE.md`
+- `.github/workflows/ci.yml` only if maintainers want CI to mirror local commands.
+- `tests/test_packaging_ci.py`
+
+Acceptance criteria:
+- Docs explain that CI uses `python` from `actions/setup-python`, while local macOS workers may need `python3`.
+- The worker validation section includes a local-safe command block using `python3`.
+- `tests/test_packaging_ci.py` is updated to assert the intended docs contract instead of only the old string.
+
+Validation:
+- `python3 -m pytest tests/test_packaging_ci.py -q`
+- `python3 -m pytest tests/test_code_index.py -q`
+
+Stop conditions:
+- If the repo standard is to require virtualenvs that provide `python`, document that instead of changing all examples.
+
+### Task 5: Add a no-write smoke lane for active experiments
+
+Purpose: give future agents a safe command that proves import/CLI shape without mutating tracked result files or starting training.
+
+Owned files:
+- `tests/test_experiment_entrypoints.py` or similar.
+- Experiment scripts only for adding `--help`, `--dry-run`, or `--out` support where missing.
+
+Acceptance criteria:
+- Smoke tests cover `--help` or dry-run for exp78, exp79_self_play_loop, exp79_lewm_tl, exp80, exp81, and exp83.
+- Tests do not train models, download model weights, call external services, or write tracked result paths.
+- Scripts that currently lack a no-write mode get the smallest CLI addition needed.
+
+Validation:
+- `python3 -m pytest tests/test_experiment_entrypoints.py -q`
+- `python3 -m pytest tests/test_packaging_ci.py -q`
+
+Stop conditions:
+- If adding no-write flags to several scripts becomes broad, split by experiment family.
+
+## Validation command candidates
+
+| Command | Observed / expected status | Notes |
+|---|---:|---|
+| `git status --short` | Required queue validation; exit 0 | Initially clean. After this report, should show only the report until committed. |
+| `python3 -m pytest tests/test_packaging_ci.py -q` | Observed pass: 3 passed | Proves package/README/CI worker validation contract tests. |
+| `python3 -m pytest tests/test_code_index.py -q` | Observed pass: 15 passed | Creates ignored `tools/index.json` during CLI status freshness test. |
+| `python3 -m pytest tests/test_web_workbench.py -q` | Observed pass: 2 passed in 6.18s | Proves workbench/CLI/API parity smoke. |
+| `python -m pytest tests/ -v` | Expected local fail unless `python` exists | Documented CI command, but local shell has no `python`. |
+| `python3 -m pytest tests/ -v` | Expected full-suite candidate, not run in this audit | Safe next validation after dependencies are installed; may take longer than narrow proofs. |
+| `python3 tools/code_index.py --status` | Observed fail before index refresh | Exit 1 because ignored index is missing/stale. Use `--lookup <symbol>` for agent planning. |
+| `rtk pytest tests/test_packaging_ci.py -q` | Observed misleading no-collection output | Prefer raw `python3 -m pytest` in handoffs for this repo. |
+| `python3 experiments/exp78_rule_induction.py --out /tmp/exp78-results.json --n-pos 5 --n-neg 5` | Expected cheap no-LM experiment candidate, not run | Use `/tmp` output to avoid tracked artifact mutation. |
+| `python3 experiments/exp79_self_play_loop.py --mode easy --out /tmp/exp79-self-play.json` | Expected local experiment candidate, not run | Avoid default tracked `experiments/exp79_data/results.json`. |
+
+## Non-goals for this queue item
+
+- No product code edits.
+- No experiment reruns that write committed data.
+- No remote jobs, Kaggle notebooks, datasets, deploys, pushes, PRs, or external tracker updates.
+- No dependency upgrades.
+- No validation of scientific or FAFSA claims against external sources.
+- No sibling-repo comparison; this repo is large enough that the workflow-handoff audit had sufficient local depth.
+
+## Unknowns and blockers
+
+- Unknown whether maintainers want exp79 naming preserved for historical continuity or split into `exp79_self_play_data` and `exp79_lewm_data`.
+- Unknown whether the preferred local Python contract is "use `python3`" or "always activate a venv that provides `python`".
+- Unknown whether optional heavy dependencies should be version-pinned now or only documented per lane.
+- Unknown whether `CONTEXT.md`/ADR docs should be introduced before more architectural changes.
+- No blockers to writing this report. Creating a local commit from this worker is blocked by sandbox permissions because this worktree's Git metadata resolves outside the writable root.
+
+## Final handoff notes
+
+- Changed file: `docs/overnight/tensor-experiments-workflow-handoff.md`
+- Product code changed: no
+- External services used: no
+- PR created: no
+- Commit created: no. Current HEAD remains `5565791a8c888511bbbff1107d2d357164f88baa`.
+- Required validation command: `git status --short`
+- Required validation result after report write: exit 0, output `?? docs/overnight/`
+- Commit blocker: `git add docs/overnight/tensor-experiments-workflow-handoff.md` failed with `fatal: Unable to create .../index.lock: Operation not permitted`.
+- Main workflow blocker found: workflow ambiguity, not local execution. The highest-risk ambiguity is exp79 artifact ownership.

--- a/docs/overnight/tensor-logic-architecture-map.md
+++ b/docs/overnight/tensor-logic-architecture-map.md
@@ -1,0 +1,156 @@
+# tensor-logic architecture-map audit
+
+Queue item: `tensor-logic-architecture-map`
+Branch: `codex/goal-tensor-logic-architecture-map`
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/tensor-logic-architecture-map`
+Audit time observed locally: `2026-05-06 23:53:02 PDT`
+Initial HEAD: `c9e2cfce206bb279a4348189726908fcb436d3dc`
+
+## Scope and decisions
+
+- Wrote exactly one report file: `docs/overnight/tensor-logic-architecture-map.md`.
+- Did not edit product code, generated data, secrets, external services, deploys, pushes, PRs, or trackers.
+- Used the architecture review vocabulary for module/interface/seam/adapter/depth/locality, but did not enter the interactive refactor loop because this queue item requires a standalone read-only report.
+- Used `python3` for code-index and test commands because `python tools/code_index.py --dump` failed locally with `python: command not found`. The repo docs still show `python -m ...` commands in places, so local runners should either provide a `python` shim or use `python3` explicitly.
+
+## Commands run
+
+- `pwd && (command -v llm-tldr >/dev/null 2>&1 && llm-tldr tree . || ...)`
+  - Result: captured repo structure. Main directories are `tensor_logic/`, `experiments/`, `demos/`, `tests/`, `docs/`, `notes/`, `phase_training/`, `web_workbench/`, `tools/`, and `examples/`.
+- `git status --short && git branch --show-current && git rev-parse HEAD`
+  - Result: initial worktree was clean; branch was `codex/goal-tensor-logic-architecture-map`; HEAD was `c9e2cfce206bb279a4348189726908fcb436d3dc`.
+- `rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g 'README*' -g 'package.json' -g 'pyproject.toml' -g 'Cargo.toml' -g 'go.mod' -g 'Makefile' -g 'justfile' -g 'docs/**'`
+  - Result: found `CLAUDE.md`, `README.md`, `pyproject.toml`, domain docs, run protocols, and superpowers plans/specs.
+- `python tools/code_index.py --dump`
+  - Result: failed with `python: command not found`.
+- `python3 tools/code_index.py --dump`
+  - Result: indexed the reusable API, including `Program`, `RuleParser`, `prove`, `prove_negative`, `execute_command`, `load_tl`, HTTP helpers, repo graph helpers, and rule adapters.
+- `python3 tools/code_index.py --lookup Program && ... --lookup RuleParser && ... --lookup prove && ... --lookup execute_command && ... --lookup parse_rule`
+  - Result: confirmed current signatures before writing next-work suggestions against `tensor_logic/`.
+- `rg -n "^(class|def|@dataclass|from |import )" tensor_logic tests/...`
+  - Result: mapped public classes/functions and the tests exercising core seams.
+- `wc -l tensor_logic/*.py tensor_logic/research/*.py tests/*.py experiments/exp8*.py experiments/exp9*.py web_workbench/server.py web_workbench/static/app.js`
+  - Result: reusable package is about 2.9k lines; `tests/test_tensor_logic_core.py` is the broadest core test at 939 lines; late support experiments are larger and mostly outside the reusable package.
+- `python3 -m tensor_logic ingest-python tensor_logic | sed -n '1,160p'`
+  - Result: generated a local import graph for `tensor_logic/` with 22 module symbols and direct imports such as `__main__ -> execution`, `http_api -> execution`, `repo_graph_view -> proofs`, `rules -> program`, and `program -> language`.
+- `python3 -m pytest tests/test_tensor_logic_core.py::TensorLogicCoreTest::test_program_string_rules tests/test_tensor_logic_core.py::TensorLogicCoreTest::test_cli_and_http_share_negative_proof_json_semantics -q`
+  - Result: `2 passed in 2.50s`.
+- Queue validation command: `git status --short`
+  - Result after writing this report: exit 0, output `?? docs/overnight/`.
+
+## Dirty state
+
+- Initial dirty state: clean.
+- Final dirty state before any commit: one untracked report under `docs/overnight/`.
+- No product code files were modified.
+
+## Architecture map
+
+The repository has two identities that now share one tree:
+
+- Research notebook/history repo: `README.md:5` and `README.md:7` frame the repo as a learning/research project; `experiments/`, `demos/`, `notes/`, and `phase_training/` preserve the exploration arc.
+- Reusable library dependency: `README.md:3` says this repo now serves as the shared `tensor_logic` library dependency for other workspace projects, and `README.md:73` says new experiments should import the package rather than copying older logic.
+
+### Main entrypoints
+
+- Python package import surface: `tensor_logic/__init__.py:3-20` imports most reusable modules, and `tensor_logic/__init__.py:23-66` exports a broad API. This includes core substrate classes, CLI/execution helpers, HTTP helpers, proof helpers, repo graph helpers, and legacy `tl_rule` parsing/evaluation.
+- CLI: `tensor_logic/__main__.py:13-49` defines `run`, `query`, `prove`, `ingest-python`, `repl`, `repo-graph`, and `serve`. `tensor_logic/__main__.py:77-90` routes loaded `.tl` programs into shared command execution.
+- HTTP API: `tensor_logic/http_api.py:20-57` exposes source-level helper functions; `tensor_logic/http_api.py:64-99` maps POST paths to `/ingest-python`, `/run`, `/query`, and `/prove`.
+- Web workbench: `web_workbench/server.py:44-83` writes a temporary `.tl` file and invokes `sys.executable -m tensor_logic` as a subprocess instead of calling `tensor_logic.execution` directly.
+- Memjuice reason subprocess: `tensor_logic/reason.py:1-8` documents a `python -m tensor_logic.reason` entrypoint; `tensor_logic/reason.py:239-293` runs the optimize loop and prints JSON.
+
+### Core modules and ownership
+
+- Tensor/equation substrate: `tensor_logic/language.py` owns `Domain`, `Relation`, expression dataclasses, relation data tensors, expression evaluation, boolean fixpoints, and arbitrary-arity relation storage. `tensor_logic/closure.py` owns graph closure helpers, and `tensor_logic/semirings.py` owns small matrix semiring helpers.
+- Program and file format: `tensor_logic/program.py:43-102` owns mutable `Program` state for domains, relations, rules, and fact sources. `tensor_logic/program.py:85-90` parses a rule once into an eager tensor equation and again into canonical proof rules. `tensor_logic/file_format.py` owns `.tl` parsing, includes, facts, rules, and queued query/prove commands.
+- Canonical rule shape: `docs/superpowers/specs/2026-05-04-rule-language-shape.md:11-27` defines `tensor_logic.program.Atom` and `Rule` as the canonical internal representation. `tensor_logic/program.py:12-34` matches that shape.
+- Rule adapters and evaluators: `tensor_logic/rules.py:13-26` parses XML-like `<tl_rule>` tags into canonical `program.Atom`/`program.Rule`. `tensor_logic/rules.py:93-155` evaluates binary graph-dict rules with PyTorch tensors. This is an adapter/evaluator surface, not the owner of the durable rule language.
+- Proof engine: `tensor_logic/proofs.py:44-76` handles positive proofs with tabling and an optional recursive fallback; `tensor_logic/proofs.py:78-117` handles negative proofs. Formatting and JSON payload shaping are split into `tensor_logic/proof_result.py` and `tensor_logic/proof_tree_viewer.py`.
+- Repo import graph: `tensor_logic/ingest.py` turns Python imports into `.tl` source; `tensor_logic/repo_graph_view.py:17-32` loads repo graph facts and `tensor_logic/repo_graph_view.py:92-114` builds dependency reports with query/proof output.
+- Search/reason loop: `tensor_logic/optimize.py` owns the general Pareto frontier loop; `tensor_logic/reason.py:49-89` maps observations into `.tl` domains/relations and `tensor_logic/reason.py:185-217` evaluates candidate TL rules.
+- Research support modules: `tensor_logic/research/` contains slot-attention and rule-induction utilities used by later experiments. Larger late experiments such as `experiments/exp85_support_tl.py` are still experiment-local modules.
+
+### Import graph evidence
+
+`python3 -m tensor_logic ingest-python tensor_logic` found these important internal edges:
+
+- CLI and adapters point inward: `__main__ -> execution`, `__main__ -> file_format`, `__main__ -> http_api`, `__main__ -> ingest`, `__main__ -> repo_graph_view`.
+- HTTP points to execution, file format, and ingestion: `http_api -> execution`, `http_api -> file_format`, `http_api -> ingest`.
+- Program points to language: `program -> language`.
+- Rules and proofs consume canonical program shapes: `rules -> program`, `proofs -> program`.
+- Proof result and repo graph consume proof engine: `proof_result -> proofs`, `repo_graph_view -> proofs`.
+- Research constants depend on research utils: `research_constants -> research_utils`.
+
+This is a mostly acyclic package with `program.py`/`language.py` as the deepest reusable substrate and outward adapters around it.
+
+## Module depth and friction
+
+### Strong seams
+
+- `Program` is a useful deep module: callers get domain/relation/fact/rule/query/fixpoint behavior through a compact interface, while tensor data, sources, expressions, and proof rules stay local to `program.py` and `language.py`.
+- `execution.py` is a useful adapter seam between CLI/HTTP and the proof/query implementation. `tensor_logic/execution.py:38-83` centralizes query/prove command behavior and keeps formatting in one place.
+- `ingest.py` plus `repo_graph_view.py` forms a coherent import-graph slice: one module renders `.tl`; the other loads and explains dependency facts.
+
+### Shallow or leaking seams
+
+- `__init__.py` is broad enough to blur ownership. Importing `tensor_logic` imports HTTP server helpers, repo graph helpers, legacy graph-dict provenance, command execution, and core language classes all at once (`tensor_logic/__init__.py:3-20`). This is convenient but weakens locality for future dependency-sensitive users.
+- `web_workbench/server.py` shells out to the CLI (`web_workbench/server.py:57-71`) while `http_api.py` and `execution.py` already provide in-process adapter surfaces. That choice may be intentional for parity with the CLI, but it means the workbench has a different error and performance path than the HTTP API.
+- `provenance.py` is a parallel proof-tree implementation over graph dictionaries (`tensor_logic/provenance.py`) while `proofs.py` is the `Program`-based proof engine. This preserves older demos, but future proof UI work has two proof representations to remember.
+
+## Stale assumptions and boundary risks
+
+1. Binary arity is explicit but spread across several modules.
+   - The canonical spec says `Atom.args` is variadic and warns not to bake binary-only fields into the shared language (`docs/superpowers/specs/2026-05-04-rule-language-shape.md:94-110`).
+   - Current code still has binary consumer boundaries in `execution.py:38-52`, `execution.py:64-112`, `rules.py:60-63`, `rules.py:93-155`, and `proofs.py:249-305`.
+   - `program.Atom.left/right` properties at `tensor_logic/program.py:22-28` assume at least two args without guardrails. That is compatible with current binary consumers but is a sharp edge if arbitrary arity expands.
+
+2. The rule parser has a two-output, two-pass interface.
+   - The approved spec says `Program.rule()` / `RuleParser` should parse one source rule into both the tensor expression and one or more canonical `Rule` values (`docs/superpowers/specs/2026-05-04-rule-language-shape.md:42-47`).
+   - Current `Program.rule()` calls `RuleParser(self).parse_rule(text)` and then creates a fresh `RuleParser(self).parse_rule_ast_list(text)` (`tensor_logic/program.py:85-90`). This keeps correctness local today, but it makes expression and proof AST behavior easier to drift.
+   - TL program syntax does not currently expose a negation spelling; `RuleParser._parse_factor_atoms` records positive atoms and skips expression methods (`tensor_logic/program.py:210-227`). Negation is only visible in the XML-like `<tl_rule>` adapter (`rules.py:43-51`) even though `program.Atom.negated` is shared.
+
+3. Recursive relation proof still has a heuristic fallback.
+   - `prove()` first tries tabled rule proofs, but if no proof is found and `recursive=True`, it calls `_prove_recursive_chain` (`tensor_logic/proofs.py:67-76`).
+   - `_find_base_relation` picks the first other binary relation with matching domains (`tensor_logic/proofs.py:372-378`). This works for simple `imports -> depends_on` / `edge -> path` shapes, but it is not a durable interface if a program has multiple same-domain base relations.
+
+4. Support/stability is called a TL engine but is currently experiment-local.
+   - The plan calls for a "TL rule engine over primitive relations" (`docs/superpowers/plans/2026-05-05-support-stability.md:70-78`) and a "TL Stability Engine" (`docs/superpowers/plans/2026-05-05-support-stability.md:217-229`).
+   - The implemented experiment starts as `experiments/exp85_support_tl.py` and defines its own `ProofTrace`, `PrimitiveRelations`, `StabilityResult`, and fixpoint logic (`experiments/exp85_support_tl.py:1-67`) rather than using `Program`, `Rule`, or `Proof`.
+   - This may be the right local experiment interface, but it should be called out before promoting it as reusable `tensor_logic` substrate.
+
+5. Historical plans are useful context but not always current source of truth.
+   - Example: `docs/superpowers/plans/2026-04-28-optimize-loop.md` describes desired `tensor_logic.reason` work and mentions APIs such as `Program.from_source`; current code instead builds `.tl` source and loads it through temp files (`tensor_logic/reason.py:196-215` and `_program_from_tl_source` around `tensor_logic/reason.py:126-137`).
+   - Morning agents should treat `docs/superpowers/specs/` decisions as higher-signal than older implementation plans unless the code contradicts them.
+
+## Missing validation
+
+- Required queue validation is only `git status --short`; it is runnable locally.
+- Required queue validation ran successfully after this report was written: `git status --short` exited 0 and reported `?? docs/overnight/`.
+- Full worker validation from `README.md:85-93` (`python -m pip install -e ".[dev]"` and `python -m pytest tests/ -v`) was not run because this queue item requested a read-only architecture report and validation command is `git status --short`.
+- I ran two focused proof/CLI parity tests as audit evidence: `python3 -m pytest tests/test_tensor_logic_core.py::TensorLogicCoreTest::test_program_string_rules tests/test_tensor_logic_core.py::TensorLogicCoreTest::test_cli_and_http_share_negative_proof_json_semantics -q` passed with `2 passed in 2.50s`.
+- Local environment note: bare `python` is missing; `python3` works for code-index and focused pytest commands.
+
+## Next safe work
+
+1. Make the binary arity boundary mechanically explicit.
+   - Files likely touched: `tensor_logic/program.py`, `tensor_logic/proofs.py`, `tensor_logic/rules.py`, `tensor_logic/execution.py`, `tests/test_tensor_logic_core.py`.
+   - Acceptance criteria: binary consumers reject non-binary atoms/commands with consistent errors; `Atom.left/right` either guard arity or become adapter-local helpers; canonical `Atom.args` remains variadic.
+   - Validation: `python3 -m pytest tests/test_tensor_logic_core.py::TensorLogicCoreTest::test_cli_invalid_arity_and_parse_errors_are_external_failures tests/test_tensor_logic_core.py::TensorLogicCoreTest::test_tl_rule_evaluate_reports_unknown_relation -q`.
+
+2. Decide whether support/stability stays experiment-local or becomes reusable package surface.
+   - Files likely touched for a planning-only slice: `docs/superpowers/plans/2026-05-05-support-stability.md` or a new ADR/context doc. Files likely touched for implementation: `experiments/exp85_support_tl.py`, `tensor_logic/research/` or a new `tensor_logic/support.py`, and `tests/test_exp85_support_tl.py`.
+   - Acceptance criteria: docs state whether `exp85` is an isolated experiment adapter or the intended reusable TL support module; if promoted, public interfaces and proof format align with `Program`/`Proof` or explicitly justify a separate interface.
+   - Validation: planning-only `git diff --check`; implementation `python3 -m pytest tests/test_exp85_support_tl.py -q`.
+
+3. Unify web workbench execution with the existing in-process execution seam, or document the subprocess choice.
+   - Files likely touched: `web_workbench/server.py`, `tests/test_web_workbench.py`, possibly `web_workbench/README.md`.
+   - Acceptance criteria: workbench either calls `tensor_logic.execution`/`http_api` directly, or README/tests explicitly assert CLI-subprocess parity as the intended contract.
+   - Validation: `python3 -m pytest tests/test_web_workbench.py -q`.
+
+## Handoff
+
+- Changed files: `docs/overnight/tensor-logic-architecture-map.md`.
+- Commit SHA at audit start: `c9e2cfce206bb279a4348189726908fcb436d3dc`.
+- Validation result: `git status --short` exited 0 and reported `?? docs/overnight/`.
+- PR URL: none; PR creation is out of scope for this queue item.
+- Blockers: none for writing the report. Environment caveat: `python` command is absent, so commands documented with `python ...` need `python3 ...` or a shim in this local worker.

--- a/docs/overnight/tensor-logic-dependency-surface.md
+++ b/docs/overnight/tensor-logic-dependency-surface.md
@@ -1,0 +1,255 @@
+# tensor-logic dependency-surface audit
+
+Queue item: `tensor-logic-dependency-surface`
+Date: 2026-05-07
+Focus area: dependency surface
+Repo: `tensor-logic`
+Branch observed: `codex/goal-tensor-logic-dependency-surface`
+
+## Purpose and State
+
+`tensor-logic` is a Python research repo that now serves two roles: a reusable
+`tensor_logic` package for tensor-logic reasoning utilities, and a large
+collection of demos, one-off experiments, notes, generated experiment data, and
+local workbench tools. The reusable package is small; the dependency surface is
+mostly created by experiment scripts and generated artifacts around it.
+
+Initial dirty state was clean. `git status --short --branch` returned only:
+
+```text
+## codex/goal-tensor-logic-dependency-surface
+```
+
+Starting HEAD before this report was:
+
+```text
+c9e2cfce206bb279a4348189726908fcb436d3dc
+```
+
+No product code, generated experiment data, external services, pushes, or PRs
+were touched. The only intended durable change from this worker is this report.
+
+## Command Evidence
+
+| Command | Observation |
+|---|---|
+| `llm-tldr tree .` | Repo has `tensor_logic/`, `experiments/`, `demos/`, `phase_training/`, `web_workbench/`, `tests/`, `docs/`, `notes/`, `tools/`, and committed experiment data folders. |
+| `rg --files` | Tracked surface includes 167 Python files, 31 Markdown files, 22 JSON files, 7 JSONL files, 4 `.tl` examples, 2 PNGs, 1 workflow, and 1 `pyproject.toml`. |
+| `du -sh . tensor_logic experiments tests docs web_workbench phase_training demos` | Repo is 11M total; `experiments/` is 10M; `tensor_logic/` is 148K; `tests/` is 160K. |
+| `python3 --version` | Local interpreter is Python 3.12.8; CI pins Python 3.11. |
+| Python AST import scan over `tensor_logic`, `experiments`, `demos`, `phase_training`, `tools`, `web_workbench`, `tests` | Scanned 167 Python files. Top import roots include `torch` in 104 files, `tensor_logic` in 17 files, `transformers` in 5 files, `numpy` in 4 files, `matplotlib` in 2 files, `mlx_lm` in 1 file, `peft` in 1 file, `datasets` in 1 file, and `scipy` in 1 file. |
+| `python3 - <<'PY' ... importlib.util.find_spec(...)` | Local environment has `torch`, `numpy`, `matplotlib`, `scipy`, `tqdm`, and `pytest`; it is missing `transformers`, `mlx_lm`, `peft`, and `datasets`. |
+| `python3 tools/code_index.py --status` | Exited 1 with `stale: index.json is missing or older than source files`; `tools/index.json` is intentionally gitignored and absent on a clean checkout. |
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/ -q` | Passed: `198 passed in 34.50s`. This test run generated ignored `tools/index.json`; the worker removed it afterward. |
+| `git status --short --ignored=matching` after cleanup | Empty before writing this report, confirming no ignored cache/index state was left behind. |
+
+## Local File Evidence
+
+- `pyproject.toml` declares package metadata, Python `>=3.11`, one runtime dependency (`torch>=2.0`), and dev extras for `pytest`, `numpy`, and `matplotlib`.
+- `.github/workflows/ci.yml` installs `.[dev]` on Python 3.11 and runs `python -m pytest tests/ -v`.
+- `README.md` documents worker validation as `python -m pip install -e ".[dev]"` and `python -m pytest tests/ -v`; it also documents demo execution through `uv run --with torch ...`.
+- `CLAUDE.md` documents MLX and transformers support in `experiments/exp78_rule_induction.py`, but those packages are not represented in `pyproject.toml` extras.
+- `.gitignore` excludes `.venv/`, `.uv/`, `__pycache__/`, `.pytest_cache/`, `.ruff_cache/`, `.cocoindex_code/`, `tools/index.json`, build outputs, `*.pt`, and `*.pth`.
+- `tools/code_index.py` writes `tools/index.json` from `--rebuild`, `--lookup`, and `--dump` through `ensure_fresh`; the generated file is ignored.
+- `tests/test_code_index.py` verifies `tools/index.json` is gitignored, but also runs CLI rebuild/status tests that can create the ignored index in a worker checkout.
+- `tests/test_packaging_ci.py` asserts the current install/test contract and README/docs validation strings, so dependency contract changes should update this test.
+- `tensor_logic/__main__.py` exposes CLI entrypoints: `run`, `query`, `prove`, `ingest-python`, `repl`, `repo-graph`, and `serve`.
+- `tensor_logic/http_api.py` provides a local HTTP API using stdlib `ThreadingHTTPServer`; it accepts source and path payloads and routes to package execution helpers.
+- `web_workbench/server.py` writes editor source to a temporary `.tl` file and calls `[sys.executable, "-m", "tensor_logic"]` through `subprocess.run` without a timeout.
+- `tensor_logic/execution.py` uses temporary `.tl` files to load source strings, and removes those temporary files in `finally`.
+- `tensor_logic/ingest.py` parses Python imports with stdlib `ast` and skips cache, VCS, virtualenv, and hidden directories.
+- `experiments/exp53_real_imports.py` and `experiments/exp54_big_imports.py` call `pip download --no-deps --no-binary :all:` and extract archives into temp directories to evaluate third-party package import graphs.
+- `experiments/exp60d_sft.py` documents `pip install torch transformers peft datasets accelerate`, imports `transformers`, `peft`, `datasets`, and optional `tqdm`, and writes a default LoRA output under `experiments/exp60_data/lora_adapter`.
+- `experiments/exp78_rule_induction.py` lazily imports `transformers` and `mlx_lm`; it has a no-transformers fallback, but MLX/transformers behavior is not covered by declared extras.
+- `experiments/exp83_slot_attention.py` imports `scipy.optimize.linear_sum_assignment`, `numpy`, `matplotlib`, and `torch`; it writes `experiments/exp83_slot_data/results.json` and `complexity_curve.png`.
+
+## Dependency Surface Map
+
+### Declared Python contract
+
+The published package contract is intentionally small:
+
+- Runtime: `torch>=2.0`
+- Dev extra: `pytest>=8.0`, `numpy>=1.24`, `matplotlib>=3.7`
+- Package discovery: `tensor_logic*`
+- No lockfile, `requirements.txt`, `uv.lock`, `poetry.lock`, `tox.ini`, `noxfile.py`, `Makefile`, or pre-commit config was found. The broad lockfile scan only matched `experiments/exp27_blocks_world.py` because the filename contains `block`.
+
+This is enough for the current test suite and the core library, but not enough
+to reproduce the full experiment portfolio.
+
+### Actual import surface
+
+The core package is mostly stdlib plus `torch`. The broader repo includes these
+additional stacks:
+
+- Research/data stack: `numpy`, `matplotlib`, `scipy`
+- LM stack: `transformers`, `mlx_lm`
+- SFT stack: `peft`, `datasets`, `accelerate` documented but not imported directly in the scan, and `tqdm`
+- Network/package acquisition: `pip download` through subprocess in `exp53` and `exp54`
+- Local HTTP/subprocess stack: stdlib `http.server`, `tempfile`, `subprocess`
+
+The missing local modules (`transformers`, `mlx_lm`, `peft`, `datasets`) mean a
+clean `.[dev]` environment can pass CI while failing several documented
+experiments.
+
+### Scripts and entrypoints
+
+The repo has no `[project.scripts]` entry in `pyproject.toml`. Users run tools
+through module/script commands:
+
+- `python -m tensor_logic ...` for CLI commands implemented in `tensor_logic/__main__.py`
+- `python web_workbench/server.py --host 127.0.0.1 --port 8080`
+- `python tools/code_index.py --status|--lookup|--dump|--rebuild`
+- Many direct experiment scripts, several with `--quick` or output flags
+
+This is workable for a research repo, but it makes the supported command set
+depend on README/docs discipline rather than package metadata.
+
+### Generated artifacts and local-only state
+
+Tracked generated artifacts are already present:
+
+- `experiments/exp60_data/*.jsonl`: 3 files, 655,897 bytes
+- `experiments/exp76_data/*.jsonl`: 4 files, 2,753,555 bytes
+- `experiments/exp78_data/results.json`: 4,744 bytes
+- `experiments/exp79_data/results.json` plus `complexity_curve.png`: 54,312 bytes
+- `experiments/exp83_slot_data/results.json` plus `complexity_curve.png`: 23,811 bytes
+- `experiments/exp87_support_data` through `experiments/exp95_scored_object_hypotheses_data`: committed `results.json` and `results_quick.json` outputs, ranging from about 10K to 2.3M per folder
+
+Ignored local-only state includes Python caches, virtualenvs, `.uv/`,
+`.cocoindex_code/`, `tools/index.json`, build outputs, and PyTorch checkpoint
+extensions. It does not explicitly ignore LoRA adapter folders, safetensors, or
+Hugging Face model cache paths under experiment data folders.
+
+### Environment variables and secrets
+
+No active source under `tensor_logic`, `experiments`, `demos`,
+`phase_training`, `web_workbench`, `tests`, or `tools` reads `os.environ` for
+API keys or service tokens. The env-var search only found false positives in
+identifier names and historical docs. There are no `.env*` files in the repo
+scan. The main external risks are package downloads, model downloads from
+`transformers`/MLX paths, and local subprocess execution, not checked-in
+secrets.
+
+## Risks and Stale Assumptions
+
+1. Declared dependencies understate the experiment surface. `pyproject.toml`
+   and CI make `.[dev]` look complete, while documented scripts need
+   `transformers`, `mlx_lm`, `peft`, `datasets`, `accelerate`, `scipy`, and
+   sometimes model downloads. Morning reviewers should not assume "CI green"
+   means "all experiments reproducible."
+
+2. The code-index workflow creates hidden local state. `CLAUDE.md` tells agents
+   to use `tools/code_index.py`, but `--lookup` and `--dump` rebuild the ignored
+   `tools/index.json` when missing or stale. Tests also rebuild it. This can
+   leave worktrees looking clean under `git status --short` while carrying an
+   ignored generated index.
+
+3. Several scripts overwrite tracked experiment outputs. `exp83`, `exp79`, and
+   support-eval experiments write `results.json`, `results_quick.json`, or PNGs
+   under committed data folders. Running a script for validation can mutate
+   review artifacts unless workers know which commands are safe.
+
+4. External package/model acquisition is not gated in metadata. `exp53` and
+   `exp54` use `pip download` against live package indexes; LM experiments can
+   trigger Hugging Face or MLX model loads. Those are appropriate for explicit
+   experiment runs, but they should not be treated as cheap local validation.
+
+5. Local web execution has no timeout boundary. `web_workbench/server.py` shells
+   out to `python -m tensor_logic` with user-provided source and no timeout.
+   This is local-only, but a recursive or expensive query can tie up a worker or
+   browser QA session.
+
+6. Python version coverage is narrower than the package range. The package says
+   Python `>=3.11`, CI tests 3.11, and this local audit ran under 3.12.8. There
+   is no matrix or lockfile proving behavior across future Python releases or
+   Torch wheels.
+
+## Validation Candidates
+
+| Command | Expected status | Observed status in this audit |
+|---|---|---|
+| `git status --short` | Pass. Required queue validation; should show only the report before commit, or no output after a local commit. | Passed after writing this report with `?? docs/overnight/`. |
+| `python3 -m pytest tests/test_packaging_ci.py -q` | Pass; verifies current packaging/CI/docs contract. | Passed: `4 passed in 0.02s`. |
+| `python3 -m pytest tests/test_tensor_logic_core.py -q` | Pass; cheap core behavior check, no optional LM deps. | Passed: `54 passed in 10.90s`. |
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/ -q` | Pass in current local environment; may create ignored `tools/index.json` through `tests/test_code_index.py`. | Passed: `198 passed in 34.50s`; generated index was removed. |
+| `python3 tools/code_index.py --status` | Fail on a clean checkout unless `tools/index.json` has been rebuilt. This is expected under current design. | Failed with exit 1: `stale: index.json is missing or older than source files`. |
+| `python3 experiments/exp86_support_baselines.py --quick` | Candidate support/stability smoke from README; expected pass if core deps are installed. | Not run in this audit; product experiment execution was outside the dependency-surface report scope. |
+| `python3 experiments/exp60d_sft.py --skip-train --n-eval 1` | Expected fail locally unless `transformers`, `peft`, and `datasets` are installed and model access is available. | Not run; import availability scan already showed missing LM/SFT deps. |
+| `python3 experiments/exp83_slot_attention.py --help` | Expected pass locally because `scipy`, `numpy`, `matplotlib`, and `torch` are installed. Full run is expensive and mutates tracked outputs. | Not run to avoid accidental artifact mutation. |
+
+## Next Safe Work
+
+1. Add optional dependency extras for experiment families.
+   Acceptance: `pyproject.toml` exposes clear extras such as `.[slot]`,
+   `.[lm]`, `.[sft]`, or `.[experiments]`; README and `tests/test_packaging_ci.py`
+   document which commands each extra supports; core `.[dev]` remains small.
+   Validation: `python3 -m pytest tests/test_packaging_ci.py -q` and an import
+   availability smoke for each new extra in an environment where those extras
+   are installed.
+
+2. Make code-index commands side-effect explicit.
+   Acceptance: `tools/code_index.py --status` remains read-only; `--dump` and
+   `--lookup` either support a documented `--no-rebuild` mode or print a clear
+   "will rebuild ignored tools/index.json" message before writing; docs tell
+   agents how to clean generated index state.
+   Validation: `python3 -m pytest tests/test_code_index.py -q` and
+   `git status --short --ignored=matching` after the test run.
+
+3. Add an experiment artifact manifest.
+   Acceptance: each committed `experiments/*_data/` folder has a documented
+   producing script, whether files are canonical or regenerable, whether script
+   runs overwrite tracked files, and the cheapest non-mutating validation.
+   Validation: a small test or script checks every tracked `*_data` directory is
+   listed in the manifest.
+
+4. Gate external acquisition scripts.
+   Acceptance: `exp53` and `exp54` require an explicit flag such as
+   `--allow-network` for `pip download`, document package-index dependency, and
+   use safe archive extraction behavior where the supported Python version
+   allows it.
+   Validation: `python3 experiments/exp53_real_imports.py --help` and a unit
+   test for the no-network default path.
+
+5. Add a timeout to local web subprocess execution.
+   Acceptance: `web_workbench/server.py` bounds `subprocess.run` with a timeout
+   and returns a structured timeout error; tests cover a timeout path without
+   sleeping for a long time.
+   Validation: `python3 -m pytest tests/test_web_workbench.py -q`.
+
+## Non-Goals
+
+- No product code edits.
+- No dependency installation or lockfile generation.
+- No experiment reruns that write result JSON, PNG, checkpoints, adapters, or
+  model outputs.
+- No network access, package downloads, model downloads, deploys, pushes, or PR
+  creation.
+- No changes to GitHub/Linear/external tracker state.
+
+## Unknowns
+
+- Whether the intended public install contract is only the reusable
+  `tensor_logic` package, or the full experiment portfolio.
+- Whether optional LM/SFT dependencies should be grouped by experiment number,
+  by capability, or left as script-local docstrings.
+- Whether committed result files under `experiments/*_data/` are canonical
+  audit artifacts or disposable generated outputs.
+- Whether downstream sibling repos (`fafsa-engine`, future `officeqa-*`) depend
+  only on `tensor_logic`, or also assume experiment modules are importable.
+- Whether `tools/index.json` should stay ignored and regenerated locally, or be
+  replaced by a pure read-only AST query path for agent planning.
+
+## Handoff
+
+The dependency surface is manageable if reviewers distinguish three layers:
+core package (`torch` plus stdlib), tested developer contract (`.[dev]`), and
+optional experiment stacks. The highest-leverage cleanup is to encode those
+layers in package metadata/docs and to make mutating/generated state explicit
+before more workers use this repo as a dependency or validation target.
+
+Local commit/PR handoff was not completed. `git add
+docs/overnight/tensor-logic-dependency-surface.md` failed because the worktree
+index lives under `/Users/jwalinshah/projects/tensor/tensor-logic/.git/worktrees/tensor-logic-dependency-surface/index.lock`,
+which is outside this sandbox's writable roots. No PR was created, per queue
+scope.

--- a/docs/overnight/tensor-logic-docs-claims.md
+++ b/docs/overnight/tensor-logic-docs-claims.md
@@ -1,0 +1,163 @@
+# tensor-logic docs-claims audit
+
+Queue item: `tensor-logic-docs-claims`  
+Repo path: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/tensor-logic-docs-claims`  
+Branch observed: `codex/goal-tensor-logic-docs-claims`  
+Focus: docs claims, supported evidence, unsupported claims, and safe next work.
+
+## Executive summary
+
+`tensor-logic` is a research repo plus reusable Python package for tensor-logic experiments, proof/query execution, and support/stability experiments. The strongest current claims are backed by local code and tests: reusable `tensor_logic` exports, TL file parsing, CLI/HTTP/workbench execution, proof trees, stratified negation, support/stability perfect-state evaluation, and committed support/stability result JSON for experiments 87-95.
+
+The main stale surface is `README.md`. It still frames the repo as `experiments/exp1` through `exp54` and says `demos/` has five headline runnable demos, while the checkout contains experiments and tests through `exp95` and eight demo scripts. The README headline transitive-closure tables cite runnable scripts but do not have committed result JSON/manifests for `exp53_real_imports.py` or `exp54_big_imports.py`; rerunning them requires network-dependent `pip download` of external packages. The support/stability docs and `notes/EXPERIMENTS.md` are much fresher and preserve caveats, but the root README has not absorbed those newer claims.
+
+## Commands run
+
+- `pwd` confirmed the worktree path.
+- `git status --short --branch` initially reported only `## codex/goal-tensor-logic-docs-claims`, with no dirty files.
+- `git rev-parse --show-toplevel` confirmed the repo root is the worktree root.
+- `git log --oneline -5` showed current HEAD at `c9e2cfc Merge pull request #46 from jwalin-shah/codex/SYM-220-scored-object-hypotheses`.
+- `llm-tldr tree .` showed the top-level surfaces: `README.md`, `tensor_logic/`, `experiments/`, `tests/`, `docs/`, `notes/`, `web_workbench/`, `phase_training/`, `examples/`, and `benchmarks/`.
+- `rg --files` showed experiments and tests through `exp95`, including committed result files under `experiments/exp87_support_data/` through `experiments/exp95_scored_object_hypotheses_data/`.
+- `find .. -maxdepth 3 -name repos.json -print` found sibling goal-pack repo manifests but this audit stayed scoped to this worktree.
+- `rg -n` and `nl -ba` were used across README, docs, tests, package modules, demos/examples, and result JSONs to cite local evidence.
+
+## Repo purpose and state
+
+- Purpose from `README.md:1-7`: "Tensor Logic -> Cognition", a learning/research project, not a product, and now also a shared `tensor_logic` library dependency for sibling projects.
+- Package contract from `pyproject.toml:5-24`: project name `tensor-logic`, Python `>=3.11`, runtime dependency `torch>=2.0`, dev extras `matplotlib`, `numpy`, `pytest`, and setuptools package include `tensor_logic*`.
+- CI contract from `.github/workflows/ci.yml:24-30`: installs `".[dev]"` and runs `python -m pytest tests/ -v` on pull requests and `main` pushes.
+- Project instruction from `CLAUDE.md:1-17`: before implementation plans touching `tensor_logic/`, run `python tools/code_index.py --lookup <RelevantSymbol>`; test suite command is `pytest tests/ -v`.
+- Initial dirty state: clean branch, observed by `git status --short --branch`.
+- Expected final dirty state for this queue item: one docs report at `docs/overnight/tensor-logic-docs-claims.md`.
+
+## Claims audit
+
+### Root README claims
+
+Supported or mostly supported:
+
+- The reusable-package claim is supported. `README.md:73` says `tensor_logic/` is a reusable extraction with named-index language, dense/sparse closure, binary Datalog-style joins, stratified negation, provenance proof trees, and semiring helpers. Local code backs this: package exports in `tensor_logic/__init__.py:3-66`, narrow semantics surface in `tensor_logic/core.py:1-30`, named-index relations/fixpoint in `tensor_logic/language.py:123-197`, closure helpers in `tensor_logic/closure.py:6-53`, rule parsing/evaluation with negation in `tensor_logic/rules.py:13-162`, proof/negative-proof types in `tensor_logic/proofs.py:13-118`, and semiring helpers in `tensor_logic/semirings.py:4-15`.
+- CLI/file-format claims are supported. `tensor_logic/__main__.py:13-90` exposes `run`, `query`, `prove`, `ingest-python`, `repl`, `repo-graph`, and `serve`. `tensor_logic/file_format.py:32-82` loads domains, relations, facts, rules, includes, queries, and proofs. `examples/code_dependencies.tl:1-20` and `examples/permissions.tl:1-19` are concrete local `.tl` examples. `tests/test_tensor_logic_core.py:173-179` verifies loading `examples/code_dependencies.tl`; `tests/test_tensor_logic_core.py:726-787` verifies CLI `run`, `query`, and JSON `prove`.
+- The support/stability validation fast path in `README.md:85-102` is backed by packaging and CI tests. `tests/test_packaging_ci.py:16-25` checks pyproject dependencies/package include, `tests/test_packaging_ci.py:28-35` checks CI runs the full worker validation, and `tests/test_packaging_ci.py:38-44` checks README documents the commands.
+- The CPU support/stability lane is well backed by newer files. `docs/superpowers/plans/2026-05-05-support-stability.md:7-24` states the perfect-object-state scope and non-goals. `experiments/exp84_support_data.py:1-4` is pure geometry, exact labels, no learned components. `experiments/exp85_support_tl.py:1-6` is the deterministic support/stability engine, and `experiments/exp85_support_tl.py:189-279` implements fixpoint-style stability, support proofs, and fall labels. `experiments/exp87_support_data/results.json` records full-run TL accuracy and gates as passed, including `experiment` at line 43, gates at lines 44-73, thesis `passed` at line 206, and TL split accuracies at lines 207-257.
+- The web workbench README is supported. `web_workbench/README.md:1-13` says it is a minimal browser shell that writes editor contents to a temporary `.tl` file and invokes `python -m tensor_logic`. `web_workbench/server.py:44-84` does exactly that, and `tests/test_web_workbench.py:20-32` verifies query API behavior.
+
+Stale, ambiguous, or weakly supported:
+
+- `README.md:71` says the repo contains `experiments/exp1`-`exp54`; `rg --files` shows experiments and tests through `exp95`, and `notes/EXPERIMENTS.md:7-20` has current rows 95 down to 78 at the top.
+- `README.md:121-123` says `demos/` has "5 headline runnable demos" and `experiments/` is `exp1..exp54`. The table at `README.md:61-68` actually lists eight demo scripts, and the file tree has those eight under `demos/`.
+- `README.md:117` says each demo runs on CPU in seconds to a few minutes. This is plausible for the listed local scripts but was not validated in this audit. It is also broad because `demos/joint_lm_kg.py`, `demos/throwing.py`, and `demos/catastrophic_forgetting.py` depend on `torch` training loops rather than pure deterministic checks.
+- `README.md:11-25` and `README.md:27-40` publish exact transitive-closure tables for external packages. The backing scripts exist (`experiments/exp53_real_imports.py:1-23`, `experiments/exp54_big_imports.py:1-18`), but no committed `exp53` or `exp54` result JSON was found by `find experiments -maxdepth 2 -name 'results*.json' -print`. Reproduction requires networked `pip download` in `experiments/exp53_real_imports.py:106-133` and `experiments/exp54_big_imports.py:98-128`, so the exact README numbers are not independently auditable from committed local artifacts alone.
+- `README.md:136-138` says one tensor equation expresses transformers, GNNs, RNNs, Datalog programs, probabilistic graphical models, and kernel machines, with GPU/autodiff plus sound logical semantics. Local code supports small pieces of this broad framing, but the statement is essay-level and not scoped to what this package currently implements. It should be marked conceptual, not an implementation claim.
+- `README.md:154` says "The pieces exist. The integration is the open problem." The repo contains many pieces, but local evidence also records failed/partial pieces and hard caveats in `notes/EXPERIMENTS.md:100-109`.
+
+### Notes and experiment-log claims
+
+- `notes/EXPERIMENTS.md:1-7` is a maintained experiment log with status legend and a "do not delete rows" instruction. This is useful claim hygiene because failed and superseded experiments stay visible.
+- Recent support/stability rows are backed by committed scripts, tests, and result JSONs. Rows 87-95 at `notes/EXPERIMENTS.md:9-17` cite exact local result files from `experiments/exp87_support_data/results.json` through `experiments/exp95_scored_object_hypotheses_data/results.json`.
+- `notes/EXPERIMENTS.md:17` makes the clean V1 support/stability claim and explicitly says it is not yet a pixel or learned-rule result. This matches `docs/superpowers/plans/2026-05-05-support-stability.md:17-24`.
+- `notes/EXPERIMENTS.md:16` records deterministic TL brittleness under tiny coordinate noise, and rows 89-95 then narrow the interface toward confidence, intervals, pixel stubs, detector anomaly signals, object hypotheses, and scored non-oracle hypotheses. This is fresher than the root README and should be promoted into a "current research lane" section.
+- The transitive-closure positive claim has local narrative support in `notes/EXPERIMENTS.md:93-98`, but the exact README `exp53/exp54` external-package tables still need committed manifests if morning review wants auditable numbers without reruns.
+
+### Support/stability docs claims
+
+- The support/stability plan has good non-goal language. `docs/superpowers/plans/2026-05-05-support-stability.md:17-24` explicitly says V1 is not pixels, learned perception, learned rules, trajectories, collision simulation, or partial physics priors.
+- The plan's falsification gate at `docs/superpowers/plans/2026-05-05-support-stability.md:111-119` requires 100% TL deterministic accuracy, 100% counterfactual retraction, and at least 10 percentage-point OOD margin over best neural baseline. `tests/test_exp87_support_eval.py:38-41` verifies those gate keys exist and pass in a quick test run, while `experiments/exp87_support_data/results.json` records full-run passed gates.
+- The plan's vertical slices at `docs/superpowers/plans/2026-05-05-support-stability.md:200-267` line up with local artifacts: `exp84`, `exp85`, `exp86`, `exp87`, and their tests exist.
+- Risk: the plan is written as a future implementation plan, not as a final memo. It includes Week 1-4 execution text at `docs/superpowers/plans/2026-05-05-support-stability.md:284-308`, but the repo already has later `exp88`-`exp95`. A morning reviewer may misread it as current backlog rather than historical plan unless a current status note is added.
+
+### Worker and handoff docs claims
+
+- `docs/SYMPHONY_RUN_PROTOCOL.md:5-16` defines branch, validation, handoff, and status-management rules for issue work. It also says implementation work is not complete until a real GitHub PR at `docs/SYMPHONY_RUN_PROTOCOL.md:17-26`.
+- This queue item explicitly says product code, pushes, and PR creation are out of scope, so this audit does not follow the implementation PR-publishing path. The report should remain a local artifact for the goal-pack runner.
+- `docs/RUN_PROTOCOL.md:1-15` documents Kaggle persistence after losing `exp76c` adapter output; `docs/RUN_PROTOCOL.md:65-85` says weights should not be committed, only pointer metadata. This is a useful docs claim and a safety constraint for future remote-run issues.
+- `docs/agents/domain.md:5-12` says read `CONTEXT.md`, `CONTEXT-MAP.md`, and `docs/adr/` if present, but this repo currently has none of those tracked paths. This is not a failure; the doc says to proceed silently.
+
+### Benchmarks claims
+
+- `benchmarks/README.md:3-11` says stable benchmark entrypoints go there and gives a suggested order (`closure.py`, `kinship.py`, `parity.py`), but only the README exists. This is a forward-looking placeholder, not an implemented benchmark suite. It should be labeled as such if linked from user-facing docs.
+
+## Risks and stale assumptions
+
+1. Root README recency risk: the README is behind the actual experiment lane. It names `exp1`-`exp54` and five demos, while the repo has `exp95`, support/stability results, web workbench, CI, examples, and agent docs.
+2. Auditable-result risk: the headline `exp53` and `exp54` tables are not backed by committed result manifests. The scripts download current external package source tarballs, so reruns can drift as packages release new versions.
+3. Conceptual-overclaim risk: `README.md:136-138` compresses a very broad Tensor Logic thesis into one paragraph. Local implementation covers a subset; docs should separate "paper/conceptual background" from "this repo implements/tests".
+4. Validation-scope risk: README's full validation command is correct but potentially expensive because tests include many experiment tests. The docs provide fast paths for support/stability, but no similarly crisp cheap proof exists for the root README transitive-closure tables.
+5. Historical-plan risk: `docs/superpowers/plans/` contains detailed plans with unchecked task checkboxes and future-tense language. Some are complete or superseded, but not clearly marked as historical.
+6. Workbench security/scope risk: `web_workbench/server.py:53-72` writes source to a temp file and invokes `python -m tensor_logic`; this is suitable for local workbench use but should not be documented as safe for remote/multi-user deployment.
+
+## Missing validation
+
+- I did not run `python -m pytest tests/ -v`; the queue validation command is `git status --short`, and the audit is docs-only.
+- I did not run `python -m pip install -e ".[dev]"`; dependency installation is outside the requested validation and could mutate the environment.
+- I did not run `experiments/exp53_real_imports.py` or `experiments/exp54_big_imports.py`; both require networked package downloads and are outside the local read-only audit scope.
+- I did not run demo scripts; README's "seconds to a few minutes" timing claim remains unverified by this audit.
+- I did not use external services, GitHub, Linear, Kaggle, or web browsing.
+
+## Validation command candidates
+
+- Required queue validation: `git status --short`
+  - Expected after report creation: one local docs report path, likely `?? docs/overnight/` or `?? docs/overnight/tensor-logic-docs-claims.md` depending on git's untracked-directory display.
+  - Status: passed for the required queue check; observed output was `?? docs/overnight/`.
+- Docs/package contract smoke: `python -m pytest tests/test_packaging_ci.py -v`
+  - Expected: pass. It only checks pyproject, CI workflow, README validation commands, and Symphony protocol strings.
+- Reusable package and CLI smoke: `python -m pytest tests/test_tensor_logic_core.py -v`
+  - Expected: likely pass, but larger than needed for this audit.
+- Support/stability docs-backed fast path: `python -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v`
+  - Expected: likely pass based on local test/code alignment.
+- Full documented worker validation: `python -m pytest tests/ -v`
+  - Expected: intended pass per CI contract, but not run here due docs-only queue validation.
+- Neural baseline smoke: `python experiments/exp86_support_baselines.py --quick`
+  - Expected: intended pass per README and protocol, but not run here because it trains models and is not needed to validate a docs report.
+- External-package result reproduction: `python experiments/exp53_real_imports.py` and `python experiments/exp54_big_imports.py`
+  - Expected: unknown locally because they use `pip download` against external packages and may drift or fail without network.
+
+## Next safe work
+
+1. Update root README recency without changing product code.
+   - Acceptance criteria: README no longer says `exp1`-`exp54` or "5 headline runnable demos"; it names the current support/stability lane and links to `notes/EXPERIMENTS.md` rows 87-95.
+   - Validation: `python -m pytest tests/test_packaging_ci.py -v` and `git diff -- README.md`.
+
+2. Add committed result manifests for the headline external-package tables.
+   - Acceptance criteria: `experiments/exp53_data/results.json` and `experiments/exp54_data/results.json` exist with package versions, source archive refs, git SHA, command, device, TL/MLP parameters, rows, and mean metrics; README tables cite those files.
+   - Validation: a new test reads the manifests and asserts README table package names/metrics match, plus `python -m pytest tests/test_packaging_ci.py -v`.
+   - Stop condition: if reruns need network approval, create the manifest schema and leave the actual numbers blocked until an approved remote/local run.
+
+3. Mark docs plans as historical/current-state.
+   - Acceptance criteria: `docs/superpowers/plans/2026-05-05-support-stability.md` starts with a short status note pointing to implemented `exp84`-`exp95` artifacts, and future-tense tasks are clearly historical plan context.
+   - Validation: docs-only diff review and `rg -n "exp95|current status|historical" docs/superpowers/plans/2026-05-05-support-stability.md`.
+
+4. Add a "claim ledger" page for research claims.
+   - Acceptance criteria: a new docs page maps each public claim to local evidence: code path, tests, result JSON, command to rerun, caveats, and whether it is conceptual, implemented, validated, stale, or falsified.
+   - Validation: `rg -n "exp53|exp54|exp87|exp95|conceptual|validated|stale" docs/`.
+
+5. Add local-only workbench warning.
+   - Acceptance criteria: `web_workbench/README.md` says the server shells out to local Python and is for trusted localhost use, not remote deployment.
+   - Validation: `python -m pytest tests/test_web_workbench.py -v`.
+
+## Non-goals for this audit
+
+- No product-code edits.
+- No experiment reruns that download external packages.
+- No dependency installation.
+- No generated data, model weights, or cache changes.
+- No GitHub PR, push, merge, or external tracker status update.
+- No claim about scientific correctness beyond what local files and commands support.
+
+## Unknowns
+
+- Whether the exact README `exp53` and `exp54` numbers still reproduce against current package source distributions.
+- Whether all demo scripts still satisfy the "CPU in seconds to a few minutes" timing claim on a clean machine.
+- Whether sibling repos currently depend on package APIs not covered by this repo's tests.
+- Whether a maintainer wants the README to stay essay-like or become a stricter evidence-index landing page.
+- Whether the goal-pack runner expects reports to remain as dirty local files or be committed by workers; this queue item only required the report and `git status --short`.
+
+## Handoff
+
+- Files changed: `docs/overnight/tensor-logic-docs-claims.md`.
+- Product code changed: none.
+- Commit/HEAD observed before edits: `c9e2cfc`.
+- Required validation result: `git status --short` passed and reported only `?? docs/overnight/`.
+- PR URL: none, not created by design for this local overnight docs audit.
+- Blockers: none for the local report. Reproducing external package tables would require networked reruns and likely package version pinning.

--- a/docs/overnight/tensor-logic-validation-map.md
+++ b/docs/overnight/tensor-logic-validation-map.md
@@ -1,0 +1,426 @@
+# tensor-logic validation-map audit
+
+Queue item: `tensor-logic-validation-map`
+Date: 2026-05-07
+Repo: `tensor-logic`
+Branch: `codex/goal-tensor-logic-validation-map`
+HEAD at audit start: `c9e2cfce206bb279a4348189726908fcb436d3dc`
+
+## Scope and decision log
+
+This audit is validation-map only. I did not edit product code, generated data,
+secrets, workflows, experiment scripts, package metadata, or external trackers.
+The only intended repo mutation is this report at
+`docs/overnight/tensor-logic-validation-map.md`.
+
+Decision: use `python3` for local proof commands because this worktree's shell
+does not expose a `python` executable. The repo and CI documentation still use
+`python`; that is valid in GitHub Actions because `actions/setup-python` places
+`python` on `PATH`, but it is not valid in this local Homebrew-style shell.
+
+Decision: run experiment CLIs that write result JSON only with an explicit
+temporary `--output` path outside the repo. This avoids mutating tracked
+`experiments/*_data/results_quick.json` files during a read-only audit.
+
+## Repo purpose and current state
+
+Purpose, from `README.md`: this is a Python research/package repo for Tensor
+Logic experiments and reusable `tensor_logic` reasoning utilities. It contains
+the reusable package under `tensor_logic/`, runnable demos under `demos/`, a
+large experiment arc under `experiments/`, support/stability work under
+`experiments/exp84` through `experiments/exp95`, and regression tests under
+`tests/`.
+
+Branch and cleanliness observations:
+
+- `git branch --show-current` -> `codex/goal-tensor-logic-validation-map`
+- Initial `git status --short` -> no output, clean tracked state.
+- `git status --short --ignored` after running tests showed ignored local state:
+  `.pytest_cache/` and `tools/index.json`.
+- `tools/index.json` is intentionally ignored by `.gitignore`, and
+  `tests/test_code_index.py` asserts that ignore contract.
+- Final required validation command is `git status --short`; after writing this
+  report it showed only `?? docs/overnight/`, the new untracked overnight report
+  directory.
+
+## Local evidence
+
+Validation-relevant files and observations:
+
+- `CLAUDE.md` declares the project test suite as `pytest tests/ -v` and says
+  agents should run `python tools/code_index.py --lookup <RelevantSymbol>` before
+  implementation plans that touch `tensor_logic/`.
+- `pyproject.toml` declares package name `tensor-logic`, Python `>=3.11`,
+  runtime dependency `torch>=2.0`, dev extras `matplotlib>=3.7`, `numpy>=1.24`,
+  and `pytest>=8.0`, with pytest `testpaths = ["tests"]`.
+- `README.md` documents clean worker validation:
+  `python -m pip install -e ".[dev]"` and `python -m pytest tests/ -v`.
+- `README.md` also documents a support/stability fast path:
+  `python -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v`
+  plus `python experiments/exp86_support_baselines.py --quick`.
+- `.github/workflows/ci.yml` runs Python 3.11 on pull requests and pushes to
+  `main`, installs `".[dev]"`, then runs `python -m pytest tests/ -v`.
+- `docs/SYMPHONY_RUN_PROTOCOL.md` repeats the full validation command, the
+  support/stability fast path, the `exp86 --quick` smoke command, and the rule
+  that docs-only changes should state why no code test was needed.
+- `docs/superpowers/plans/2026-05-05-support-stability.md` explains the
+  validation contract for the support/stability lane: deterministic tests in
+  fast CI, neural `--quick` smoke checks outside CI, and exact TL gates for the
+  V1 evaluation.
+- `tests/conftest.py` injects the repo root into `sys.path`, so local tests can
+  import the package without requiring an editable install.
+- `tests/test_packaging_ci.py` asserts that `pyproject.toml`, README validation
+  docs, Symphony protocol docs, and `.github/workflows/ci.yml` stay aligned.
+- `tests/test_code_index.py` exercises `tools/code_index.py`, including CLI
+  lookup/status behavior, and intentionally rebuilds the ignored index in tests.
+- `tests/test_exp84_support_data.py` and `tests/test_exp85_support_tl.py` are
+  the cheap deterministic support/stability fast path.
+- `tests/test_exp86_support_baselines.py` validates neural baseline tensorization,
+  masking, loss reduction, and the `run_baselines(quick=True)` metric schema.
+- `tests/test_exp87_support_eval.py` validates V1 eval split coverage and gate
+  schema through direct function calls with a `tmp_path` result file.
+- `tests/test_exp88_support_noisy_relations.py` through
+  `tests/test_exp95_scored_object_hypotheses.py` cover later robustness,
+  uncertainty, detector, object-hypothesis, and scored-hypothesis experiment
+  layers using temporary output paths.
+- `tests/test_tensor_logic_core.py` is the largest test file and covers package
+  core behavior, CLI/HTTP parity, proof/negative-proof JSON semantics, repo
+  ingestion, proof tree rendering, includes, REPL helpers, and TL file examples.
+- `tests/test_web_workbench.py` covers the web workbench query and why-not
+  integration without starting a long-running server.
+- `tools/code_index.py` writes `tools/index.json` when stale; that file is
+  ignored and should not be treated as source.
+- `experiments/exp87_support_eval.py` and `experiments/exp88` through `exp95`
+  write default results under tracked `experiments/*_data/` directories unless
+  `--output` is supplied.
+- `web_workbench/server.py` has a local server entrypoint, but current tests call
+  helper functions directly; no browser/server validation is required for this
+  docs-only audit.
+
+## Commands run
+
+Repository and structure:
+
+| Command | Result |
+| --- | --- |
+| `llm-tldr tree .` | Passed. Confirmed package, tests, docs, demos, experiments, web workbench, and data-output directories. |
+| `git branch --show-current` | Passed. Branch is `codex/goal-tensor-logic-validation-map`. |
+| `git status --short` | Passed. Initial tracked state clean. |
+| `git rev-parse HEAD` | Passed. `c9e2cfce206bb279a4348189726908fcb436d3dc`. |
+| `rg --files .github` | Passed. Found `.github/workflows/ci.yml`. |
+| `git status --short --ignored` | Passed. Showed ignored `.pytest_cache/` and `tools/index.json`. |
+
+Local interpreter and dependency surface:
+
+| Command | Result |
+| --- | --- |
+| `python -m pytest --collect-only -q` | Failed before pytest: `/opt/homebrew/bin/bash: line 1: python: command not found`. |
+| `python -m pytest tests/test_packaging_ci.py -v` | Failed before pytest for the same missing `python` executable. |
+| `which python3` | Passed. `/usr/local/bin/python3`. |
+| `python3 --version` | Passed. `Python 3.12.8`. |
+| `python3 -m pytest --version` | Passed. `pytest 9.0.3`. |
+| `uv --version` | Passed. `uv 0.11.5 (Homebrew 2026-04-08 aarch64-apple-darwin)`. |
+| `python3 -m pip check` | Passed with pip cache ownership warning; output included `No broken requirements found.` |
+
+Pytest validation:
+
+| Command | Result |
+| --- | --- |
+| `python3 -m pytest --collect-only -q` | Passed. `198 tests collected in 21.85s`. |
+| `python3 -m pytest tests/test_packaging_ci.py -v` | Passed. `4 passed in 0.02s`. |
+| `python3 -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v` | Passed. `16 passed in 0.08s`. |
+| `python3 -m pytest tests/test_tensor_logic_core.py tests/test_reason.py tests/test_web_workbench.py -q` | Passed. `66 passed in 15.37s`. |
+| `python3 -m pytest tests/test_exp86_support_baselines.py -v` | Passed. `5 passed in 1.83s`. |
+| `python3 -m pytest tests/ -v` | Passed. `198 passed in 33.32s`. |
+
+Runtime smoke checks:
+
+| Command | Result |
+| --- | --- |
+| `python3 tools/code_index.py --status` | Passed. Reported `fresh: .../tools/index.json`. |
+| `python3 experiments/exp86_support_baselines.py --quick` | Passed. Printed deterministic JSON with `quick: true`, `max_objects: 8`, MLP ID accuracy `0.8947`, DeepSets ID accuracy `0.8947`, and OOD accuracies around `0.77`. |
+| `python3 -m tensor_logic run examples/code_dependencies.tl` | Passed. Printed `depends_on(worker, models) = True` and a proof chain through `worker -> api -> db -> models`. |
+| `python3 experiments/exp87_support_eval.py --quick --output /private/tmp/tensor-logic-exp87-quick.json` | Passed. Printed `thesis: "passed"` and `gates.v1_passed: true`; wrote outside the repo. |
+
+## Validation surface map
+
+Primary CI/full validation:
+
+- Command in docs and CI: `python -m pip install -e ".[dev]"` then
+  `python -m pytest tests/ -v`.
+- Local equivalent that passed in this worktree: `python3 -m pytest tests/ -v`.
+- Coverage: 198 tests across package core, proof engine, CLI/HTTP parity,
+  web workbench helpers, code index, optimization helpers, FAFSA experiment,
+  support/stability experiments, neural baselines, and scored object hypotheses.
+- Local caveat: `tests/conftest.py` makes package imports work from source, so
+  the local full-suite pass does not prove the editable install step by itself.
+  `tests/test_packaging_ci.py` does check package metadata and CI command text.
+
+Support/stability cheap path:
+
+- Command in README/protocol: `python -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v`.
+- Local equivalent that passed: `python3 -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v`.
+- Coverage: deterministic generator invariants plus TL stability/retraction
+  behavior against hand-built and generated support scenes.
+- Expected use: cheapest proof for changes limited to `experiments/exp84` or
+  `experiments/exp85`.
+
+Neural baseline smoke path:
+
+- Command in README/protocol: `python experiments/exp86_support_baselines.py --quick`.
+- Local equivalent that passed: `python3 experiments/exp86_support_baselines.py --quick`.
+- Coverage: quick MLP and DeepSets training/eval on generated object tables.
+- Expected use: required for changes touching `experiments/exp86_support_baselines.py`.
+- Caveat: this script prints JSON and does not write a repo result file.
+
+V1 evaluation CLI path:
+
+- Candidate command: `python3 experiments/exp87_support_eval.py --quick --output /private/tmp/tensor-logic-exp87-quick.json`.
+- Result: passed with `v1_passed: true`.
+- Expected use: proof that the end-to-end support/stability gate still computes
+  without mutating tracked quick-result files.
+- Caveat: default command without `--output` writes to
+  `experiments/exp87_support_data/results_quick.json`, which is tracked in git.
+
+Robustness/evaluation result writers:
+
+- `experiments/exp88_support_noisy_relations.py`
+- `experiments/exp89_support_primitive_confidence.py`
+- `experiments/exp90_support_repair_sweep.py`
+- `experiments/exp91_interval_support_uncertainty.py`
+- `experiments/exp92_pixel_abstain_recover.py`
+- `experiments/exp93_detector_calibration_stress.py`
+- `experiments/exp94_object_hypothesis_layer.py`
+- `experiments/exp95_scored_object_hypotheses.py`
+
+These scripts expose `--quick` and `--output` according to grep/read evidence.
+Their tests exercise the run functions with `tmp_path` outputs, but this audit
+did not run every CLI. For read-only/nightly audits, prefer:
+
+```bash
+python3 experiments/<script>.py --quick --output /private/tmp/<script>-quick.json
+```
+
+Package/core smoke path:
+
+- `python3 -m tensor_logic run examples/code_dependencies.tl` passed and proves
+  the installed-source CLI path can parse/run a TL file and print proof output.
+- Targeted package tests in `tests/test_tensor_logic_core.py`, `tests/test_reason.py`,
+  and `tests/test_web_workbench.py` passed as a 66-test core/web subset.
+
+Code index validation:
+
+- `python3 tools/code_index.py --status` passed and reported a fresh ignored
+  `tools/index.json`.
+- `tests/test_code_index.py` covers rebuild, status, lookup success, and lookup
+  miss behavior.
+- Risk: this is an operational helper, not part of package metadata or CI
+  artifacts. Its ignored output can appear in dirty-state inspections only when
+  `--ignored` is used.
+
+Missing validation surfaces:
+
+- No configured lint command was found in `pyproject.toml`, `.github/workflows/ci.yml`,
+  README, CLAUDE, or Symphony protocol.
+- No configured type-check command was found.
+- No coverage threshold or coverage command was found.
+- No tox/nox/pre-commit/Makefile/justfile validation wrapper was found.
+
+## Risks and stale assumptions
+
+1. Local docs use `python`, but this worker shell only has `python3`.
+   Local agents following README literally will fail before pytest. CI likely
+   still works because `actions/setup-python` provides `python`, but the repo
+   lacks a cross-environment wrapper that normalizes this.
+
+2. The full-suite local pass does not prove the documented install step.
+   Because `tests/conftest.py` inserts the repo root into `sys.path`, tests can
+   pass without `python -m pip install -e ".[dev]"`. The CI job does install,
+   and `tests/test_packaging_ci.py` checks the install command is present, but
+   this audit did not mutate the environment by running an editable install.
+
+3. Many experiment CLIs write tracked result files by default.
+   `exp87` through `exp95` have committed `results.json` and `results_quick.json`
+   files under `experiments/*_data/`. Running a default quick command during an
+   audit or implementation can create noisy tracked diffs even when the code is
+   unchanged. Supplying `--output` avoids this.
+
+4. There is no lint/type/format gate.
+   The test suite is green, but validation has no automated guard for style,
+   import hygiene, static typing regressions, dead code, or formatting drift.
+   That may be acceptable for a research repo, but it should be explicit.
+
+5. CI uses Python 3.11, local validation used Python 3.12.8.
+   `pyproject.toml` permits `>=3.11`, so this is allowed, but it means the
+   local pass is not an exact CI-version reproduction. Potential version-sensitive
+   torch/numpy behavior remains an unknown without running Python 3.11 locally.
+
+6. Neural quick checks are deterministic enough for smoke validation, but they
+   are still training loops.
+   The `exp86 --quick` and `exp87 --quick` commands passed quickly here, but
+   they depend on torch CPU behavior and seeded training. They are more expensive
+   and potentially more brittle than pure deterministic unit tests.
+
+7. The code index helper writes ignored local state.
+   `tools/code_index.py --status` is read-only when fresh, but `--lookup` and
+   tests may rebuild `tools/index.json`. That is intentional and ignored, yet it
+   can confuse workers who inspect only filesystem state without checking
+   `.gitignore`.
+
+## Next safe work
+
+### Task 1: Add a repo-local validation wrapper
+
+Acceptance criteria:
+
+- Add a small `Makefile`, `justfile`, or script that resolves `python` vs
+  `python3` once and exposes `test`, `test-fast`, `test-exp86-quick`, and
+  `test-exp87-quick-temp` commands.
+- Wrapper commands must not write tracked experiment result files by default.
+- README and `docs/SYMPHONY_RUN_PROTOCOL.md` point workers at the wrapper while
+  preserving raw commands for CI.
+
+Validation:
+
+```bash
+<wrapper> test-fast
+<wrapper> test-exp86-quick
+<wrapper> test-exp87-quick-temp
+git status --short
+```
+
+Expected status: wrapper commands pass; `git status --short` shows only intended
+wrapper/docs changes.
+
+### Task 2: Add CLI smoke tests for result-writing experiment scripts
+
+Acceptance criteria:
+
+- Add parametrized pytest coverage that invokes `exp87` through `exp95` CLIs
+  with `--quick --output <tmp_path>/results.json` where practical.
+- Assert each CLI exits 0, writes the requested output path, and does not write
+  to the default tracked `experiments/*_data/` path during the test.
+- Keep runtime bounded; split slow scripts or mark them if necessary.
+
+Validation:
+
+```bash
+python3 -m pytest tests/test_experiment_cli_outputs.py -v
+python3 -m pytest tests/ -v
+git status --short
+```
+
+Expected status: new CLI tests and full suite pass; no tracked result JSON files
+change during the tests.
+
+### Task 3: Make the install contract observable locally
+
+Acceptance criteria:
+
+- Add a packaging smoke test or docs step that proves a clean editable install
+  can import `tensor_logic` without relying on `tests/conftest.py`.
+- Prefer a temporary virtual environment or `uv run`-based smoke that does not
+  leave repo-local env artifacts except ignored caches.
+- Record the expected Python version and interpreter command in README/protocol.
+
+Validation:
+
+```bash
+python3 -m pytest tests/test_packaging_ci.py -v
+<new install smoke command>
+git status --short
+```
+
+Expected status: packaging tests pass; install smoke imports package and runs a
+minimal CLI command; no product files change.
+
+### Task 4: Decide and encode lint/type policy
+
+Acceptance criteria:
+
+- Either add a lightweight lint/format/type gate, or document explicitly that
+  this research repo currently has no lint/type gate and tests are the only
+  enforced validation.
+- If a tool is added, add it to `pyproject.toml`, CI, README, and
+  `tests/test_packaging_ci.py` so the validation contract remains aligned.
+- Keep the first tool scoped and boring; avoid broad style churn in the same PR.
+
+Validation candidates:
+
+```bash
+python3 -m pytest tests/test_packaging_ci.py -v
+python3 -m pytest tests/ -v
+<lint/type command if added>
+```
+
+Expected status: packaging contract and full suite pass; lint/type status is
+either enforced or explicitly non-goal.
+
+## Validation command candidates
+
+| Situation | Command | Expected status |
+| --- | --- | --- |
+| Required queue validation | `git status --short` | Passed after report creation, exit 0, output `?? docs/overnight/`. |
+| CI-equivalent in GitHub Actions | `python -m pip install -e ".[dev]" && python -m pytest tests/ -v` | Expected pass in CI Python 3.11; not locally runnable here because `python` is missing. |
+| Local full suite | `python3 -m pytest tests/ -v` | Passed locally, `198 passed in 33.32s`. |
+| Local collection check | `python3 -m pytest --collect-only -q` | Passed locally, `198 tests collected in 21.85s`. |
+| Packaging/docs alignment | `python3 -m pytest tests/test_packaging_ci.py -v` | Passed locally, `4 passed in 0.02s`. |
+| Support/stability deterministic fast path | `python3 -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v` | Passed locally, `16 passed in 0.08s`. |
+| Neural baseline unit tests | `python3 -m pytest tests/test_exp86_support_baselines.py -v` | Passed locally, `5 passed in 1.83s`. |
+| Neural baseline CLI smoke | `python3 experiments/exp86_support_baselines.py --quick` | Passed locally; prints JSON only. |
+| V1 evaluation CLI smoke without repo mutation | `python3 experiments/exp87_support_eval.py --quick --output /private/tmp/tensor-logic-exp87-quick.json` | Passed locally; `v1_passed: true`. |
+| Package CLI smoke | `python3 -m tensor_logic run examples/code_dependencies.tl` | Passed locally; query true and proof printed. |
+| Code index freshness | `python3 tools/code_index.py --status` | Passed locally; reported fresh ignored index. |
+| Dependency consistency | `python3 -m pip check` | Passed locally with pip cache warning; no broken requirements. |
+
+## Non-goals
+
+- No product-code edits.
+- No changes to package metadata, CI workflow, tests, demos, experiments, or
+  generated result JSON files.
+- No external service calls, deploys, pushes, PR creation, or tracker updates.
+- No full remote/CI validation.
+- No claim that Python 3.11 CI was reproduced locally; local interpreter was
+  Python 3.12.8.
+- No benchmark accuracy claim beyond the smoke results printed by the commands
+  listed above.
+
+## Unknowns
+
+- Whether a fresh Python 3.11 virtualenv can install `".[dev]"` without network
+  or platform issues in this exact workspace.
+- Whether GitHub Actions is currently green on remote `main`; this audit did
+  not query GitHub or external services.
+- Whether all older `experiments/exp1` through `exp83` standalone scripts still
+  run. The test suite covers selected experiment functions, not every historical
+  script entrypoint.
+- Whether lint/type validation should be added or intentionally omitted for the
+  research workflow.
+- Whether committed `experiments/*_data/results_quick.json` files are meant to
+  be regenerated by humans only, or can be regenerated by automated workers with
+  a stable protocol.
+
+## Handoff
+
+Changed files:
+
+- `docs/overnight/tensor-logic-validation-map.md`
+
+Commit SHA:
+
+- No new commit created by this audit. Base/current HEAD is
+  `c9e2cfce206bb279a4348189726908fcb436d3dc`.
+
+PR URL:
+
+- None. PR creation is out of scope for this overnight read-only audit.
+
+Required validation:
+
+- `git status --short` -> exit 0, output `?? docs/overnight/`.
+
+Blockers:
+
+- None for the report.
+- Local command caveat: raw `python ...` validation commands fail in this shell
+  because `python` is not on `PATH`; use `python3` locally or run under CI.

--- a/docs/overnight/tensor-logic-workflow-handoff.md
+++ b/docs/overnight/tensor-logic-workflow-handoff.md
@@ -1,0 +1,201 @@
+# tensor-logic workflow-handoff audit
+
+Queue item: `tensor-logic-workflow-handoff`  
+Focus area: `workflow-handoff`  
+Worktree: `/Users/jwalinshah/projects/agent-stack/.agent-stack-worktrees/2026-05-07-overnight-marathon/tensor-logic-workflow-handoff`  
+Branch: `codex/goal-tensor-logic-workflow-handoff`  
+HEAD at audit time: `c9e2cfce206bb279a4348189726908fcb436d3dc`  
+Remote: `origin https://github.com/jwalin-shah/tensor-logic.git`
+
+## Purpose and state
+
+`tensor-logic` is a Python research repo that has grown into a reusable `tensor_logic` package plus many experiment scripts. The README frames it as "Tensor Logic -> Cognition", a learning project, and also says the repo is now the shared `tensor_logic` library dependency for sibling projects such as `fafsa-engine`.
+
+Initial state was clean:
+
+- `git status --short --branch` printed `## codex/goal-tensor-logic-workflow-handoff`.
+- `git status --short` printed no tracked or untracked changes.
+- `git log --oneline -5` showed recent merged support/object-hypothesis work, with `c9e2cfc Merge pull request #46 from jwalin-shah/codex/SYM-220-scored-object-hypotheses` at HEAD.
+
+This audit intentionally changed only this report file under `docs/overnight/`.
+
+## Local evidence
+
+- `README.md` describes the public story, headline transitive-closure result, limits on XOR/parity and non-reachability tasks, worker validation commands, and CPU demo commands.
+- `pyproject.toml` declares package `tensor-logic`, Python `>=3.11`, runtime dependency `torch>=2.0`, dev extras `matplotlib`, `numpy`, and `pytest`, and setuptools package discovery for `tensor_logic*`.
+- `.github/workflows/ci.yml` installs `python -m pip install -e ".[dev]"` and runs `python -m pytest tests/ -v` on PRs and pushes to `main`.
+- `CLAUDE.md` says to run `python tools/code_index.py --lookup <RelevantSymbol>` before planning changes that touch `tensor_logic/`, but this shell has no `python` executable.
+- `docs/SYMPHONY_RUN_PROTOCOL.md` defines branch, validation, PR, and result-recording expectations; it still says to treat a Linear issue as the final task contract.
+- `docs/agents/issue-tracker.md` says this repo uses GitHub Issues and `gh`, which conflicts with the Linear wording in the Symphony protocol.
+- `docs/agents/domain.md` expects optional `CONTEXT.md`, `CONTEXT-MAP.md`, and `docs/adr/`; `fd -H 'CONTEXT.md|CONTEXT-MAP.md|docs/adr' .` found none.
+- `tensor_logic/__init__.py` re-exports a broad public API: closure, language, program, file loading, command execution, HTTP helpers, ingest, proof results, proof trees, provenance, repo-graph view, and rule parsing/evaluation.
+- `tensor_logic/__main__.py` is the CLI entrypoint for `run`, `query`, `prove`, `ingest-python`, `repl`, `repo-graph`, and `serve`.
+- `tensor_logic/file_format.py` parses `.tl` files with `domain`, `relation`, `fact`, `rule`, `query`, `prove`, and `include` statements; include cycles raise `ValueError`.
+- `tensor_logic/execution.py` is the command execution layer and currently requires binary query/proof args.
+- `tensor_logic/http_api.py` exposes local POST endpoints for `/ingest-python`, `/run`, `/query`, and `/prove` using `ThreadingHTTPServer`.
+- `web_workbench/server.py` shells out with `sys.executable -m tensor_logic`, which is safer than the README text that says `python -m tensor_logic`.
+- `tests/test_packaging_ci.py` explicitly guards the packaging, README validation commands, CI workflow, and PR handoff protocol.
+- `tests/test_code_index.py` covers `tools/code_index.py`, but `test_cli_status_exits_0_when_fresh` rebuilds `tools/index.json` in the real repo root. That file is gitignored, but this is still a local side effect.
+- `fd -e py -d 2 . tensor_logic tests experiments demos phase_training tools web_workbench | wc -l` found 167 Python files; `experiments/` alone has 98 Python files and `tests/` has 23 Python files.
+- `fd -H 'requirements.*|uv.lock|poetry.lock|Pipfile|environment.yml|setup.cfg|tox.ini|noxfile.py|Makefile|Dockerfile|\\.env|\\.python-version|ruff.toml|mypy.ini|pytest.ini' .` found no lockfile, Makefile, tox/nox config, `.python-version`, or dedicated lint/type config.
+- `.gitignore` excludes `.venv/`, `.uv/`, `.pytest_cache/`, `.ruff_cache/`, weight files (`*.pt`, `*.pth`), `/.cocoindex_code/`, and `tools/index.json`.
+- `python --version` and `python tools/code_index.py --dump` both failed with exit 127: `/opt/homebrew/bin/bash: line 1: python: command not found`.
+- `python3 --version` printed `Python 3.12.8`, even though project metadata says `>=3.11` and CI uses Python 3.11.
+- `python3 tools/code_index.py --status` failed with exit 1 and printed `stale: index.json is missing or older than source files`.
+- `git check-ignore -v tools/index.json` confirmed `tools/index.json` is ignored by `.gitignore:19`.
+- `python3 -m pytest tests/test_packaging_ci.py -q` passed: `4 passed in 0.02s`.
+
+## Handoff boundaries
+
+Use these as the repo's current implementation boundaries:
+
+- Public library API: `tensor_logic/__init__.py`.
+- CLI: `tensor_logic/__main__.py`.
+- File parser and include semantics: `tensor_logic/file_format.py`.
+- Command execution shared by CLI, HTTP, and workbench: `tensor_logic/execution.py`.
+- Local HTTP API: `tensor_logic/http_api.py`.
+- Web shell: `web_workbench/server.py` and `web_workbench/static/`.
+- Code-index planning rail: `tools/code_index.py` plus ignored `tools/index.json`.
+- Support/stability research lane: `experiments/exp84_support_data.py`, `experiments/exp85_support_tl.py`, `experiments/exp86_support_baselines.py`, and tests `tests/test_exp84_support_data.py`, `tests/test_exp85_support_tl.py`, `tests/test_exp86_support_baselines.py`.
+- Long-running or external-compute experiment discipline: `docs/RUN_PROTOCOL.md`, especially for Kaggle output persistence and adapter/result pointers.
+- Worker and PR handoff discipline: `docs/SYMPHONY_RUN_PROTOCOL.md`, `docs/agents/issue-tracker.md`, and `tests/test_packaging_ci.py`.
+
+## Risks and stale assumptions
+
+1. Python command mismatch. README, CI, protocol docs, and CLAUDE examples use `python`, but this local shell only has `python3`. Future local workers copying the documented commands will fail before reaching tests.
+2. Tracker-contract mismatch. `docs/SYMPHONY_RUN_PROTOCOL.md` says "Linear issue" while `docs/agents/issue-tracker.md` says GitHub Issues. A worker starting from repo docs alone could update/comment the wrong tracker or fail handoff.
+3. Code index is both required and stale/missing. `CLAUDE.md` says lookup before planning `tensor_logic/` changes, but `python3 tools/code_index.py --status` exits 1 and `--lookup`/`--dump` would create ignored `tools/index.json`. That side effect is easy to miss in isolated worktrees.
+4. Code-index tests mutate local ignored state. `tests/test_code_index.py::test_cli_status_exits_0_when_fresh` rebuilds `tools/index.json` in the real repo root. It is ignored, but it violates the clean-read expectation for validation-only workers.
+5. Full dependency state is under-specified. `pyproject.toml` has dependencies, but there is no lockfile or `.python-version`; CI uses Python 3.11 while this worktree has Python 3.12.8.
+6. The repo is dual-use: research notebook/script archive and shared package. `README.md` says it is a learning project, but also a shared library dependency. Handoffs should identify whether a task is product-library behavior, experiment result reproduction, or documentation only.
+7. Generated experiment results are committed while large artifacts are intentionally ignored. `experiments/*_data/results*.json`, JSONL data, and PNGs are tracked; weights/checkpoints are ignored. Work orders must specify whether a result file is expected to change.
+
+## Next safe tasks
+
+### Task 1: Align worker command docs with local Python reality
+
+Problem: `python` is not available here, but the repo's handoff docs rely on it.
+
+Scope:
+
+- Update docs only unless tests force tiny assertion changes.
+- Candidate files: `README.md`, `CLAUDE.md`, `docs/SYMPHONY_RUN_PROTOCOL.md`, `web_workbench/README.md`, and `tests/test_packaging_ci.py`.
+
+Acceptance criteria:
+
+- Docs either use `python3` consistently for local worker commands, or explicitly define a preflight such as `python --version || python3 --version` and tell workers which executable to substitute.
+- `web_workbench/README.md` matches `web_workbench/server.py`, which uses `sys.executable`.
+- Packaging/CI documentation tests assert the chosen contract.
+
+Validation:
+
+- `python3 -m pytest tests/test_packaging_ci.py -q` should pass.
+- `git status --short` should show only the intended docs/test edits.
+
+### Task 2: Make code-index usage side-effect explicit and validation-safe
+
+Problem: `CLAUDE.md` requires code-index lookup before planning `tensor_logic/` changes, but the index is stale/missing and the CLI can write ignored state during lookup/status test flows.
+
+Scope:
+
+- Candidate files: `tools/code_index.py`, `tests/test_code_index.py`, `CLAUDE.md`, and possibly `docs/superpowers/plans/2026-04-28-code-index.md` if docs need historical clarification.
+
+Acceptance criteria:
+
+- There is a documented no-surprise command for workers to check the index before planning.
+- Tests that exercise CLI rebuild/status do not leave `tools/index.json` in the real repo root unless the test explicitly cleans it up.
+- `CLAUDE.md` tells workers what to do when `tools/index.json` is missing or stale.
+
+Validation:
+
+- `python3 -m pytest tests/test_code_index.py -q` should pass and leave `git status --short --ignored` without a new `!! tools/index.json` unless the task deliberately changes that contract.
+- `python3 tools/code_index.py --status` should have a documented expected result after a rebuild or when no index is present.
+
+### Task 3: Resolve GitHub-vs-Linear handoff wording
+
+Problem: Repo-local docs disagree about whether execution starts from Linear or GitHub Issues.
+
+Scope:
+
+- Candidate files: `docs/SYMPHONY_RUN_PROTOCOL.md`, `docs/agents/issue-tracker.md`, `docs/agents/triage-labels.md`, and `tests/test_packaging_ci.py`.
+
+Acceptance criteria:
+
+- One tracker is clearly declared as source of truth for this repo.
+- PR handoff instructions name the exact comment/update destination.
+- Tests guard the final wording so future protocol edits do not reintroduce mixed tracker assumptions.
+
+Validation:
+
+- `python3 -m pytest tests/test_packaging_ci.py -q` should pass.
+- Optional: `gh issue list --state open --limit 1` only if credentials are available and the task explicitly asks to verify GitHub access.
+
+### Task 4: Add a concise testing handoff page for support/stability workers
+
+Problem: README and protocol mention full validation and a support fast path, but there is no single `docs/TESTING_FOR_AGENTS.md` style page that distinguishes cheap deterministic tests from neural smoke runs and generated result files.
+
+Scope:
+
+- Candidate files: new `docs/TESTING_FOR_AGENTS.md`, `README.md`, `docs/SYMPHONY_RUN_PROTOCOL.md`, and `tests/test_packaging_ci.py`.
+
+Acceptance criteria:
+
+- The page lists install, cheap package/docs validation, deterministic support tests, neural quick smoke, and full test commands.
+- It states which commands may write generated result files and which are read-only.
+- README/protocol link to the page rather than duplicating all command nuance.
+
+Validation:
+
+- `python3 -m pytest tests/test_packaging_ci.py -q` should pass.
+- `python3 -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -q` should pass in an installed dev environment.
+
+## Validation candidates
+
+- Required queue validation: `git status --short`. Expected: exit 0 and show this report as the only untracked/changed file.
+- Observed cheap validation: `python3 -m pytest tests/test_packaging_ci.py -q`. Result: passed, `4 passed in 0.02s`.
+- Environment check: `python --version`. Observed fail, exit 127. This is a handoff risk, not a product test failure.
+- Environment check: `python3 --version`. Observed pass, `Python 3.12.8`.
+- Code-index status: `python3 tools/code_index.py --status`. Observed fail, exit 1, because `tools/index.json` is missing or stale. Do not run `--lookup`/`--dump` casually in this audit lane because it can create the ignored cache file.
+- Full clean-checkout install candidate: `python3 -m pip install -e ".[dev]"`. Expected pass if network/package cache is available; not run in this read-only audit.
+- Full CI candidate: `python3 -m pytest tests/ -v`. Expected pass after dev install; not run because the queue validation command is `git status --short` and full suite may run many research tests.
+- Support deterministic candidate: `python3 -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v`. Expected pass after dev install; not run.
+- Neural support smoke candidate: `python3 experiments/exp86_support_baselines.py --quick`. Expected pass if `torch` is installed; intentionally outside CI per README/protocol.
+
+## Non-goals
+
+- No product code changes.
+- No generated experiment result updates.
+- No dependency installation.
+- No external services, Kaggle jobs, model downloads, deploys, pushes, PR creation, or tracker updates.
+- No attempt to run the full test suite or regenerate the code index in this audit.
+- No decision on whether Tensor Logic's research claims are scientifically sufficient; this handoff audit only maps local workflow risk.
+
+## Unknowns
+
+- Whether the intended worker command contract should prefer `python`, `python3`, or a repo-local virtualenv executable.
+- Whether the repo should remain GitHub-Issue-first or inherit the portfolio's Linear-first convention.
+- Whether `tools/index.json` should be committed, generated in preflight, or kept ignored but recreated by agents as needed.
+- Whether Python 3.12 is officially supported, despite CI pinning 3.11.
+- Whether sibling repos depend on the broad public API in `tensor_logic/__init__.py`; changing exports may have cross-repo blast radius.
+- Whether full `python3 -m pytest tests/ -v` currently passes in this exact worktree without installing dev dependencies.
+
+## Worker handoff
+
+Changed files:
+
+- `docs/overnight/tensor-logic-workflow-handoff.md`
+
+Commit SHA:
+
+- Current HEAD before this report: `c9e2cfce206bb279a4348189726908fcb436d3dc`
+- No commit was created because the queue item only requested a local audit report and PR creation is out of scope.
+
+PR URL:
+
+- None. PR creation is explicitly out of scope for this overnight audit queue item.
+
+Blockers:
+
+- None for writing the report.
+- `python` executable is missing locally, so documented `python ...` commands fail unless workers use `python3` or a venv alias.
+- Code-index status is stale/missing; rebuilding would create ignored local state and was not done in this read-only audit.


### PR DESCRIPTION
## Summary

Adds generated overnight Codex review reports from the May 7 Goal Pack runs.

This PR is docs-only: it copies successful `docs/overnight` reports from isolated Goal Pack worktrees into a normal review branch.

## Included work

- Registered repo IDs: tensor-experiments, tensor-logic
- Report files: 13
- Source goal runs: 13 successful report outputs

## Validation

- Secret-like scan over copied reports found no live token/API-key patterns.
- Placeholder secret examples such as `*_API_KEY=...` were redacted in copied report text.
- `git status --short` showed only `docs/overnight` report additions before commit.
- No product code, deploys, external tracker updates, or generated runtime logs are included.

## Review notes

This is opened as a draft because the reports are generated audit output and should be skimmed before merge.