### PR TITLE
[codex] Add whole-portfolio review reports

### DIFF
--- a/docs/overnight/2026-05-07-whole-portfolio-review/tensor-experiments-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/tensor-experiments-implementation-readiness.md
@@ -1,0 +1,235 @@
+# tensor-experiments implementation-readiness review
+
+Date: 2026-05-07
+Queue item: `tensor-experiments-implementation-readiness`
+Branch: `codex/goal-tensor-experiments-implementation-readiness`
+Review HEAD: `c9e2cfce206bb279a4348189726908fcb436d3dc`
+
+## Scope and method
+
+This pass reviewed the local `tensor-experiments` worktree only. It did not edit product code, contact external services, update trackers, push branches, or create a PR.
+
+Repo-local evidence checked:
+
+```bash
+llm-tldr tree .
+git status --short --branch
+git rev-parse HEAD
+git branch --show-current
+git ls-files | rg '^(\.github/|docs/overnight/|runs/|items/|AGENTS\.md$|CLAUDE\.md$|README\.md$|pyproject\.toml$)'
+llm-tldr search "pytest|test|lint|validation|overnight|CI|workflow|ruff|black|mypy" .
+python3 tools/code_index.py --dump
+rtk grep "TODO|FIXME|Known limitation|NotImplemented|skip|xfail|argparse|__main__|TODO" .
+rtk grep "exp84|exp85|exp86|exp87|exp88|exp89|exp90|exp91|exp92|exp93|exp94|exp95" notes/EXPERIMENTS.md
+rg --files experiments | rg 'results(_quick)?\.json$'
+jq -r 'input_filename + "\t" + ((.experiment // .name // "unknown")|tostring) + "\t" + ((.passed // .pass // .gate_passed // .success // .summary.pass // "")|tostring) + "\t" + ((.metrics // .summary // .results // {})|keys|join(","))' experiments/exp8*_data/results*.json experiments/exp9*_data/results*.json
+```
+
+No tracked prior `docs/overnight/`, `runs/`, or `items/` artifacts were present in this worktree before this report. The tracked control/config files found were `.github/workflows/ci.yml`, `CLAUDE.md`, `README.md`, and `pyproject.toml`.
+
+## Implementation-readiness observations
+
+1. `README.md` frames this as both a learning repo and the shared `tensor_logic` library dependency for sibling projects, so implementation work can affect downstream users even when it looks like an experiment-only change.
+2. `README.md` documents the worker validation contract: install with `python -m pip install -e ".[dev]"`, then run `python -m pytest tests/ -v`; it also gives the support fast path and keeps `exp86` neural baseline smoke out of CI unless it stays quick and deterministic.
+3. `pyproject.toml` packages only `tensor_logic*`, requires Python `>=3.11`, has a single runtime dependency on `torch>=2.0`, and puts `pytest`, `numpy`, and `matplotlib` in the `dev` extra. This makes new experiment scripts importable from tests but not package exports unless moved under `tensor_logic`.
+4. `.github/workflows/ci.yml` runs on PRs and `main` pushes, sets up Python 3.11, installs `.[dev]`, and runs `python -m pytest tests/ -v`. There is CI coverage, but no separate result-manifest audit or quick-script smoke job.
+5. `CLAUDE.md` requires `python tools/code_index.py --lookup <RelevantSymbol>` before implementation planning that touches `tensor_logic/`. In this environment `python` was not found, while `python3 tools/code_index.py --dump` worked. Future tickets should use the repo's documented command but may need to normalize interpreter expectations.
+6. `CLAUDE.md` records a concrete exp78 backend limitation: VLM-style MLX model names can be incompatible with `mlx_lm.load()` and should use text-only models or transformers fallback. That is a ready blocker note for any rule-induction LM backend ticket.
+7. `docs/RUN_PROTOCOL.md` is strong on remote experiment provenance: output dir per run, `manifest.json`, `failures.jsonl`, adapter persistence through committed Kaggle notebook versions, and local pointer files under `experiments/expN_data/`. This should be reused for any future remote or adapter-producing work.
+8. `docs/SYMPHONY_RUN_PROTOCOL.md` is implementation-ready for normal workers: one issue, one branch, one PR, smallest validation, PR URL plus commit SHA in the handoff. This queue item intentionally stayed read-only except for this report.
+9. `docs/superpowers/plans/2026-05-05-support-stability.md` is the clearest current productized research plan. It names the V1 support/stability claim, non-goals, rule sketch, required neural baselines, falsification gate, test contract, and vertical slices.
+10. `tests/test_packaging_ci.py` already guards the packaging/CI/docs contract by asserting `pyproject.toml` dependencies, `.github/workflows/ci.yml` commands, README validation commands, and the Symphony PR handoff language.
+11. `tests/test_exp84_support_data.py` has implementation-ready generator invariants: deterministic generation, ID/OOD object-count ranges, non-overlap, intervention retraction, deep-copy safety, and unknown removal target rejection.
+12. `tests/test_exp85_support_tl.py` has strong TL support-engine tests: hand-built near misses, stable/falls proofs, branching full-width union, generator parity, removal retraction, and tolerant contact/horizontal extraction.
+13. `experiments/exp87_support_eval.py` is a complete V1 gate harness. It builds ID, larger OOD, deeper OOD, branching OOD, and counterfactual splits, evaluates TL plus MLP/DeepSets, raises on TL deterministic or counterfactual accuracy below 100%, and records the 10pp OOD margin gate.
+14. `tests/test_exp87_support_eval.py` verifies the required split coverage and result schema, including TL gates and neural metric shapes. This is a good pattern for future experiments that write `results.json`.
+15. `experiments/exp88_support_noisy_relations.py` through `experiments/exp95_scored_object_hypotheses.py` all expose `--quick` modes and write `results_quick.json` or `results.json` under their experiment data directories. Their tests call the underlying run functions with temporary outputs, so schema regressions are covered without committing regenerated data.
+16. `notes/EXPERIMENTS.md` has the freshest scientific evidence. Exp87 confirms the perfect-state support substrate, exp88-93 map brittleness and calibrated uncertainty, exp94 shows an oracle object-hypothesis upper bound, and exp95 shows non-oracle false-positive ranking is useful while missing/merge identity and cardinality remain unsafe.
+17. `experiments/exp95_scored_object_hypotheses_data/results.json` is the current full-run artifact for the latest lane. The notes record the key gap: false-positive stress improves materially, but missing-object and merge recovery still trail the oracle and can introduce accepted wrong labels.
+18. `tools/code_index.py` and `tests/test_code_index.py` provide a local AST signature index for `tensor_logic/`. `tests/test_code_index.py` also asserts `tools/index.json` is gitignored, which is correct for generated local planning state.
+19. `web_workbench/server.py`, `web_workbench/static/app.js`, and `tests/test_web_workbench.py` give a small interactive surface over the package. Tests verify query API smoke behavior, CLI/HTTP why-not JSON parity, and bundled sample TL validity.
+20. Current git history shows this branch at `origin/main` with recent merged support-lane PRs for exp92-95. There was no dirty product-code state before this report.
+
+## Risks and blockers
+
+- Interpreter mismatch: repo docs and CI use `python`, but this local shell only resolved `python3` during review. Any local worker issue should either run inside the intended venv or make the validation command explicit.
+- The full validation command depends on `torch`, `numpy`, `matplotlib`, and `pytest` from `.[dev]`. This review did not install dependencies or run the full suite because the queue validation is `git status --short`.
+- The latest support lane is implementation-ready, but exp95 is not claim-ready for missing/merge structural recovery. It needs an abstention policy and more identity/cardinality evidence before it can safely become a broader pixel-facing result.
+- CI proves tests, but not that committed `experiments/*_data/results.json` files match their corresponding scripts and notes. Result drift is an easy way for claims to go stale.
+- Pixel-facing experiments still use synthetic segmentation/detector stubs. Follow-up work should avoid implying real-world perception robustness until a real detector or a more faithful detector-error model is introduced.
+- `docs/RUN_PROTOCOL.md` is strongest for Kaggle adapter work, but exp87-95 local CPU result files do not have a uniform manifest checker. A small audit tool would make future generated artifacts safer to update.
+- `CLAUDE.md` contains a VLM backend limitation for exp78. Any ticket involving LM/VLM backend selection should carry that blocker forward instead of rediscovering it.
+- No previous overnight report or runner handoff existed locally for this queue item. Morning review should treat this file as the first implementation-readiness artifact for `tensor-experiments`.
+
+## Exact validation commands
+
+Required validation for this queue item:
+
+```bash
+git status --short
+```
+
+Documented full repo validation:
+
+```bash
+python -m pip install -e ".[dev]"
+python -m pytest tests/ -v
+```
+
+Support/stability fast path from README and Symphony protocol:
+
+```bash
+python -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v
+python experiments/exp86_support_baselines.py --quick
+```
+
+Current exp87-95 quick-script checks that would be useful before touching generated result artifacts:
+
+```bash
+python experiments/exp87_support_eval.py --quick
+python experiments/exp88_support_noisy_relations.py --quick
+python experiments/exp89_support_primitive_confidence.py --quick
+python experiments/exp90_support_repair_sweep.py --quick
+python experiments/exp91_interval_support_uncertainty.py --quick
+python experiments/exp92_pixel_abstain_recover.py --quick
+python experiments/exp93_detector_calibration_stress.py --quick
+python experiments/exp94_object_hypothesis_layer.py --quick
+python experiments/exp95_scored_object_hypotheses.py --quick
+```
+
+Use `python3` in this local shell if `python` is unavailable.
+
+## Implementation-ready follow-up tasks
+
+### 1. Add confidence-gated acceptance for exp95 non-oracle hypotheses
+
+Owned files:
+
+- `experiments/exp95_scored_object_hypotheses.py`
+- `tests/test_exp95_scored_object_hypotheses.py`
+- `notes/EXPERIMENTS.md` only if a full run updates the claim
+
+Acceptance criteria:
+
+- Scored false-positive drops can still be accepted when ranked confidently.
+- Missing-support and merge-split hypotheses abstain instead of accepting when rank margin or identity evidence is weak.
+- Result summaries include policy counters: accepted, abstained, accepted wrong, false-stable accepted, and recovery gap vs oracle.
+- Unit tests cover one missing, one merge, and one false-positive scene without relying on oracle IDs.
+
+Smallest useful validation:
+
+```bash
+pytest tests/test_exp95_scored_object_hypotheses.py -v
+python experiments/exp95_scored_object_hypotheses.py --quick
+```
+
+### 2. Add identity/cardinality evidence features for missing and merge hypotheses
+
+Owned files:
+
+- `experiments/exp92_pixel_abstain_recover.py`
+- `experiments/exp93_detector_calibration_stress.py`
+- `experiments/exp95_scored_object_hypotheses.py`
+- `tests/test_exp92_pixel_abstain_recover.py`
+- `tests/test_exp93_detector_calibration_stress.py`
+- `tests/test_exp95_scored_object_hypotheses.py`
+
+Acceptance criteria:
+
+- The detector/stress table exposes non-oracle evidence useful for object count anomalies, such as unmatched pixel area, compound-box aspect/height signals, and per-candidate support consistency.
+- Exp95 ranking can consume those features without reading `affected_ids`, `source_ids`, or `false_positive_ids`.
+- Tests prove missing/merge candidates can be ranked or abstained from evidence, not true source identity.
+
+Smallest useful validation:
+
+```bash
+pytest tests/test_exp92_pixel_abstain_recover.py tests/test_exp93_detector_calibration_stress.py tests/test_exp95_scored_object_hypotheses.py -v
+```
+
+### 3. Add a result-artifact audit tool for exp87-95
+
+Owned files:
+
+- `tools/results_audit.py`
+- `tests/test_results_audit.py`
+- `README.md`
+
+Acceptance criteria:
+
+- The tool validates all committed `experiments/exp8*_data/results*.json` and `experiments/exp9*_data/results*.json` files for `experiment`, `quick`, `results_path`, `config`, and required top-level metric sections.
+- The tool catches a mismatched `results_path` or missing `experiment` field.
+- README documents the audit command next to worker validation.
+
+Smallest useful validation:
+
+```bash
+pytest tests/test_results_audit.py -v
+python tools/results_audit.py
+```
+
+### 4. Add CI coverage for support-lane quick-script smoke runs
+
+Owned files:
+
+- `.github/workflows/ci.yml`
+- `tests/test_packaging_ci.py`
+- `README.md`
+
+Acceptance criteria:
+
+- CI still runs the full test suite.
+- CI or a separate optional job runs at least the deterministic quick scripts for exp87 and exp95 with temporary output paths.
+- `tests/test_packaging_ci.py` asserts the new CI commands so validation docs and CI do not drift.
+- README explains which quick scripts are CI-safe and which full runs are manual.
+
+Smallest useful validation:
+
+```bash
+pytest tests/test_packaging_ci.py -v
+```
+
+### 5. Normalize local interpreter and code-index validation docs
+
+Owned files:
+
+- `CLAUDE.md`
+- `README.md`
+- `docs/SYMPHONY_RUN_PROTOCOL.md`
+- `tests/test_packaging_ci.py`
+- `tests/test_code_index.py`
+
+Acceptance criteria:
+
+- Worker docs specify whether `python`, `python3`, or a venv-provided interpreter is required.
+- Code-index planning examples remain executable in a clean local shell or explicitly state the venv prerequisite.
+- Tests continue to prove `tools/code_index.py --lookup Program` works through `sys.executable`.
+
+Smallest useful validation:
+
+```bash
+pytest tests/test_packaging_ci.py tests/test_code_index.py -v
+python3 tools/code_index.py --lookup Program
+```
+
+## Handoff
+
+Changed files:
+
+- `docs/overnight/2026-05-07-whole-portfolio-review/tensor-experiments-implementation-readiness.md`
+
+Commit SHA reviewed:
+
+- `c9e2cfce206bb279a4348189726908fcb436d3dc`
+
+Validation result:
+
+- `git status --short` exited 0 and reported the expected untracked report directory: `?? docs/overnight/`.
+
+PR URL:
+
+- Not created. External pushes and PR creation are out of scope for this queue item.
+
+Blockers:
+
+- None for the report.
+- Full tests were not required by the queue item and were not run.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/tensor-experiments-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/tensor-experiments-risk-and-validation-review.md
@@ -1,0 +1,295 @@
+# tensor-experiments risk-and-validation review
+
+Queue item: `tensor-experiments-risk-and-validation-review`  
+Branch: `codex/goal-tensor-experiments-risk-and-validation-review`  
+Evidence HEAD before report: `c9e2cfce206bb279a4348189726908fcb436d3dc`  
+Review date: 2026-05-07
+
+## Scope
+
+This is a read-only risk and validation review of the local `tensor-experiments`
+worktree, plus this report file. I did not edit product code, create or merge a
+PR, push, deploy, run external services, or update trackers.
+
+No previous local overnight reports, `runs/` handoffs, or queue `items/` were
+present in this checkout when searched with `rg --hidden --files`.
+
+## Validation Evidence
+
+Commands run:
+
+```bash
+llm-tldr tree .
+git branch --show-current
+git rev-parse HEAD
+git status --short
+rg --hidden --files -g '.github/**' -g 'docs/overnight/**' -g 'runs/**' -g 'items/**'
+python -m pytest tests/test_packaging_ci.py -q
+python3 -m pytest tests/test_packaging_ci.py -q
+python3 -m pytest --collect-only -q
+python3 -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -q
+python3 -m pytest tests/test_exp87_support_eval.py -q
+python3 -m pytest tests/test_exp88_support_noisy_relations.py tests/test_exp89_support_primitive_confidence.py tests/test_exp90_support_repair_sweep.py tests/test_exp91_interval_support_uncertainty.py tests/test_exp92_pixel_abstain_recover.py tests/test_exp93_detector_calibration_stress.py tests/test_exp94_object_hypothesis_layer.py tests/test_exp95_scored_object_hypotheses.py -q
+```
+
+Observed results:
+
+- `git status --short` was clean before writing this report.
+- `python -m pytest tests/test_packaging_ci.py -q` could not run locally because
+  `python` is not on PATH in this worktree shell.
+- `python3 -m pytest tests/test_packaging_ci.py -q` passed: `4 passed in 0.02s`.
+- `python3 -m pytest --collect-only -q` collected 198 tests in 19.64s.
+- `python3 -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -q`
+  passed: `16 passed in 0.05s`.
+- `python3 -m pytest tests/test_exp87_support_eval.py -q` passed:
+  `2 passed in 2.28s`.
+- The exp88-exp95 focused batch passed: `34 passed in 2.69s`.
+
+The queue validation command to rerun after this report is:
+
+```bash
+git status --short
+```
+
+## Concrete Observations
+
+1. `README.md` documents the worker validation contract as
+   `python -m pip install -e ".[dev]"` and `python -m pytest tests/ -v`, plus a
+   support/stability fast path for `tests/test_exp84_support_data.py`,
+   `tests/test_exp85_support_tl.py`, and `python experiments/exp86_support_baselines.py --quick`.
+2. `CLAUDE.md` repeats the repo-local test command `pytest tests/ -v` and
+   records a known exp78 limitation: VLM-style MLX model names can be
+   incompatible with `mlx_lm.load()`.
+3. `pyproject.toml` declares only `torch` as a runtime dependency, with
+   `matplotlib`, `numpy`, and `pytest` in the `dev` extra; LLM experiment imports
+   such as `transformers`, `mlx_lm`, `peft`, and `datasets` are not represented
+   as installable extras.
+4. `.github/workflows/ci.yml` exists and runs on pull requests and pushes to
+   `main`, sets up Python 3.11, installs `".[dev]"`, and runs
+   `python -m pytest tests/ -v`.
+5. `tests/test_packaging_ci.py` explicitly checks the packaging and CI contract:
+   pyproject dependencies, workflow triggers, editable dev install, full pytest
+   command, README validation text, and `docs/SYMPHONY_RUN_PROTOCOL.md`.
+6. `docs/RUN_PROTOCOL.md` requires experiment manifests with config, metrics,
+   git SHA, timestamp, failure dumps, and result pointers, and says no experiment
+   should run without a pre-written spec containing a falsification criterion.
+7. `docs/superpowers/plans/2026-05-05-support-stability.md` defines the V1 gate:
+   TL must hit 100% deterministic and counterfactual accuracy and beat the best
+   neural baseline by at least 10pp on larger/deeper OOD stacks.
+8. `experiments/exp87_support_eval.py` computes the 10pp OOD neural-margin gate
+   and writes `thesis: "passed"` or `"falsified"`, but only raises hard failures
+   for TL deterministic and counterfactual accuracy, not for a failed OOD margin.
+9. `experiments/exp87_support_data/results.json` records the clean V1 pass:
+   100% TL deterministic label accuracy on 3,438 labels, 100% counterfactual
+   accuracy on 1,709 labels, and OOD margins of +16.3pp on larger OOD and
+   +30.8pp on deeper OOD versus DeepSets.
+10. `experiments/exp88_support_noisy_relations.py` and
+    `experiments/exp88_support_noisy_relations_data/results.json` show the clean
+    support engine is not perception-robust: first non-zero XY jitter
+    `delta=0.0001` drops aggregate accuracy to about 52.7%; a 0.001 tolerance
+    improves microscopic jitter but first drops by `delta=0.001`.
+11. `experiments/exp92_pixel_abstain_recover.py` and
+    `experiments/exp92_pixel_abstain_recover_data/results.json` show a useful
+    abstain contract but also a zero-noise pixel quantization caveat: hard TL is
+    90.7% accurate at `delta=0`, while interval feasibility gives 100% accepted
+    accuracy at 90.7% coverage.
+12. `experiments/exp93_detector_calibration_stress.py` explicitly models
+    coordinate, missing, merge, and false-positive detector failures; its result
+    artifact shows structural detector failures need a detector-health/object
+    hypothesis signal rather than just coordinate bands.
+13. `experiments/exp94_object_hypothesis_layer.py` is an oracle-style upper
+    bound using simulated structural anomaly metadata; `notes/EXPERIMENTS.md`
+    states this caveat directly and points to non-oracle ranking as the next
+    gate.
+14. `experiments/exp95_scored_object_hypotheses.py` removes several oracle
+    identity assumptions, but `experiments/exp95_scored_object_hypotheses_data/results.json`
+    and `notes/EXPERIMENTS.md` show large residual risk: missing-object scoring
+    can be worse than observed-naive, merge recovery is limited, and false-stable
+    accepted errors still occur.
+15. `tests/test_exp88_support_noisy_relations.py` through
+    `tests/test_exp95_scored_object_hypotheses.py` cover schema, zero-noise, and
+    targeted unit cases, but they do not enforce full-run result freshness,
+    manifest provenance, or acceptance thresholds for the exp95 non-oracle gate.
+16. `notes/EXPERIMENTS.md` is well maintained through exp95 and contains the
+    strongest current risk language: exp87 is a clean perfect-state substrate
+    result, exp88-exp93 are robustness/perception boundary maps, exp94 is an
+    oracle upper bound, and exp95 is partial with identity/cardinality gaps.
+17. `.gitignore` excludes generated caches, model weights, `.cocoindex_code/`,
+    and `tools/index.json`, matching `CLAUDE.md`'s warning that the local code
+    index is generated and should not be hand-edited.
+18. `tools/code_index.py` can rebuild `tools/index.json` on lookup/status, so
+    planning agents touching `tensor_logic/` have a local API signature guard,
+    but that guard is not part of the queue validation command.
+
+## Risks And Blockers
+
+- The required queue validation command, `git status --short`, only proves
+  worktree state. It does not prove the report quality or the repo's executable
+  validation contracts.
+- Local shell portability is weak: the documented `python -m ...` commands fail
+  here because only `python3` was available. CI's setup-python environment
+  should provide `python`, but local worker docs should state the precondition or
+  provide a `python3`/`uv` path.
+- Result artifacts for exp87-exp95 can go stale silently. The scripts write
+  `results.json`/`results_quick.json` by default, but the committed artifacts do
+  not consistently include git SHA, run timestamp, command, or a freshness check
+  against current code.
+- The exp87 V1 gate is not fully hard-failing: if TL still hits 100% but the
+  neural margin falls below 10pp, the script records `thesis: "falsified"` but
+  does not raise.
+- The support/perception story is easy to overclaim. Evidence currently supports
+  a perfect-state substrate claim and an abstain/recover interface direction,
+  not a production pixel model, real-world physics engine, or learned detector.
+- The exp95 non-oracle object-hypothesis layer is not yet ready to become a
+  positive claim. It has a real false-positive foothold, but missing/merge
+  identity gaps and false-stable accepted errors remain.
+- LLM-heavy older experiments are not covered by installable optional extras,
+  so fresh workers can install `".[dev]"` and still fail when trying exp36,
+  exp60d, exp77, or exp78 LM paths.
+- No previous local overnight handoff/report existed for this queue item, so
+  there was no prior generated review to reconcile.
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Make the exp87 OOD margin a hard gate
+
+Owned files:
+
+- `experiments/exp87_support_eval.py`
+- `tests/test_exp87_support_eval.py`
+
+Acceptance criteria:
+
+- `run_evaluation()` exits nonzero or raises when
+  `tl_ood_margin_vs_best_neural_at_least_10pp.passed` is false.
+- Tests cover the falsified-margin path without requiring a long neural run
+  (monkeypatch or inject baseline metrics).
+- Result JSON still records the failed gate details before the error path when
+  practical.
+
+Smallest useful validation:
+
+```bash
+python3 -m pytest tests/test_exp87_support_eval.py -q
+```
+
+### 2. Add CLI smoke tests that write to temp outputs
+
+Owned files:
+
+- `tests/test_support_cli_smokes.py`
+- `experiments/exp87_support_eval.py` through `experiments/exp95_scored_object_hypotheses.py` only if a CLI bug is exposed
+
+Acceptance criteria:
+
+- A parametrized test runs each support/stability script with
+  `--quick --output <tmp_path>/results.json`.
+- The test asserts exit code 0, valid JSON on stdout, output file exists, and
+  no default committed `experiments/exp*_data/results_quick.json` file is
+  modified.
+- Exp86 CLI quick smoke is included or covered by a separate focused test.
+
+Smallest useful validation:
+
+```bash
+python3 -m pytest tests/test_support_cli_smokes.py -q
+```
+
+### 3. Validate result manifests and freshness
+
+Owned files:
+
+- `tools/validate_experiment_results.py`
+- `tests/test_experiment_results_manifest.py`
+- `docs/RUN_PROTOCOL.md` if the required schema is refined
+
+Acceptance criteria:
+
+- The validator checks committed `experiments/exp*_data/results*.json` for
+  required fields: experiment name, quick/full mode, config, command or mode,
+  result path, git SHA or explicit `unversioned` marker, and generated timestamp.
+- The validator reports missing metadata for legacy artifacts without modifying
+  them unless explicitly run with a repair flag.
+- Tests cover both a valid manifest and a missing-field failure.
+
+Smallest useful validation:
+
+```bash
+python3 -m pytest tests/test_experiment_results_manifest.py -q
+python3 tools/validate_experiment_results.py
+```
+
+### 4. Add falsification specs for exp87-exp95
+
+Owned files:
+
+- `docs/exp87_support_eval_spec.md`
+- `docs/exp88_support_noisy_relations_spec.md`
+- `docs/exp89_support_primitive_confidence_spec.md`
+- `docs/exp90_support_repair_sweep_spec.md`
+- `docs/exp91_interval_support_uncertainty_spec.md`
+- `docs/exp92_pixel_abstain_recover_spec.md`
+- `docs/exp93_detector_calibration_stress_spec.md`
+- `docs/exp94_object_hypothesis_layer_spec.md`
+- `docs/exp95_scored_object_hypotheses_spec.md`
+- Optional: `tests/test_experiment_specs.py`
+
+Acceptance criteria:
+
+- Every exp87-exp95 spec states the hypothesis, null baseline, falsification
+  threshold, runtime tier, output artifact, and smallest validation command.
+- The specs preserve the caveats already documented in `notes/EXPERIMENTS.md`,
+  especially exp94's oracle upper-bound status and exp95's partial result.
+- A lightweight test or script verifies every `experiments/exp8*.py`/`exp9*.py`
+  support script has a matching spec with the words `Falsification` and
+  `Validation`.
+
+Smallest useful validation:
+
+```bash
+python3 -m pytest tests/test_experiment_specs.py -q
+```
+
+### 5. Add an install contract for optional LLM experiments
+
+Owned files:
+
+- `pyproject.toml`
+- `tests/test_packaging_ci.py`
+- `README.md`
+- `CLAUDE.md`
+
+Acceptance criteria:
+
+- Add one or more optional extras, for example `lm`, that document/install the
+  dependencies used by exp36, exp60d, exp77, and exp78 (`transformers`, `peft`,
+  `datasets`, and MLX packages where appropriate).
+- README and CLAUDE distinguish the core/dev install from optional LM/Kaggle
+  experiment installs.
+- Packaging tests assert the extras exist without requiring network access.
+
+Smallest useful validation:
+
+```bash
+python3 -m pytest tests/test_packaging_ci.py -q
+```
+
+## Handoff
+
+Changed files:
+
+- `docs/overnight/2026-05-07-whole-portfolio-review/tensor-experiments-risk-and-validation-review.md`
+
+PR URL: none; PR creation is out of scope for this queue item.
+
+Blockers:
+
+- No external credentials or approvals were needed.
+- Local `python` is missing; use `python3` locally or a CI/setup-python
+  environment that provides `python`.
+
+Final required validation:
+
+```bash
+git status --short
+```

--- a/docs/overnight/2026-05-07-whole-portfolio-review/tensor-logic-implementation-readiness.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/tensor-logic-implementation-readiness.md
@@ -1,0 +1,207 @@
+# tensor-logic implementation-readiness review
+
+Date: 2026-05-07
+Queue item: `tensor-logic-implementation-readiness`
+Branch: `codex/goal-tensor-logic-implementation-readiness`
+Initial HEAD: `c9e2cfce206bb279a4348189726908fcb436d3dc`
+
+## Scope and validation
+
+This is a read-only review and queue-prep pass. I did not edit product code or touch external trackers, deploys, pushes, or PRs. The only intended repository change is this report under `docs/overnight/2026-05-07-whole-portfolio-review/`.
+
+Required validation command for this queue item:
+
+```bash
+git status --short
+```
+
+Additional evidence commands used for this review:
+
+```bash
+git status --short --branch
+git rev-parse --show-toplevel
+git rev-parse --abbrev-ref HEAD
+git rev-parse HEAD
+llm-tldr tree .
+fd -H -t f '(^package.json$|^pnpm-lock.yaml$|^yarn.lock$|^package-lock.json$|^vite.config|^vitest.config|^tsconfig|^README|^AGENTS.md$|^CLAUDE.md$|^\.github|docs|test|spec|__tests__|playwright|eslint|prettier)' .
+fd -H -t f . docs/overnight 2>/dev/null || true
+fd -H -t f 'result.json|handoff.md' runs 2>/dev/null || true
+python3 tools/code_index.py --dump
+jq '{experiment, quick, gates, tl, mlp, deepsets}' experiments/exp87_support_data/results.json
+```
+
+Local note: this worktree's shell has `python3` but not `python`; CI and repo docs use `python`.
+
+## Repository state
+
+- `git status --short --branch` started clean on `codex/goal-tensor-logic-implementation-readiness`.
+- No `docs/overnight/` report files existed before this pass.
+- No local `runs/*/result.json` or `runs/*/handoff.md` files were present in this worktree.
+- No `CONTEXT.md`, `CONTEXT-MAP.md`, or `docs/adr/` files were present, even though `docs/agents/domain.md` describes that optional domain-doc layout.
+- No PR was created; external service access is out of scope for this queue item.
+
+## Concrete file-path observations
+
+1. `README.md` frames the repo as both a learning project and a shared `tensor_logic` library dependency, then records the headline import-closure result and the limits on parity/code-closure tasks. This makes claim hygiene important before turning new experiment results into public-facing work.
+
+2. `pyproject.toml` defines a Python 3.11 package named `tensor-logic`, depends only on `torch>=2.0`, and puts `numpy`, `matplotlib`, and `pytest` in the `dev` extra. There is no lockfile in the repo, so reproducible worker setup relies on environment discipline rather than pinned dependency resolution.
+
+3. `.github/workflows/ci.yml` runs one CI job on Python 3.11: install `-e ".[dev]"` and run `python -m pytest tests/ -v`. There is no separate lint, format, type-check, or quick experiment result validation job.
+
+4. `tests/test_packaging_ci.py` explicitly asserts that `pyproject.toml`, `.github/workflows/ci.yml`, `README.md`, and `docs/SYMPHONY_RUN_PROTOCOL.md` preserve the worker validation contract. This is a good guardrail for packaging and CI drift.
+
+5. `CLAUDE.md` requires `python tools/code_index.py --lookup <RelevantSymbol>` before implementation plans that touch `tensor_logic/`. `python3 tools/code_index.py --dump` showed exported APIs across `tensor_logic.closure`, `execution`, `file_format`, `http_api`, `language`, `optimize`, `program`, `proofs`, `reason`, `repo_graph_view`, `rules`, and `semirings`.
+
+6. `tensor_logic/__init__.py` exports a broad public surface: proof APIs, file loading, HTTP helpers, repo ingest, proof-tree rendering, provenance helpers, and semiring/rule utilities. Changes under `tensor_logic/` should be treated as shared-library changes, not experiment-only edits.
+
+7. `tests/test_tensor_logic_core.py` is the main integration test for core behavior: dense/BFS closure, rule parsing, stratified negation, provenance ranking, GF(2), named-index recursion, `.tl` file loading, positive and negative proofs, source-backed facts, disjunctive rule splitting, repo graph helpers, CLI/HTTP parity, and workbench sample validity.
+
+8. `tensor_logic/proofs.py` has tabled recursion and cycle guards for positive and negative proof construction, plus a fallback BFS-style recursive proof path. The tests cover cycles and false recursive queries, so proof work can be queued safely if it is narrow and test-first.
+
+9. `web_workbench/server.py` implements the browser workbench by writing temporary `.tl` files and invoking `python -m tensor_logic` via `subprocess.run`; `tests/test_web_workbench.py` covers query smoke behavior and why-not parity with `tensor_logic.http_api.prove_source`. This is executable but still duplicates CLI plumbing instead of using the in-process execution API.
+
+10. `docs/superpowers/plans/2026-05-05-support-stability.md` is a strong implementation contract for the physics support/stability lane: it defines V1 non-goals, primitive relations, baselines, evaluation splits, falsification gates, testing contracts, and vertical slices exp84-exp87.
+
+11. `experiments/exp84_support_data.py` and `tests/test_exp84_support_data.py` provide deterministic object-table generation plus label oracle checks for ID/OOD scenes, removal retraction, branching support, aliasing, and invalid interventions.
+
+12. `experiments/exp85_support_tl.py` and `tests/test_exp85_support_tl.py` provide the TL stability engine, primitive extraction, proof-bearing labels, tolerance handling, generator parity, and removal retraction coverage.
+
+13. `experiments/exp86_support_baselines.py` and `tests/test_exp86_support_baselines.py` provide MLP and DeepSets baselines with padding/masking, per-object logits, masked accuracy, and a tiny loss-reduction check. These are enough for smoke validation but not a statistical robustness story.
+
+14. `experiments/exp87_support_eval.py` writes full V1 ID/OOD/counterfactual results and raises if TL deterministic or counterfactual accuracy falls below 100%. `experiments/exp87_support_data/results.json` records `v1_passed: true`, TL 100% across ID, larger OOD, deeper OOD, branching OOD, and counterfactual, with best-neural OOD margins of about 16.3 points on larger OOD and 30.8 points on deeper OOD.
+
+15. `experiments/exp88_support_noisy_relations_data/results.json` shows the first sharp brittleness boundary: in XY geometry noise, hard TL first falls below 100% at delta `0.0001` with aggregate accuracy about `0.527`; tolerant geometry first falls below 100% at delta `0.001` with aggregate accuracy about `0.842`.
+
+16. `experiments/exp91_interval_support_uncertainty.py` and `tests/test_exp91_interval_support_uncertainty.py` implement coordinate-band feasibility as an abstain/recover signal. `experiments/exp91_interval_support_uncertainty_data/results.json` shows interval feasibility can preserve 100% accepted accuracy at useful coverage for point predictions that degrade under noise.
+
+17. `experiments/exp92_pixel_abstain_recover.py` and `tests/test_exp92_pixel_abstain_recover.py` move one step upstream to a synthetic pixel renderer/detector stub. Full results show XY delta `0.01` hard accuracy around `0.549`, while interval plus repair keeps accepted accuracy at `1.0` with about `0.800` coverage and zero accepted wrong cases.
+
+18. `experiments/exp93_detector_calibration_stress.py` and `tests/test_exp93_detector_calibration_stress.py` introduce coordinate, missing, merge, and false-positive detector stress. Full XY results at uncertainty multiplier `1.0` show structural modes require a guard: guarded structural abstain has zero accepted wrong but zero coverage for structural failures, while naive routes have many false-stable cases, especially false positives.
+
+19. `experiments/exp94_object_hypothesis_layer.py` and `tests/test_exp94_object_hypothesis_layer.py` add an oracle object-hypothesis layer that uses simulated structural anomaly metadata. `experiments/exp94_object_hypothesis_layer_data/results.json` shows this upper-bound route gets 100% accepted accuracy across missing, merge, and false-positive structural modes, with high but not full coverage.
+
+20. `experiments/exp95_scored_object_hypotheses.py` and `tests/test_exp95_scored_object_hypotheses.py` remove oracle structural identity metadata and rank non-oracle candidates. This is the active implementation frontier: `experiments/exp95_scored_object_hypotheses_data/results.json` shows scored non-oracle still has large recovery gaps versus oracle and nonzero false-stable cases. For example, XY delta `0.01` has scored accuracy about `0.598` on missing with `592` false-stable records, and scored accuracy about `0.722` on false-positive with `82` false-stable records.
+
+## Implementation-readiness assessment
+
+The repo is ready for narrow executable work, especially in the support/stability experiment chain. Exp84-exp87 have a clean vertical slice with tests, CI coverage, and committed full results. Exp91-exp95 expose the next concrete frontier: moving from perfect object tables to pixel/detector uncertainty and then from oracle structural metadata to non-oracle object hypotheses.
+
+The safest next work should not start by claiming a new research result. It should first improve measurement, failure-case auditability, and result-contract tests around exp93-exp95. Exp95 in particular is not claim-ready, but it is highly task-ready: the failing metrics are concrete, the owned files are localized, and the validations can be small.
+
+## Risks and blockers
+
+- Full local test validation was not required by this queue item and was not run. The required validation for this report is `git status --short`.
+- The local shell does not provide `python`; worker docs and CI commands use `python`. Future local workers in this exact shell should use a venv or `python3`.
+- No lockfile is present, so `torch>=2.0` plus the dev extras can resolve differently across worker machines.
+- The full committed result JSONs for exp93-exp95 are large, and current tests mostly validate quick-run schemas rather than persisted full-result claims.
+- Exp95 is not ready for an external claim: non-oracle scoring still accepts wrong structural repairs and has large recovery gaps versus the exp94 oracle upper bound.
+- No previous overnight reports or local `runs/*` artifacts were available in this worktree, so this pass could not cross-check runner handoffs.
+
+## Implementation-ready follow-up tasks
+
+### 1. Add exp95 failure-case dumps for ranked candidate debugging
+
+Owned files:
+- `experiments/exp95_scored_object_hypotheses.py`
+- `tests/test_exp95_scored_object_hypotheses.py`
+
+Acceptance criteria:
+- Add an optional `--dump-failures <path>` argument.
+- When provided, write JSONL records for accepted-wrong and false-stable scored predictions.
+- Each JSONL row includes split, failure mode, localization mode, delta, object id, expected label, observed label, oracle label, scored label, selected hypothesis, selected repair kind, candidate count, selected score, and score parts.
+- Existing default result JSON schema remains backward compatible.
+
+Smallest useful validation:
+
+```bash
+python -m pytest tests/test_exp95_scored_object_hypotheses.py -v
+python experiments/exp95_scored_object_hypotheses.py --quick --dump-failures /tmp/exp95_failures.jsonl
+```
+
+### 2. Add explicit exp95 gates for non-oracle claim readiness
+
+Owned files:
+- `experiments/exp95_scored_object_hypotheses.py`
+- `tests/test_exp95_scored_object_hypotheses.py`
+- `experiments/exp95_scored_object_hypotheses_data/results_quick.json`
+- `experiments/exp95_scored_object_hypotheses_data/results.json`
+
+Acceptance criteria:
+- Add a top-level `gates` object to exp95 results.
+- Gates include zero accepted false-stable records, maximum recovery gap versus oracle, and minimum scored accepted accuracy per structural failure mode.
+- Current full results should mark the non-oracle claim as not passed instead of relying on prose interpretation.
+- Add `--enforce-gates` so future result-generation jobs can fail loudly when configured thresholds are missed.
+
+Smallest useful validation:
+
+```bash
+python -m pytest tests/test_exp95_scored_object_hypotheses.py -v
+python experiments/exp95_scored_object_hypotheses.py --quick
+```
+
+### 3. Add persisted results contract tests for exp87-exp95
+
+Owned files:
+- `tests/test_support_results_contract.py`
+- `experiments/exp87_support_data/results.json`
+- `experiments/exp91_interval_support_uncertainty_data/results.json`
+- `experiments/exp92_pixel_abstain_recover_data/results.json`
+- `experiments/exp93_detector_calibration_stress_data/results.json`
+- `experiments/exp94_object_hypothesis_layer_data/results.json`
+- `experiments/exp95_scored_object_hypotheses_data/results.json`
+
+Acceptance criteria:
+- Add lightweight tests that read committed full result JSONs without rerunning experiments.
+- Assert exp87 V1 gates pass and split totals are nonzero.
+- Assert exp91 and exp92 accepted-accuracy routes remain 100% for the documented XY uncertainty rows.
+- Assert exp93 structural guarded route has zero accepted wrong for structural failures.
+- Assert exp94 oracle object-hypothesis accepted accuracy is 100% for structural modes.
+- Assert exp95 currently records non-oracle gaps or false-stable counts, so stale "passed" claims cannot slip into committed results.
+
+Smallest useful validation:
+
+```bash
+python -m pytest tests/test_support_results_contract.py -v
+```
+
+### 4. Convert the web workbench server to in-process execution APIs
+
+Owned files:
+- `web_workbench/server.py`
+- `tests/test_web_workbench.py`
+- `web_workbench/static/app.js` if UI output options need a JSON/tree toggle
+
+Acceptance criteria:
+- Replace temporary-file subprocess execution in `run_tensor_logic_action()` with `tensor_logic.execution` or `tensor_logic.http_api` helpers where possible.
+- Preserve current `run`, `query`, `prove`, and `why-not` behavior.
+- Keep parse and arity errors as HTTP 400 responses with useful stderr/error text.
+- Add a test proving why-not JSON semantics can be requested or that tree output remains semantically equivalent to `prove_source(..., why_not=True)`.
+
+Smallest useful validation:
+
+```bash
+python -m pytest tests/test_web_workbench.py tests/test_tensor_logic_core.py::TensorLogicCoreTest::test_web_workbench_sample_is_valid_tl -v
+```
+
+### 5. Document and test the exp95 non-oracle ranking frontier
+
+Owned files:
+- `docs/superpowers/plans/2026-05-05-support-stability.md`
+- `notes/EXPERIMENTS.md`
+- `tests/test_exp95_scored_object_hypotheses.py`
+
+Acceptance criteria:
+- Add a short "current frontier" section stating that exp94 is an oracle upper bound and exp95 is a non-oracle ranking attempt with known gaps.
+- Include the exact exp95 full-result metrics that block a claim: recovery gap versus oracle and false-stable counts for missing, merge, and false-positive modes.
+- Add one focused regression test for the most dangerous exp95 failure class: a scored candidate must not accept a stable label for an object whose expected label is falls in a hand-built false-positive support scene.
+- Keep this as documentation plus a targeted guard, not a broad ranking rewrite.
+
+Smallest useful validation:
+
+```bash
+python -m pytest tests/test_exp95_scored_object_hypotheses.py -v
+```
+
+## Bottom line
+
+`tensor-logic` is implementation-ready for small, well-owned tasks. The strongest immediate queue items are result-contract tests and exp95 failure audit tooling. The repo should not promote exp95 as a solved detector-structural-repair result until non-oracle gates are explicit and false-stable accepted cases are driven to zero or intentionally framed as an abstention tradeoff.

--- a/docs/overnight/2026-05-07-whole-portfolio-review/tensor-logic-risk-and-validation-review.md
+++ b/docs/overnight/2026-05-07-whole-portfolio-review/tensor-logic-risk-and-validation-review.md
@@ -1,0 +1,179 @@
+# tensor-logic Risk And Validation Review
+
+Date: 2026-05-07
+Queue item: `tensor-logic-risk-and-validation-review`
+Branch: `codex/goal-tensor-logic-risk-and-validation-review`
+Reviewed HEAD: `c9e2cfce206bb279a4348189726908fcb436d3dc`
+
+## Scope
+
+This is a read-only risk and validation review for `tensor-logic`. Product code was not edited. The only intended repository change from this queue item is this report.
+
+No repo-local prior overnight artifacts were found: `rg --files --hidden | rg '(^runs/|^docs/overnight/|result\.json$|handoff\.md$)'` found committed experiment result JSONs, but no `runs/*/result.json`, no `runs/*/handoff.md`, and no existing `docs/overnight/*` report for this pass.
+
+## Commands Run
+
+- Repo structure: `llm-tldr tree .`
+- Hidden CI/overnight scan: `rg --files --hidden -g '.github/**' -g 'docs/overnight/**' -g 'runs/**' -g 'CODEX_WORKPAD.md' -g 'ISSUE.md' -g 'AGENTS.md' -g 'CLAUDE.md' -g 'README.md'`
+- Current state: `git status --porcelain=v1 --branch`
+- HEAD: `git rev-parse HEAD`
+- API index lookups required before planning `tensor_logic/` changes: `python3 tools/code_index.py --lookup Program`, `python3 tools/code_index.py --lookup prove`, `python3 tools/code_index.py --lookup load_tl`
+- Smoke validation run during review: `python3 -m pytest tests/test_packaging_ci.py tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -q` -> `20 passed in 0.06s`
+- Required queue validation to run after writing this report: `git status --short`
+
+Note: `python tools/code_index.py --dump` failed locally because `python` is not on PATH in this shell; `python3` worked. CI and docs use `python`, so local worker setup should either provide a `python` shim or workers should use `python3` consistently when running locally.
+
+## Concrete Observations
+
+1. `README.md:85-102` documents the clean-checkout worker validation contract: `python -m pip install -e ".[dev]"`, `python -m pytest tests/ -v`, the support fast path for `tests/test_exp84_support_data.py tests/test_exp85_support_tl.py`, and `python experiments/exp86_support_baselines.py --quick`.
+
+2. `.github/workflows/ci.yml:18-30` runs Python 3.11 on pull requests and `main`, installs `".[dev]"`, and runs `python -m pytest tests/ -v`. This is a real CI contract, not only README text.
+
+3. `pyproject.toml:12-21` keeps install scope small: runtime dependency is only `torch>=2.0`; dev extras are `matplotlib`, `numpy`, and `pytest`. Experiments with optional LM backends (`transformers`, `mlx_lm`) are not part of the default test/install contract.
+
+4. `tests/test_packaging_ci.py:16-54` protects package metadata, README validation text, CI command strings, and the Symphony protocol's PR/validation contract. This makes drift in the basic worker instructions test-visible.
+
+5. `CLAUDE.md:5-11` requires `tools/code_index.py` lookups before implementation planning that touches `tensor_logic/`. `tools/code_index.py` writes `tools/index.json`, and `.gitignore:18-19` correctly ignores `.cocoindex_code/` and `tools/index.json`, so the lookup can be used without adding generated artifacts.
+
+6. `docs/RUN_PROTOCOL.md:16-24` requires remote experiment outputs to include a manifest with config, metrics, git SHA, timestamps, and failure logs; `docs/RUN_PROTOCOL.md:65-85` requires committed result pointers. Current support/stability scripts such as `experiments/exp87_support_eval.py:366-383` write config and `results_path`, but no git SHA or run timestamps.
+
+7. `docs/superpowers/plans/2026-05-05-support-stability.md:111-119` defines the V1 falsification gate: TL must be 100% on deterministic labels, 100% on counterfactual retraction, and at least 10 percentage points better than the best neural baseline on larger/deeper OOD. `experiments/exp87_support_eval.py:286-334` computes all three gates.
+
+8. `experiments/exp87_support_eval.py:361-364` raises when TL deterministic or counterfactual gates fail, but it does not raise when `tl_ood_margin_vs_best_neural_at_least_10pp` fails. It can therefore write a falsified result with exit code 0 even though the plan treats the OOD margin as part of the pass gate.
+
+9. `experiments/exp87_support_data/results_quick.json` currently records a passing quick V1 result: TL accuracy is 1.0 on ID, larger OOD, deeper OOD, branching OOD, and counterfactual splits; larger OOD margin is about 20.8 percentage points over DeepSets, and deeper OOD margin is about 38.4 percentage points over DeepSets.
+
+10. `tests/test_exp84_support_data.py` covers deterministic generation, object ranges, non-overlap, removal-chain retraction, branch support, non-aliasing, and unknown remove targets. `tests/test_exp85_support_tl.py` covers hand-built near misses, stable/falling cases, branching support, generator parity, removal retraction, and tolerance recovery. These are strong deterministic contracts for the support substrate.
+
+11. `tests/test_exp86_support_baselines.py:51-71` checks loss reduction and metric schema for neural baselines, but it intentionally avoids a research-accuracy threshold. That is appropriate for CI stability, but it means claims about baseline strength depend on committed result JSONs and notes, not on a failing unit gate.
+
+12. `notes/EXPERIMENTS.md:9-11` records the latest support/pixel-facing conclusions. Exp93 says structural detector failures break naive routing; exp94 says oracle object hypotheses recover them; exp95 is explicitly mixed, with false-positive ranking useful but missing/merge still needing identity evidence.
+
+13. `experiments/exp95_scored_object_hypotheses.py:740-747` accurately labels the current non-oracle hypothesis layer as having remaining identity/cardinality gaps. The quick result JSON mirrors the risk: for missing-object stress at `delta=0.0`, observed naive accepted accuracy is about 70.8%, but scored non-oracle is about 68.1% with 65 scored false-stable accepts; oracle remains 100%.
+
+14. `tests/test_exp95_scored_object_hypotheses.py:120-146` only checks schema and presence of oracle/scored fields for the aggregate run. It does not gate the safety property implied by `notes/EXPERIMENTS.md:9`: accept false-positive drops when confident, but abstain missing/merge repairs until identity evidence is available.
+
+15. `tensor_logic/proofs.py:348-378` implements recursive proof fallback by choosing the first binary relation with the same domains as the recursive relation. That is convenient for examples, but it is ambiguous if a program has multiple same-domain base relations and a recursive rule should only follow one of them.
+
+16. `web_workbench/server.py:44-71` writes user source to a temp file and shells out to `python -m tensor_logic` without a timeout or source-size guard. Existing tests cover happy-path query/prove behavior, but not runaway recursive rules or oversized source payloads.
+
+## Risks And Blockers
+
+- No prior overnight `runs/*` handoff artifacts were available in this worktree, so this review could not compare runner-created PRs or handoffs against current repo state.
+- Local command drift exists: docs and CI use `python`, while this shell only has `python3`. That is not a repo bug by itself, but it is a worker reliability risk.
+- Support/stability results are well documented, but committed result JSONs lack the run provenance required by the older experiment run protocol: git SHA, timestamps, command, and failure-output pointers.
+- Exp87 computes the OOD margin gate but does not fail the script when that gate fails. This is the sharpest validation hole because the falsification gate is central to the current research claim.
+- Exp95 is correctly documented as mixed, but its tests do not yet encode a safety gate that prevents missing/merge hypothesis scoring from becoming an accepted recovery claim.
+- Recursive proof fallback can silently use the wrong base relation in ambiguous same-domain programs.
+- The web workbench subprocess path can hang or consume resources on pathological input because it has no timeout or size limit.
+
+## Implementation-Ready Follow-Up Tasks
+
+### 1. Make the exp87 OOD margin gate fail loudly
+
+Owned files:
+- `experiments/exp87_support_eval.py`
+- `tests/test_exp87_support_eval.py`
+
+Acceptance criteria:
+- `run_evaluation()` raises a clear `RuntimeError` when `tl_ood_margin_vs_best_neural_at_least_10pp.passed` is false.
+- Tests cover the negative path by constructing or monkeypatching a gate result where deterministic and counterfactual TL pass but the OOD margin fails.
+- Positive-path tests still assert the current quick schema and gate fields.
+
+Smallest useful validation:
+
+```bash
+python3 -m pytest tests/test_exp87_support_eval.py -v
+```
+
+### 2. Add result provenance metadata for support/stability result JSONs
+
+Owned files:
+- `experiments/exp87_support_eval.py`
+- `experiments/exp88_support_noisy_relations.py`
+- `experiments/exp89_support_primitive_confidence.py`
+- `experiments/exp90_support_repair_sweep.py`
+- `experiments/exp91_interval_support_uncertainty.py`
+- `experiments/exp92_pixel_abstain_recover.py`
+- `experiments/exp93_detector_calibration_stress.py`
+- `experiments/exp94_object_hypothesis_layer.py`
+- `experiments/exp95_scored_object_hypotheses.py`
+- `tests/test_support_result_metadata.py`
+
+Acceptance criteria:
+- Every support/stability runner from exp87 through exp95 writes `git_sha`, `started_at`, `finished_at`, and `command` or `argv` into its result JSON.
+- Tests verify the metadata exists when a runner writes to a temp output path.
+- The metadata helper must not require network access or external services.
+
+Smallest useful validation:
+
+```bash
+python3 -m pytest tests/test_support_result_metadata.py -v
+```
+
+### 3. Encode exp95 non-oracle safety gates
+
+Owned files:
+- `experiments/exp95_scored_object_hypotheses.py`
+- `tests/test_exp95_scored_object_hypotheses.py`
+- `notes/EXPERIMENTS.md`
+
+Acceptance criteria:
+- Results include explicit `safety_gates` per failure mode for `scored_non_oracle`.
+- False-positive stress must show fewer false-stable accepts than observed naive at the configured gate point.
+- Missing and merge stress must not be reported as recovery successes unless scored non-oracle is at least as safe as observed naive on accepted-wrong and false-stable counts; otherwise the result should be labeled `needs_identity_evidence` or equivalent.
+- Tests include one aggregate quick run assertion for the safety-gate fields and one focused unit test for a missing-object case that should abstain rather than accept an unsafe synthetic support.
+
+Smallest useful validation:
+
+```bash
+python3 -m pytest tests/test_exp95_scored_object_hypotheses.py -v
+```
+
+### 4. Disambiguate recursive proof fallback base relations
+
+Owned files:
+- `tensor_logic/proofs.py`
+- `tests/test_proof_recursion.py` or `tests/test_tensor_logic_core.py`
+
+Acceptance criteria:
+- Recursive proof fallback uses the base relation implied by the rule body, or refuses fallback when multiple same-domain base relations are plausible.
+- A new regression test builds a program with two same-domain base relations and proves that `reachable` does not traverse the unrelated relation.
+- Existing recursive proof and `.tl` file proof tests continue to pass.
+
+Smallest useful validation:
+
+```bash
+python3 -m pytest tests/test_proof_recursion.py tests/test_tensor_logic_core.py -k "recursive or proof" -v
+```
+
+Before planning this task, run:
+
+```bash
+python3 tools/code_index.py --lookup prove
+```
+
+### 5. Add timeout and input-size guard to the web workbench subprocess wrapper
+
+Owned files:
+- `web_workbench/server.py`
+- `tests/test_web_workbench.py`
+
+Acceptance criteria:
+- `run_tensor_logic_action()` rejects oversized `source` payloads with a clear HTTP error before writing a temp file.
+- The subprocess call has a bounded timeout and returns a structured timeout error instead of hanging.
+- Existing query/prove/why-not behavior and CLI parity tests continue to pass.
+
+Smallest useful validation:
+
+```bash
+python3 -m pytest tests/test_web_workbench.py -v
+```
+
+## Handoff Notes
+
+- Product code changes made: none.
+- Report path: `docs/overnight/2026-05-07-whole-portfolio-review/tensor-logic-risk-and-validation-review.md`
+- Local commit: not created. `git add docs/overnight/2026-05-07-whole-portfolio-review/tensor-logic-risk-and-validation-review.md` failed because the sandbox could not create `/Users/jwalinshah/projects/tensor/tensor-logic/.git/worktrees/tensor-logic-risk-and-validation-review/index.lock`.
+- PR created: none; external pushes and PR creation are out of scope for this queue item.
+- Required final validation: `git status --short`


### PR DESCRIPTION
## Summary

Adds generated whole-portfolio review reports from `2026-05-07-whole-portfolio-review`.

This PR is docs-only and includes successful `docs/overnight` report outputs.

## Included work

- Registered repo IDs: tensor-experiments, tensor-logic
- Report files: 4

## Validation

- Secret-like scan over copied reports found no live token/API-key patterns.
- Placeholder secret examples such as `*_API_KEY=...` were redacted in copied report text.
- No product code, deploys, external tracker updates, or generated runtime logs are included.

## Review notes

Opened as a draft because the reports are generated audit output and should be skimmed before merge.