### PR TITLE
[codex] Package web workbench local updates

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -1,0 +1,315 @@
+# Tensor Logic Claim/Evidence Boundary
+
+Last updated: 2026-05-06
+
+This file separates claims that are supported by committed experiments from
+claims that remain hypotheses, extrapolations, or non-goals. It is intentionally
+conservative: if a result depends on toy data, perfect object state, oracle
+metadata, or a synthetic detector, the claim must say so.
+
+## Supported Claims
+
+### 1. Tensor Logic is strong when the operator matches the task structure.
+
+Supported by:
+
+- `README.md`
+- `notes/EXPERIMENTS.md`
+- `experiments/exp44_import_closure.py`
+- `experiments/exp47_size_generalization.py`
+- `experiments/exp53_real_imports.py`
+- `experiments/exp54_big_imports.py`
+
+Evidence boundary:
+
+- The strongest validated closure claim is about transitive closure/reachability
+  and import-graph closure.
+- The 3-scalar recurrence generalizes across graph sizes because the recurrence
+  matches Boolean closure over matrix powers.
+- The README reports zero-shot real-package import-graph F1 results and a larger
+  package sweep. It also names Django as a weak case, so the claim is not
+  "perfect on all import graphs."
+
+Allowed phrasing:
+
+- "TL is highly parameter-efficient on closure-shaped tasks."
+- "For transitive closure and import reachability, the structural recurrence
+  generalizes across graph size better than flat MLP baselines in these
+  experiments."
+
+Do not claim:
+
+- "TL beats neural nets generally."
+- "TL solves code understanding."
+- "TL handles arbitrary program analysis."
+
+### 2. Perfect-state support/stability V1 passed its planned gate.
+
+Supported by:
+
+- `docs/superpowers/plans/2026-05-05-support-stability.md`
+- `experiments/exp84_support_data.py`
+- `experiments/exp85_support_tl.py`
+- `experiments/exp86_support_baselines.py`
+- `experiments/exp87_support_eval.py`
+- `experiments/exp87_support_data/results.json`
+- `tests/test_exp84_support_data.py`
+- `tests/test_exp85_support_tl.py`
+- `tests/test_exp86_support_baselines.py`
+- `tests/test_exp87_support_eval.py`
+
+Evidence boundary:
+
+- Inputs are perfect object tables with primitive geometry computed from known
+  object boxes.
+- The full-run exp87 result reports TL at 100.0% on 3,438 deterministic labels
+  and 100.0% on 1,709 counterfactual labels.
+- The planned OOD gates passed against both padded MLP and DeepSets baselines:
+  larger OOD margin was +16.3 percentage points over the best neural baseline,
+  and deeper OOD margin was +30.8 percentage points.
+- TL receives primitive geometry facts, not pre-derived `supports` labels.
+
+Allowed phrasing:
+
+- "Given perfect object-state input, the deterministic TL support module gives
+  exact labels, proofs, and counterfactual retraction on the toy support/stability
+  benchmark, and beats the tested MLP/DeepSets baselines on larger/deeper OOD
+  stacks."
+
+Do not claim:
+
+- "TL solves physical reasoning."
+- "TL works from real images."
+- "TL has learned support rules."
+- "The result covers collision, friction, deformation, motion transfer, or
+  continuous trajectories."
+
+### 3. The clean support/stability result is brittle to noisy geometry, but the
+failure boundary is mapped.
+
+Supported by:
+
+- `experiments/exp88_support_noisy_relations.py`
+- `experiments/exp88_support_noisy_relations_data/results.json`
+- `tests/test_exp88_support_noisy_relations.py`
+
+Evidence boundary:
+
+- Zero-noise accuracy remains 100.0%.
+- Tiny coordinate jitter can break exact support predicates, especially through
+  contact and full-width coverage boundaries.
+- A small extraction tolerance recovers microscopic jitter but does not make the
+  system perception-robust.
+
+Allowed phrasing:
+
+- "The perfect-state support engine has a sharp brittleness boundary under
+  geometry noise."
+- "Tolerance helps at the tolerance scale only."
+
+Do not claim:
+
+- "The hard TL engine is robust to perception noise."
+
+### 4. Confidence, interval, and repair wrappers provide useful abstain/recover
+contracts under synthetic object-table and pixel-stub noise.
+
+Supported by:
+
+- `experiments/exp89_support_primitive_confidence.py`
+- `experiments/exp90_support_repair_sweep.py`
+- `experiments/exp91_interval_support_uncertainty.py`
+- `experiments/exp92_pixel_abstain_recover.py`
+- `experiments/exp89_support_primitive_confidence_data/results.json`
+- `experiments/exp90_support_repair_sweep_data/results.json`
+- `experiments/exp91_interval_support_uncertainty_data/results.json`
+- `experiments/exp92_pixel_abstain_recover_data/results.json`
+- `tests/test_exp89_support_primitive_confidence.py`
+- `tests/test_exp90_support_repair_sweep.py`
+- `tests/test_exp91_interval_support_uncertainty.py`
+- `tests/test_exp92_pixel_abstain_recover.py`
+
+Evidence boundary:
+
+- These are wrappers around the same hard TL engine, not learned perception.
+- The pixel-facing experiment uses rendered synthetic segmentation boxes and
+  detector-style localization perturbations.
+- The supported claim is about interface shape: calibrated uncertainty lets TL
+  abstain or recover instead of forcing brittle hard primitive facts.
+
+Allowed phrasing:
+
+- "Calibrated coordinate bands are a useful interface between object detection
+  and hard TL support reasoning."
+- "Interval/repair routing can preserve 100% accepted accuracy at reduced
+  coverage when uncertainty is calibrated in these synthetic settings."
+
+Do not claim:
+
+- "A real vision model has been integrated."
+- "The pixel pipeline handles occlusion, missing detections, merged detections,
+  or false positives without additional detector-health signals."
+
+### 5. Detector structural failures require object identity/cardinality signals.
+
+Supported by:
+
+- `experiments/exp93_detector_calibration_stress.py`
+- `experiments/exp94_object_hypothesis_layer.py`
+- `experiments/exp95_scored_object_hypotheses.py`
+- `experiments/exp93_detector_calibration_stress_data/results.json`
+- `experiments/exp94_object_hypothesis_layer_data/results.json`
+- `experiments/exp95_scored_object_hypotheses_data/results.json`
+- `tests/test_exp93_detector_calibration_stress.py`
+- `tests/test_exp94_object_hypothesis_layer.py`
+- `tests/test_exp95_scored_object_hypotheses.py`
+
+Evidence boundary:
+
+- exp93 shows coordinate calibration is insufficient for missing, merged, or
+  false-positive object failures.
+- exp94 is an oracle/upper-bound object-hypothesis layer that uses simulated
+  anomaly metadata.
+- exp95 removes oracle source IDs and shows a partial foothold for false-positive
+  ranking, but missing and merge repairs remain unsafe or incomplete.
+
+Allowed phrasing:
+
+- "Pixel-facing TL needs coordinate uncertainty and detector-health/object
+  hypothesis signals."
+- "The current non-oracle object-hypothesis layer is partial; false positives are
+  the strongest recovered case, while missing/merge identity gaps remain open."
+
+Do not claim:
+
+- "Object hypotheses solve detector structural failures."
+- "The non-oracle hypothesis ranker closes the gap to the oracle upper bound."
+
+### 6. TL-as-tool works on the tested kinship closure protocol.
+
+Supported by:
+
+- `notes/EXPERIMENTS.md` rows for exp60d and related exp60 files.
+
+Evidence boundary:
+
+- The supported result is a small-LM delegation protocol for kinship closure,
+  not general language reasoning.
+- The language model learns to emit tool calls; TL performs the closure.
+
+Allowed phrasing:
+
+- "A small SFT'd LM can learn to delegate specific kinship closure questions to a
+  TL tool in the tested synthetic protocol."
+
+Do not claim:
+
+- "The LM learned symbolic reasoning."
+- "This proves general agentic reasoning."
+
+## Unsupported Or Only Partially Supported Claims
+
+- Real-world physical reasoning from natural images.
+- Learned rule induction for support/stability.
+- Learned perception for support/stability.
+- Continuous physics, motion prediction, collision response, friction,
+  deformation, or dynamics.
+- General code understanding beyond import/reachability-style closure.
+- General theorem proving.
+- General superiority over neural models.
+- Robustness to arbitrary detector failures.
+- Non-oracle identity/cardinality recovery for missing or merged objects.
+- TL inside transformers as a proven performance win.
+
+## Explicit Non-Claims
+
+- This repository is a research/learning project, not a production product.
+- A toy benchmark pass is not a real-world deployment claim.
+- A deterministic proof trace is not evidence that the input facts are true.
+- Exact inference over wrong detected facts can still produce wrong conclusions.
+- Baseline wins are scoped to the specific baseline implementations, training
+  distributions, seeds, and gates in the committed experiments.
+
+## Baselines Required Before Stronger Claims
+
+For support/stability:
+
+- Perfect-state TL rule engine.
+- Padded-object MLP.
+- DeepSets or GNN-style variable-object baseline.
+- ID, larger OOD, deeper OOD, branching OOD, and counterfactual splits.
+- Explicit gates for TL deterministic accuracy, TL counterfactual accuracy, and
+  TL margin over the best neural baseline.
+
+For noisy/pixel-facing claims:
+
+- Hard point-estimate TL.
+- Primitive confidence or calibrated uncertainty route.
+- Interval feasibility route.
+- Repair route, if repairs are part of the claim.
+- Guarded abstention when detector structural failures are present.
+- Oracle and non-oracle object-hypothesis variants must be reported separately.
+
+For closure/code-graph claims:
+
+- TL recurrence at fixed parameter count.
+- Neural baseline with a stated size/input limitation.
+- Native-size or explicitly cropped evaluation, with the crop caveat stated.
+- Real-package results plus the known weak cases.
+
+## Validation Commands
+
+Clean checkout validation:
+
+```bash
+python -m pip install -e ".[dev]"
+python -m pytest tests/ -v
+```
+
+Support/stability fast path:
+
+```bash
+python -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v
+python experiments/exp86_support_baselines.py --quick
+```
+
+Support/stability V1 gate:
+
+```bash
+python -m pytest tests/test_exp86_support_baselines.py tests/test_exp87_support_eval.py -v
+python experiments/exp87_support_eval.py --quick
+python experiments/exp87_support_eval.py
+```
+
+Noisy and pixel-facing boundary checks:
+
+```bash
+python -m pytest tests/test_exp88_support_noisy_relations.py tests/test_exp89_support_primitive_confidence.py tests/test_exp90_support_repair_sweep.py tests/test_exp91_interval_support_uncertainty.py -v
+python -m pytest tests/test_exp92_pixel_abstain_recover.py tests/test_exp93_detector_calibration_stress.py tests/test_exp94_object_hypothesis_layer.py tests/test_exp95_scored_object_hypotheses.py -v
+```
+
+Quick experiment entrypoints:
+
+```bash
+python experiments/exp87_support_eval.py --quick
+python experiments/exp88_support_noisy_relations.py --quick
+python experiments/exp89_support_primitive_confidence.py --quick
+python experiments/exp90_support_repair_sweep.py --quick
+python experiments/exp91_interval_support_uncertainty.py --quick
+python experiments/exp92_pixel_abstain_recover.py --quick
+python experiments/exp93_detector_calibration_stress.py --quick
+python experiments/exp94_object_hypothesis_layer.py --quick
+python experiments/exp95_scored_object_hypotheses.py --quick
+```
+
+## Reporting Rule
+
+When writing a README, memo, PR description, paper note, or Linear issue from
+this repo, include three fields:
+
+- Claim:
+- Evidence:
+- Boundary:
+
+If the boundary cannot be stated in one or two sentences, the claim is probably
+too broad.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ download experiments, or FAFSA/ISIR validation data.
 - `AGENTS.md` is memjuice-managed — do not edit it manually.
 - `.cocoindex_code/` contains a vector embedding index (semantic search) — separate from `tools/index.json` (structured API signatures).
 
+## GitHits MCP
+
+Use GitHits MCP to search for real-world open-source implementation patterns when local context or official docs are not enough, especially for current APIs, fragile integrations, or unfamiliar libraries. Treat GitHits output as external reference material with source/license context; adapt patterns to this repo instead of copying blindly.
+
 ## Agent skills
 
 ### Issue tracker

--- a/docs/remote-jobs/tensor-logic-baseline-sweep.md
+++ b/docs/remote-jobs/tensor-logic-baseline-sweep.md
@@ -1,0 +1,210 @@
+# Tensor Logic Baseline Sweep Remote Job
+
+Purpose: produce repeatable evidence for support/stability baseline claims
+without broadening the claim beyond the current toy object-table benchmark.
+
+## Scope
+
+Run the committed support/stability evaluation with multiple seeds and both
+quick and full settings. The target claim is limited to:
+
+> Given perfect object-state input, the deterministic TL support/stability module
+> reaches exact label/proof/counterfactual behavior on the generated toy
+> benchmark and beats the tested neural baselines on larger/deeper OOD stacks.
+
+This job does not test real images, learned perception, learned rules, continuous
+physics, collision, friction, deformation, or motion prediction.
+
+## Inputs
+
+Repo:
+
+```bash
+git clone <repo-url> tensor-logic
+cd tensor-logic
+python -m pip install -e ".[dev]"
+```
+
+Reference files:
+
+- `CLAIMS.md`
+- `docs/superpowers/plans/2026-05-05-support-stability.md`
+- `experiments/exp84_support_data.py`
+- `experiments/exp85_support_tl.py`
+- `experiments/exp86_support_baselines.py`
+- `experiments/exp87_support_eval.py`
+- `tests/test_exp84_support_data.py`
+- `tests/test_exp85_support_tl.py`
+- `tests/test_exp86_support_baselines.py`
+- `tests/test_exp87_support_eval.py`
+
+## Preflight
+
+Run deterministic tests first:
+
+```bash
+python -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py tests/test_exp86_support_baselines.py tests/test_exp87_support_eval.py -v
+```
+
+Expected:
+
+- Generator invariants pass.
+- TL exact support/counterfactual tests pass.
+- Baseline tensorization/masking tests pass.
+- Evaluation schema and gate tests pass.
+
+Stop if any preflight test fails.
+
+## Baseline Sweep
+
+Minimum local smoke run:
+
+```bash
+python experiments/exp87_support_eval.py --quick --output experiments/exp87_support_data/results_quick.json
+```
+
+Full reference run:
+
+```bash
+python experiments/exp87_support_eval.py --output experiments/exp87_support_data/results.json
+```
+
+Seed sweep, if the evaluator exposes a seed/config flag in the current branch:
+
+```bash
+for seed in 8700 8701 8702 8703 8704; do
+  python experiments/exp87_support_eval.py \
+    --seed "$seed" \
+    --output "experiments/exp87_support_data/results_seed_${seed}.json"
+done
+```
+
+If the current CLI does not expose seed selection, do not patch product code in a
+remote job. Record that limitation and run the committed quick/full commands
+only.
+
+## Required Metrics
+
+Record these fields from each result JSON:
+
+- `config.quick`
+- `config.seed`
+- `splits.train.scenes`
+- `splits.id.objects`
+- `splits.larger_ood.objects`
+- `splits.deeper_ood.objects`
+- `splits.counterfactual.objects`
+- `tl.id.accuracy`
+- `tl.larger_ood.accuracy`
+- `tl.deeper_ood.accuracy`
+- `tl.counterfactual.accuracy`
+- `mlp.larger_ood.accuracy`
+- `mlp.deeper_ood.accuracy`
+- `deepsets.larger_ood.accuracy`
+- `deepsets.deeper_ood.accuracy`
+- `gates.tl_deterministic_label_accuracy_100.passed`
+- `gates.tl_counterfactual_retraction_accuracy_100.passed`
+- `gates.tl_ood_margin_vs_best_neural_at_least_10pp.passed`
+- `gates.v1_passed`
+
+The V1 support/stability claim is reportable only if all gates pass.
+
+## Expected Current Baseline
+
+The committed full result in `experiments/exp87_support_data/results.json`
+reports:
+
+- TL deterministic label accuracy: 100.0% on 3,438 labels.
+- TL counterfactual retraction accuracy: 100.0% on 1,709 labels.
+- Best larger OOD neural baseline: DeepSets at 83.7%; TL margin +16.3pp.
+- Best deeper OOD neural baseline: DeepSets at 69.2%; TL margin +30.8pp.
+- `gates.v1_passed`: true.
+
+Treat these numbers as the current reference, not as a guarantee for modified
+branches.
+
+## Artifact Layout
+
+Do not commit model weights or large generated outputs. Store remote artifacts
+under the remote runner's output directory, then mirror only compact result JSONs
+or a pointer file if needed.
+
+Suggested output layout:
+
+```text
+remote-output/tensor-logic-baseline-sweep/
+  manifest.json
+  results_quick.json
+  results.json
+  results_seed_8700.json
+  results_seed_8701.json
+  summary.md
+```
+
+`manifest.json` should include:
+
+```json
+{
+  "job": "tensor-logic-baseline-sweep",
+  "git_sha": "<sha>",
+  "started_at": "<iso8601>",
+  "finished_at": "<iso8601>",
+  "python": "<version>",
+  "torch": "<version>",
+  "commands": [],
+  "results": []
+}
+```
+
+## Summary Template
+
+```markdown
+# Tensor Logic Baseline Sweep Summary
+
+Git SHA:
+Runner:
+Started:
+Finished:
+
+## Commands
+
+- `python -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py tests/test_exp86_support_baselines.py tests/test_exp87_support_eval.py -v`
+- `python experiments/exp87_support_eval.py --quick --output ...`
+- `python experiments/exp87_support_eval.py --output ...`
+
+## Result
+
+| run | TL ID | TL larger OOD | best neural larger OOD | margin | TL deeper OOD | best neural deeper OOD | margin | TL counterfactual | V1 gate |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| full | | | | | | | | | |
+
+## Claim Status
+
+- Supported:
+- Unsupported:
+- Notes:
+```
+
+## Stop Conditions
+
+Stop and report instead of continuing if:
+
+- Any preflight test fails.
+- TL deterministic label accuracy is below 100%.
+- TL counterfactual retraction accuracy is below 100%.
+- Either larger/deeper OOD margin over the best neural baseline is below 10pp.
+- The result JSON omits either `mlp` or `deepsets`.
+- The run modifies product code, tests, lockfiles, generated assets, or
+  `web_workbench`.
+
+## Boundary For Reporting
+
+Acceptable final sentence:
+
+> The perfect-state support/stability V1 gate passed for this SHA: TL was exact
+> on generated labels and counterfactuals and cleared the planned OOD margin over
+> MLP/DeepSets baselines.
+
+Unacceptable final sentence:
+
+> Tensor Logic solves visual physical reasoning.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "torch>=2.0",
 ]
 
+[project.scripts]
+tensor-logic-workbench = "web_workbench.server:main"
+
 [project.optional-dependencies]
 dev = [
     "matplotlib>=3.7",
@@ -33,7 +36,10 @@ science = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["tensor_logic*"]
+include = ["tensor_logic*", "web_workbench*"]
+
+[tool.setuptools.package-data]
+web_workbench = ["static/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tensor_logic/ingest.py
+++ b/tensor_logic/ingest.py
@@ -23,6 +23,7 @@ class PythonImportGraph:
     modules: tuple[str, ...]
     edges: tuple[tuple[str, str], ...]
     symbols: dict[str, str]
+    files: dict[str, str]
 
 
 def ingest_python(root: str | Path) -> PythonImportGraph:
@@ -51,7 +52,8 @@ def ingest_python(root: str | Path) -> PythonImportGraph:
                         edges.add((module, target))
     modules = tuple(sorted(known))
     symbols = _module_symbols(modules)
-    return PythonImportGraph(modules, tuple(sorted(edges)), symbols)
+    files_by_module = {module: str(path) for path, module in module_by_file.items()}
+    return PythonImportGraph(modules, tuple(sorted(edges)), symbols, files_by_module)
 
 
 def render_python_imports_tl(graph: PythonImportGraph) -> str:

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -70,6 +70,16 @@ def test_readme_documents_worker_validation_commands():
     assert "docs/VALIDATION.md" in readme
 
 
+def test_workbench_readme_scopes_console_script_to_local_install():
+    readme = (REPO_ROOT / "web_workbench" / "README.md").read_text()
+
+    assert "After installing the package locally" in readme
+    assert "python -m pip install -e ." in readme
+    assert "tensor-logic-workbench --host 127.0.0.1 --port 8080" in readme
+    assert "source checkout without the console script installed" in readme
+    assert "python web_workbench/server.py --host 127.0.0.1 --port 8080" in readme
+
+
 def test_symphony_protocol_requires_real_github_prs_and_support_fast_path():
     protocol = (REPO_ROOT / "docs" / "SYMPHONY_RUN_PROTOCOL.md").read_text()
 
@@ -143,6 +153,8 @@ def test_built_wheel_contains_web_workbench_package_and_assets():
                 "wheel",
                 ".",
                 "--no-deps",
+                "--no-build-isolation",
+                "--no-index",
                 "--wheel-dir",
                 td,
             ],

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -2,7 +2,9 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+import tempfile
 import tomllib
+import zipfile
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -26,6 +28,9 @@ def test_pyproject_declares_worker_dev_install_contract():
     assert "torch" in dependencies
     assert {"pytest", "numpy", "matplotlib"} <= dev_dependencies
     assert "tensor_logic*" in package_include
+    assert "web_workbench*" in package_include
+    assert project["scripts"]["tensor-logic-workbench"] == "web_workbench.server:main"
+    assert "static/*" in pyproject["tool"]["setuptools"]["package-data"]["web_workbench"]
 
 
 def test_heavy_ml_dependencies_are_optional_not_default_ci():
@@ -126,3 +131,31 @@ def test_lightweight_import_proof_runs_without_remote_or_gpu():
 
     assert result.returncode == 0, result.stderr
     assert "tensor_logic import ok" in result.stdout
+
+
+def test_built_wheel_contains_web_workbench_package_and_assets():
+    with tempfile.TemporaryDirectory() as td:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "wheel",
+                ".",
+                "--no-deps",
+                "--wheel-dir",
+                td,
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+
+        assert result.returncode == 0, result.stderr
+        wheel = next(Path(td).glob("tensor_logic-*.whl"))
+        with zipfile.ZipFile(wheel) as archive:
+            names = set(archive.namelist())
+
+    assert "web_workbench/__init__.py" in names
+    assert "web_workbench/server.py" in names
+    assert "web_workbench/static/index.html" in names

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -925,14 +925,21 @@ class TensorLogicCoreTest(unittest.TestCase):
         from tensor_logic.file_format import load_tl
 
         app_js = open("web_workbench/static/app.js", encoding="utf-8").read()
-        match = re.search(r"sourceEl\.value = `(?P<source>.*?)`;", app_js, re.S)
-        self.assertIsNotNone(match)
+        sources = re.findall(r"source:\s*`(?P<source>.*?)`,", app_js, re.S)
+        self.assertGreaterEqual(len(sources), 1)
+        import os
         import tempfile
-        with tempfile.NamedTemporaryFile("w", suffix=".tl", delete=False, encoding="utf-8") as f:
-            f.write(match.group("source"))
-            path = f.name
-        loaded = load_tl(path)
-        self.assertEqual(loaded.program.query("ancestor", "alice", "cara", recursive=True), 1.0)
+        for index, source in enumerate(sources):
+            with tempfile.NamedTemporaryFile("w", suffix=".tl", delete=False, encoding="utf-8") as f:
+                f.write(source)
+                path = f.name
+            try:
+                loaded = load_tl(path)
+                self.assertGreaterEqual(len(loaded.program.relations), 1)
+                if index == 0:
+                    self.assertEqual(loaded.program.query("ancestor", "alice", "dave", recursive=True), 1.0)
+            finally:
+                os.unlink(path)
 
 
 if __name__ == "__main__":

--- a/tests/test_web_workbench.py
+++ b/tests/test_web_workbench.py
@@ -30,6 +30,219 @@ class TestWebWorkbench(unittest.TestCase):
         self.assertEqual(result["action"], "query")
         self.assertEqual(result["exit_code"], 0)
         self.assertIn("ancestor(alice, cara) = True", result["stdout"])
+        self.assertEqual(result["payload"]["answer"], True)
+        self.assertEqual(result["payload"]["relation"], "ancestor")
+        self.assertEqual(result["payload"]["args"], ["alice", "cara"])
+        self.assertIn("duration_ms", result)
+
+    def test_prove_action_exposes_structured_payload(self):
+        payload = {
+            "source": _SAMPLE_SOURCE,
+            "relation": "ancestor",
+            "arg1": "alice",
+            "arg2": "cara",
+            "recursive": True,
+        }
+        result, status = run_tensor_logic_action("prove", payload)
+        self.assertEqual(status, HTTPStatus.OK)
+        self.assertEqual(result["exit_code"], 0)
+        self.assertEqual(result["payload"]["answer"], True)
+        self.assertEqual(result["payload"]["proof"]["head"], ["ancestor", "alice", "cara"])
+        self.assertIn("ancestor(alice, cara)", result["stdout"])
+
+    def test_ingest_python_action_loads_dependency_program(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            pkg = root / "pkg"
+            pkg.mkdir()
+            (pkg / "__init__.py").write_text("")
+            (pkg / "api.py").write_text("from . import db\n")
+            (pkg / "db.py").write_text("from . import models\n")
+            (pkg / "models.py").write_text("")
+
+            result, status = run_tensor_logic_action("ingest-python", {"path": str(root)})
+
+        self.assertEqual(status, HTTPStatus.OK)
+        self.assertEqual(result["action"], "ingest-python")
+        self.assertEqual(result["exit_code"], 0)
+        self.assertIn("relation depends_on(Module, Module)", result["payload"]["source"])
+        self.assertIn(["pkg_api", "pkg_db"], result["payload"]["imports"])
+        self.assertEqual(result["payload"]["suggested_query"]["relation"], "depends_on")
+        self.assertEqual(result["payload"]["suggested_query"]["arg1"], "pkg_api")
+        self.assertEqual(result["payload"]["suggested_query"]["arg2"], "pkg_models")
+        self.assertEqual(result["payload"]["symbol_to_module"]["pkg_api"], "pkg.api")
+        self.assertTrue(result["payload"]["symbol_to_file"]["pkg_api"].endswith("pkg/api.py"))
+
+    def test_repo_impact_action_reports_blast_radius(self):
+        source = """
+domain Module { api db models web }
+relation imports(Module, Module)
+relation depends_on(Module, Module)
+fact imports(web, api)
+fact imports(api, db)
+fact imports(db, models)
+rule depends_on(x,z) := (imports(x,z) + depends_on(x,y) * imports(y,z)).step()
+"""
+        result, status = run_tensor_logic_action(
+            "repo-impact",
+            {
+                "source": source,
+                "module": "models",
+                "metadata": {
+                    "symbol_to_module": {
+                        "api": "pkg.api",
+                        "db": "pkg.db",
+                        "models": "pkg.models",
+                        "web": "pkg.web",
+                    },
+                    "symbol_to_file": {
+                        "models": "/tmp/pkg/models.py",
+                    },
+                },
+            },
+        )
+        self.assertEqual(status, HTTPStatus.OK)
+        self.assertEqual(result["payload"]["module"], "models")
+        self.assertEqual(result["payload"]["direct_imports"], [])
+        self.assertEqual(result["payload"]["direct_imported_by"], ["db"])
+        self.assertEqual(result["payload"]["transitive_dependents"], ["api", "db", "web"])
+        self.assertEqual(result["payload"]["dependent_paths"]["web"], ["web", "api", "db", "models"])
+        self.assertEqual(result["payload"]["module_details"]["models"]["module"], "pkg.models")
+        self.assertEqual(result["payload"]["module_details"]["models"]["file"], "/tmp/pkg/models.py")
+        self.assertIn("transitive dependents (3)", result["stdout"])
+        self.assertIn("module: pkg.models", result["stdout"])
+
+    def test_repo_overview_action_ranks_hotspots_and_cycles(self):
+        source = """
+domain Module { api db models web a b }
+relation imports(Module, Module)
+relation depends_on(Module, Module)
+fact imports(web, api)
+fact imports(api, db)
+fact imports(db, models)
+fact imports(a, b)
+fact imports(b, a)
+rule depends_on(x,z) := (imports(x,z) + depends_on(x,y) * imports(y,z)).step()
+"""
+        result, status = run_tensor_logic_action(
+            "repo-overview",
+            {
+                "source": source,
+                "metadata": {
+                    "symbol_to_module": {"models": "pkg.models", "web": "pkg.web"},
+                    "symbol_to_file": {"models": "/tmp/pkg/models.py"},
+                },
+            },
+        )
+        self.assertEqual(status, HTTPStatus.OK)
+        self.assertEqual(result["payload"]["modules"], 6)
+        self.assertEqual(result["payload"]["imports"], 5)
+        self.assertEqual(result["payload"]["top_dependents"][0], {"module": "models", "count": 3})
+        self.assertIn({"module": "web", "count": 3}, result["payload"]["top_dependencies"])
+        self.assertIn("web", result["payload"]["entrypoints"])
+        self.assertIn("models", result["payload"]["leaves"])
+        self.assertIn(["a", "b"], result["payload"]["cycles"])
+        self.assertEqual(result["payload"]["module_details"]["models"]["module"], "pkg.models")
+        self.assertIn("cycles=1", result["stdout"])
+
+    def test_repo_brief_action_outputs_actionable_change_plan(self):
+        source = """
+domain Module { api db models web }
+relation imports(Module, Module)
+relation depends_on(Module, Module)
+fact imports(web, api)
+fact imports(api, db)
+fact imports(db, models)
+rule depends_on(x,z) := (imports(x,z) + depends_on(x,y) * imports(y,z)).step()
+"""
+        result, status = run_tensor_logic_action(
+            "repo-brief",
+            {
+                "source": source,
+                "module": "models",
+                "metadata": {
+                    "symbol_to_module": {
+                        "api": "pkg.api",
+                        "db": "pkg.db",
+                        "models": "pkg.models",
+                        "web": "pkg.web",
+                    },
+                    "symbol_to_file": {
+                        "api": "/tmp/pkg/api.py",
+                        "db": "/tmp/pkg/db.py",
+                        "models": "/tmp/pkg/models.py",
+                        "web": "/tmp/pkg/web.py",
+                    },
+                },
+            },
+        )
+        self.assertEqual(status, HTTPStatus.OK)
+        self.assertEqual(result["action"], "repo-brief")
+        self.assertEqual(result["payload"]["risk_level"], "medium")
+        self.assertEqual(result["payload"]["blast_radius"], 3)
+        self.assertEqual(result["payload"]["read_first"][0]["file"], "/tmp/pkg/models.py")
+        self.assertIn({"relation": "depends_on", "arg1": "web", "arg2": "models", "recursive": True}, result["payload"]["proof_checks"])
+        self.assertIn("Change brief: models (pkg.models)", result["stdout"])
+        self.assertIn("prove depends_on(web, models) recursive", result["stdout"])
+
+    def test_repo_compare_action_reports_dependency_drift(self):
+        before_source = """
+domain Module { api db models web }
+relation imports(Module, Module)
+relation depends_on(Module, Module)
+fact imports(web, api)
+fact imports(api, db)
+rule depends_on(x,z) := (imports(x,z) + depends_on(x,y) * imports(y,z)).step()
+"""
+        after_source = """
+domain Module { api db models web worker }
+relation imports(Module, Module)
+relation depends_on(Module, Module)
+fact imports(web, api)
+fact imports(api, models)
+fact imports(worker, api)
+rule depends_on(x,z) := (imports(x,z) + depends_on(x,y) * imports(y,z)).step()
+"""
+        result, status = run_tensor_logic_action(
+            "repo-compare",
+            {
+                "before_source": before_source,
+                "after_source": after_source,
+                "after_metadata": {
+                    "symbol_to_module": {
+                        "api": "pkg.api",
+                        "db": "pkg.db",
+                        "models": "pkg.models",
+                        "web": "pkg.web",
+                        "worker": "pkg.worker",
+                    },
+                    "symbol_to_file": {"worker": "/tmp/pkg/worker.py"},
+                },
+            },
+        )
+        self.assertEqual(status, HTTPStatus.OK)
+        self.assertEqual(result["action"], "repo-compare")
+        self.assertEqual(result["payload"]["added_modules"], ["worker"])
+        self.assertEqual(result["payload"]["removed_modules"], [])
+        self.assertIn(["api", "models"], result["payload"]["added_imports"])
+        self.assertIn(["worker", "api"], result["payload"]["added_imports"])
+        self.assertIn(["api", "db"], result["payload"]["removed_imports"])
+        self.assertIn({"module": "api", "before": 1, "after": 2, "delta": 1}, result["payload"]["blast_radius_deltas"])
+        self.assertIn(
+            {
+                "kind": "added dependency",
+                "action": "prove",
+                "relation": "depends_on",
+                "arg1": "worker",
+                "arg2": "api",
+                "recursive": True,
+                "expected": True,
+            },
+            result["payload"]["suggested_checks"],
+        )
+        self.assertEqual(result["payload"]["module_details"]["worker"]["file"], "/tmp/pkg/worker.py")
+        self.assertIn("Repo graph compare", result["stdout"])
+        self.assertIn("Added imports", result["stdout"])
 
     def test_why_not_json_parity_with_http_api(self):
         from tensor_logic.http_api import prove_source
@@ -78,3 +291,6 @@ class TestWebWorkbench(unittest.TestCase):
         wb_res, wb_status = run_tensor_logic_action("why-not", payload)
         self.assertEqual(wb_status, HTTPStatus.OK)
         self.assertIn("ancestor(alice, dave) = False", wb_res["stdout"])
+        self.assertNotIn("unknown(?, ?)", wb_res["stdout"])
+        self.assertEqual(wb_res["payload"]["answer"], False)
+        self.assertEqual(wb_res["payload"]["explanation"]["head"], ["ancestor", "alice", "dave"])

--- a/web_workbench/README.md
+++ b/web_workbench/README.md
@@ -25,8 +25,20 @@ clickable proof or why-not checks for changed dependencies.
 
 ## Run
 
+After installing the package locally, run the packaged console script:
+
+```bash
+python -m pip install -e .
+```
+
 ```bash
 tensor-logic-workbench --host 127.0.0.1 --port 8080
+```
+
+From a source checkout without the console script installed, run:
+
+```bash
+python web_workbench/server.py --host 127.0.0.1 --port 8080
 ```
 
 Then open <http://127.0.0.1:8080>.

--- a/web_workbench/README.md
+++ b/web_workbench/README.md
@@ -1,6 +1,27 @@
 # tensor_logic web workbench
 
-Minimal browser shell for editing `.tl` source and running local tensor_logic commands.
+Browser workbench for editing `.tl` source, running local tensor_logic commands,
+and inspecting proof trees.
+
+The repo graph loader turns a Python package into a Tensor Logic dependency
+program. Use **Load Imports** with a path such as `tensor_logic` or `.` to
+generate `Module`, `imports`, and recursive `depends_on` facts/rules, then run
+`Prove` or `Why Not` to inspect dependency paths.
+
+Use **Analyze Impact** on a module symbol to see direct imports, direct
+imported-by edges, transitive dependencies, transitive dependents, and example
+paths. Ingested repo graphs carry module and source-file metadata through to the
+impact JSON and UI tooltips. This is the practical "what might change if I
+touch this module?" view.
+
+Use **Repo Overview** to rank hotspots, dependency fanout, entrypoints, leaves,
+and import cycles across the loaded graph. Use **Change Brief** on a selected
+module to produce a deterministic handoff: read-first files, regression watch,
+proof paths, and suggested `depends_on(...)` checks.
+
+Use **Set Baseline** before editing or reloading a graph, then **Compare Graph**
+to get added/removed modules and imports, blast-radius deltas, cycle drift, and
+clickable proof or why-not checks for changed dependencies.
 
 ## Run
 

--- a/web_workbench/README.md
+++ b/web_workbench/README.md
@@ -26,7 +26,7 @@ clickable proof or why-not checks for changed dependencies.
 ## Run
 
 ```bash
-python web_workbench/server.py --host 127.0.0.1 --port 8080
+tensor-logic-workbench --host 127.0.0.1 --port 8080
 ```
 
 Then open <http://127.0.0.1:8080>.

--- a/web_workbench/__init__.py
+++ b/web_workbench/__init__.py
@@ -1,0 +1,1 @@
+"""Browser workbench package for tensor_logic."""

--- a/web_workbench/server.py
+++ b/web_workbench/server.py
@@ -2,15 +2,23 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
-import tempfile
+import time
 from http import HTTPStatus
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parent
+REPO_ROOT = ROOT.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tensor_logic.http_api import ApiError, prove_source, query_source, run_source
+from tensor_logic.execution import load_tl_source
+from tensor_logic.ingest import ingest_python, render_python_imports_tl
+from tensor_logic.repo_graph_view import imports_path
+
+
 STATIC_DIR = ROOT / "static"
 
 
@@ -42,6 +50,17 @@ class WorkbenchHandler(SimpleHTTPRequestHandler):
 
 
 def run_tensor_logic_action(action: str, payload: dict) -> tuple[dict, HTTPStatus]:
+    if action == "ingest-python":
+        return ingest_python_action(payload)
+    if action == "repo-impact":
+        return repo_impact_action(payload)
+    if action == "repo-overview":
+        return repo_overview_action(payload)
+    if action == "repo-brief":
+        return repo_brief_action(payload)
+    if action == "repo-compare":
+        return repo_compare_action(payload)
+
     source = str(payload.get("source", ""))
     if not source.strip():
         return {"error": "Missing source"}, HTTPStatus.BAD_REQUEST
@@ -50,38 +69,920 @@ def run_tensor_logic_action(action: str, payload: dict) -> tuple[dict, HTTPStatu
     arg2 = str(payload.get("arg2", "")).strip()
     recursive = bool(payload.get("recursive", False))
 
-    with tempfile.NamedTemporaryFile("w", suffix=".tl", delete=False, encoding="utf-8") as handle:
-        handle.write(source)
-        temp_path = Path(handle.name)
+    start = time.perf_counter()
     try:
-        cmd = [sys.executable, "-m", "tensor_logic"]
         if action == "run":
-            cmd += ["run", str(temp_path)]
+            result_payload = run_source(source)
+            stdout = "\n".join(result_payload.get("outputs", []))
+            command = "run source.tl"
         elif action in {"query", "prove", "why-not"}:
             if not (relation and arg1 and arg2):
                 return {"error": "relation, arg1, and arg2 are required"}, HTTPStatus.BAD_REQUEST
-            command = "prove" if action == "why-not" else action
-            cmd += [command, str(temp_path), relation, arg1, arg2]
-            if recursive:
-                cmd.append("--recursive")
+            args = [arg1, arg2]
+            if action == "query":
+                result_payload = query_source(source, relation, args, recursive=recursive)
+                stdout = render_query_text(result_payload)
+                command = f"query {relation}({arg1}, {arg2})"
+            else:
+                why_not = action == "why-not"
+                result_payload = prove_source(
+                    source,
+                    relation,
+                    args,
+                    recursive=recursive,
+                    why_not=why_not,
+                    format_type="json",
+                )
+                stdout = render_proof_text(result_payload, relation, args)
+                command = f"{'why-not' if why_not else 'prove'} {relation}({arg1}, {arg2})"
             if action == "why-not":
-                cmd.append("--why-not")
+                command += " --why-not"
+            if recursive:
+                command += " --recursive"
         else:
             return {"error": f"Unknown action: {action}"}, HTTPStatus.NOT_FOUND
-        proc = subprocess.run(cmd, capture_output=True, text=True, cwd=str(ROOT.parent), check=False)
-    finally:
-        temp_path.unlink(missing_ok=True)
+    except ApiError as exc:
+        return {"error": exc.message, "exit_code": 1, "stderr": exc.message}, HTTPStatus(exc.status_code)
+    except Exception as exc:
+        message = str(exc)
+        return {"error": message, "exit_code": 1, "stderr": message}, HTTPStatus.BAD_REQUEST
 
     return (
         {
             "action": action,
-            "command": " ".join(cmd),
-            "exit_code": proc.returncode,
-            "stdout": proc.stdout,
-            "stderr": proc.stderr,
+            "command": command,
+            "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+            "exit_code": 0,
+            "stdout": stdout,
+            "stderr": "",
+            "payload": result_payload,
         },
-        HTTPStatus.OK if proc.returncode == 0 else HTTPStatus.BAD_REQUEST,
+        HTTPStatus.OK,
     )
+
+
+def repo_impact_action(payload: dict) -> tuple[dict, HTTPStatus]:
+    source = str(payload.get("source", ""))
+    module = str(payload.get("module", "")).strip()
+    if not source.strip():
+        return {"error": "Missing source", "exit_code": 1}, HTTPStatus.BAD_REQUEST
+    if not module:
+        return {"error": "module is required", "exit_code": 1}, HTTPStatus.BAD_REQUEST
+
+    start = time.perf_counter()
+    try:
+        graph = repo_graph_from_source(source)
+        if module not in graph["modules"]:
+            return {"error": f"Unknown module: {module}", "exit_code": 1}, HTTPStatus.BAD_REQUEST
+        impact = build_repo_impact(graph, module)
+        impact = attach_module_metadata(impact, payload.get("metadata"))
+    except Exception as exc:
+        message = str(exc)
+        return {"error": message, "exit_code": 1, "stderr": message}, HTTPStatus.BAD_REQUEST
+
+    stdout = render_repo_impact_text(impact)
+    return (
+        {
+            "action": "repo-impact",
+            "command": f"repo-impact {module}",
+            "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+            "exit_code": 0,
+            "stdout": stdout,
+            "stderr": "",
+            "payload": impact,
+        },
+        HTTPStatus.OK,
+    )
+
+
+def repo_overview_action(payload: dict) -> tuple[dict, HTTPStatus]:
+    source = str(payload.get("source", ""))
+    if not source.strip():
+        return {"error": "Missing source", "exit_code": 1}, HTTPStatus.BAD_REQUEST
+
+    start = time.perf_counter()
+    try:
+        graph = repo_graph_from_source(source)
+        overview = build_repo_overview(graph)
+        overview = attach_overview_metadata(overview, payload.get("metadata"))
+    except Exception as exc:
+        message = str(exc)
+        return {"error": message, "exit_code": 1, "stderr": message}, HTTPStatus.BAD_REQUEST
+
+    stdout = render_repo_overview_text(overview)
+    return (
+        {
+            "action": "repo-overview",
+            "command": "repo-overview",
+            "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+            "exit_code": 0,
+            "stdout": stdout,
+            "stderr": "",
+            "payload": overview,
+        },
+        HTTPStatus.OK,
+    )
+
+
+def repo_brief_action(payload: dict) -> tuple[dict, HTTPStatus]:
+    source = str(payload.get("source", ""))
+    module = str(payload.get("module", "")).strip()
+    if not source.strip():
+        return {"error": "Missing source", "exit_code": 1}, HTTPStatus.BAD_REQUEST
+    if not module:
+        return {"error": "module is required", "exit_code": 1}, HTTPStatus.BAD_REQUEST
+
+    start = time.perf_counter()
+    try:
+        graph = repo_graph_from_source(source)
+        if module not in graph["modules"]:
+            return {"error": f"Unknown module: {module}", "exit_code": 1}, HTTPStatus.BAD_REQUEST
+        impact = build_repo_impact(graph, module)
+        impact = attach_module_metadata(impact, payload.get("metadata"))
+        brief = build_repo_change_brief(impact)
+    except Exception as exc:
+        message = str(exc)
+        return {"error": message, "exit_code": 1, "stderr": message}, HTTPStatus.BAD_REQUEST
+
+    return (
+        {
+            "action": "repo-brief",
+            "command": f"repo-brief {module}",
+            "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+            "exit_code": 0,
+            "stdout": brief["markdown"],
+            "stderr": "",
+            "payload": brief,
+        },
+        HTTPStatus.OK,
+    )
+
+
+def repo_compare_action(payload: dict) -> tuple[dict, HTTPStatus]:
+    before_source = str(payload.get("before_source", ""))
+    after_source = str(payload.get("after_source", ""))
+    if not before_source.strip():
+        return {"error": "before_source is required", "exit_code": 1}, HTTPStatus.BAD_REQUEST
+    if not after_source.strip():
+        return {"error": "after_source is required", "exit_code": 1}, HTTPStatus.BAD_REQUEST
+
+    start = time.perf_counter()
+    try:
+        before_graph = repo_graph_from_source(before_source)
+        after_graph = repo_graph_from_source(after_source)
+        compare = build_repo_compare(
+            before_graph,
+            after_graph,
+            payload.get("before_metadata"),
+            payload.get("after_metadata") or payload.get("metadata"),
+        )
+    except Exception as exc:
+        message = str(exc)
+        return {"error": message, "exit_code": 1, "stderr": message}, HTTPStatus.BAD_REQUEST
+
+    return (
+        {
+            "action": "repo-compare",
+            "command": "repo-compare baseline current",
+            "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+            "exit_code": 0,
+            "stdout": compare["markdown"],
+            "stderr": "",
+            "payload": compare,
+        },
+        HTTPStatus.OK,
+    )
+
+
+def repo_graph_from_source(source: str) -> dict:
+    loaded = load_tl_source(source, prefix="tensor_logic_workbench_repo_")
+    program = loaded.program
+    if "Module" not in program.domains:
+        raise ValueError("domain 'Module' is required")
+    if "imports" not in program.relations:
+        raise ValueError("relation 'imports' is required")
+    if "depends_on" not in program.relations:
+        raise ValueError("relation 'depends_on' is required")
+    modules = tuple(program.domains["Module"].symbols)
+    imports_rel = program.relations["imports"]
+    imports = tuple(
+        sorted(
+            (src, dst)
+            for src in modules
+            for dst in modules
+            if imports_rel.value(src, dst, semiring="boolean") > 0
+        )
+    )
+    return {"program": program, "modules": modules, "imports": imports}
+
+
+def build_repo_overview(graph: dict) -> dict:
+    modules = graph["modules"]
+    imports = graph["imports"]
+    program = graph["program"]
+    direct_imports = {module: 0 for module in modules}
+    direct_imported_by = {module: 0 for module in modules}
+    for src, dst in imports:
+        direct_imports[src] += 1
+        direct_imported_by[dst] += 1
+
+    transitive_dependencies: dict[str, int] = {}
+    transitive_dependents: dict[str, int] = {}
+    for module in modules:
+        transitive_dependencies[module] = sum(
+            1
+            for dst in modules
+            if dst != module and bool(program.query("depends_on", module, dst, recursive=True))
+        )
+        transitive_dependents[module] = sum(
+            1
+            for src in modules
+            if src != module and bool(program.query("depends_on", src, module, recursive=True))
+        )
+
+    cycles = strongly_connected_components(modules, imports)
+    payload = {
+        "modules": len(modules),
+        "imports": len(imports),
+        "top_dependents": rank_counts(transitive_dependents),
+        "top_dependencies": rank_counts(transitive_dependencies),
+        "direct_import_hubs": rank_counts(direct_imports),
+        "direct_imported_hubs": rank_counts(direct_imported_by),
+        "entrypoints": sorted(module for module in modules if direct_imported_by[module] == 0 and direct_imports[module] > 0),
+        "leaves": sorted(module for module in modules if direct_imports[module] == 0 and direct_imported_by[module] > 0),
+        "cycles": cycles,
+    }
+    return payload
+
+
+def rank_counts(counts: dict[str, int], limit: int = 12) -> list[dict]:
+    ranked = sorted(
+        ({"module": module, "count": count} for module, count in counts.items() if count > 0),
+        key=lambda item: (-item["count"], item["module"]),
+    )
+    return ranked[:limit]
+
+
+def strongly_connected_components(
+    modules: tuple[str, ...],
+    imports: tuple[tuple[str, str], ...],
+) -> list[list[str]]:
+    adjacency = {module: [] for module in modules}
+    for src, dst in imports:
+        adjacency[src].append(dst)
+    for targets in adjacency.values():
+        targets.sort()
+
+    index = 0
+    stack: list[str] = []
+    on_stack: set[str] = set()
+    indices: dict[str, int] = {}
+    lowlinks: dict[str, int] = {}
+    components: list[list[str]] = []
+
+    def visit(module: str) -> None:
+        nonlocal index
+        indices[module] = index
+        lowlinks[module] = index
+        index += 1
+        stack.append(module)
+        on_stack.add(module)
+
+        for target in adjacency[module]:
+            if target not in indices:
+                visit(target)
+                lowlinks[module] = min(lowlinks[module], lowlinks[target])
+            elif target in on_stack:
+                lowlinks[module] = min(lowlinks[module], indices[target])
+
+        if lowlinks[module] == indices[module]:
+            component: list[str] = []
+            while True:
+                target = stack.pop()
+                on_stack.remove(target)
+                component.append(target)
+                if target == module:
+                    break
+            if len(component) > 1:
+                components.append(sorted(component))
+
+    for module in modules:
+        if module not in indices:
+            visit(module)
+
+    return sorted(components, key=lambda component: (-len(component), component))
+
+
+def build_repo_impact(graph: dict, module: str) -> dict:
+    modules = graph["modules"]
+    imports = graph["imports"]
+    program = graph["program"]
+    direct_imports = sorted(dst for src, dst in imports if src == module)
+    direct_imported_by = sorted(src for src, dst in imports if dst == module)
+    dependencies = sorted(
+        dst
+        for dst in modules
+        if dst != module and bool(program.query("depends_on", module, dst, recursive=True))
+    )
+    dependents = sorted(
+        src
+        for src in modules
+        if src != module and bool(program.query("depends_on", src, module, recursive=True))
+    )
+    return {
+        "module": module,
+        "modules": len(modules),
+        "imports": len(imports),
+        "direct_imports": direct_imports,
+        "direct_imported_by": direct_imported_by,
+        "transitive_dependencies": dependencies,
+        "transitive_dependents": dependents,
+        "dependency_paths": path_map(modules, imports, module, dependencies),
+        "dependent_paths": path_map(modules, imports, None, dependents, target=module),
+    }
+
+
+def build_repo_change_brief(impact: dict) -> dict:
+    module = impact["module"]
+    details = impact.get("module_details", {})
+    module_detail = details.get(module, {"symbol": module, "module": module, "file": None})
+    blast_radius = len(impact["transitive_dependents"])
+    coupling = len(impact["transitive_dependencies"])
+    risk_level = change_risk_level(blast_radius, coupling)
+
+    read_symbols = unique_symbols(
+        [module]
+        + impact["direct_imports"]
+        + impact["direct_imported_by"]
+        + impact["transitive_dependencies"][:4]
+    )
+    regression_symbols = unique_symbols(impact["direct_imported_by"] + impact["transitive_dependents"])
+    path_examples = build_path_examples(impact)
+    proof_checks = build_proof_checks(impact)
+
+    brief = {
+        "module": module,
+        "module_details": details,
+        "risk_level": risk_level,
+        "blast_radius": blast_radius,
+        "coupling": coupling,
+        "summary": (
+            f"{display_module(module_detail)} has {blast_radius} transitive dependents "
+            f"and {coupling} transitive dependencies."
+        ),
+        "read_first": detail_rows(read_symbols, details),
+        "regression_targets": detail_rows(regression_symbols[:12], details),
+        "path_examples": path_examples,
+        "proof_checks": proof_checks,
+    }
+    brief["markdown"] = render_repo_brief_markdown(brief)
+    return brief
+
+
+def build_repo_compare(before_graph: dict, after_graph: dict, before_metadata, after_metadata) -> dict:
+    before_modules = set(before_graph["modules"])
+    after_modules = set(after_graph["modules"])
+    before_imports = set(before_graph["imports"])
+    after_imports = set(after_graph["imports"])
+
+    added_modules = sorted(after_modules - before_modules)
+    removed_modules = sorted(before_modules - after_modules)
+    added_imports = sorted(after_imports - before_imports)
+    removed_imports = sorted(before_imports - after_imports)
+    before_cycles = cycle_keys(strongly_connected_components(before_graph["modules"], before_graph["imports"]))
+    after_cycles = cycle_keys(strongly_connected_components(after_graph["modules"], after_graph["imports"]))
+    introduced_cycles = sorted(after_cycles - before_cycles)
+    resolved_cycles = sorted(before_cycles - after_cycles)
+    before_blast = transitive_dependent_counts(before_graph)
+    after_blast = transitive_dependent_counts(after_graph)
+    blast_radius_deltas = rank_blast_radius_deltas(before_blast, after_blast)
+
+    touched = touched_modules(added_modules, removed_modules, added_imports, removed_imports)
+    suggested_checks = build_compare_checks(after_graph, added_imports, removed_imports)
+    metadata = merge_metadata(before_metadata, after_metadata)
+    detail_symbols = set(touched)
+    for item in blast_radius_deltas:
+        detail_symbols.add(item["module"])
+    for cycle in set(introduced_cycles) | set(resolved_cycles):
+        detail_symbols.update(cycle)
+
+    compare = {
+        "before": {"modules": len(before_modules), "imports": len(before_imports), "cycles": len(before_cycles)},
+        "after": {"modules": len(after_modules), "imports": len(after_imports), "cycles": len(after_cycles)},
+        "risk_level": compare_risk_level(added_imports, removed_imports, introduced_cycles, blast_radius_deltas),
+        "added_modules": added_modules,
+        "removed_modules": removed_modules,
+        "added_imports": [list(edge) for edge in added_imports],
+        "removed_imports": [list(edge) for edge in removed_imports],
+        "introduced_cycles": [list(cycle) for cycle in introduced_cycles],
+        "resolved_cycles": [list(cycle) for cycle in resolved_cycles],
+        "blast_radius_deltas": blast_radius_deltas,
+        "touched_modules": touched,
+        "suggested_checks": suggested_checks,
+        "module_details": module_details(detail_symbols, metadata),
+    }
+    compare["summary"] = compare_summary(compare)
+    compare["markdown"] = render_repo_compare_markdown(compare)
+    return compare
+
+
+def cycle_keys(cycles: list[list[str]]) -> set[tuple[str, ...]]:
+    return {tuple(cycle) for cycle in cycles}
+
+
+def transitive_dependent_counts(graph: dict) -> dict[str, int]:
+    modules = graph["modules"]
+    program = graph["program"]
+    return {
+        module: sum(
+            1
+            for src in modules
+            if src != module and bool(program.query("depends_on", src, module, recursive=True))
+        )
+        for module in modules
+    }
+
+
+def rank_blast_radius_deltas(before: dict[str, int], after: dict[str, int], limit: int = 12) -> list[dict]:
+    rows = []
+    for module in sorted(set(before) | set(after)):
+        before_count = before.get(module, 0)
+        after_count = after.get(module, 0)
+        delta = after_count - before_count
+        if delta:
+            rows.append({"module": module, "before": before_count, "after": after_count, "delta": delta})
+    rows.sort(key=lambda item: (-abs(item["delta"]), item["module"]))
+    return rows[:limit]
+
+
+def touched_modules(
+    added_modules: list[str],
+    removed_modules: list[str],
+    added_imports: list[tuple[str, str]],
+    removed_imports: list[tuple[str, str]],
+) -> list[str]:
+    touched = set(added_modules) | set(removed_modules)
+    for src, dst in added_imports + removed_imports:
+        touched.add(src)
+        touched.add(dst)
+    return sorted(touched)
+
+
+def build_compare_checks(
+    after_graph: dict,
+    added_imports: list[tuple[str, str]],
+    removed_imports: list[tuple[str, str]],
+) -> list[dict]:
+    checks: list[dict] = []
+    for src, dst in added_imports:
+        checks.append(
+            {
+                "kind": "added dependency",
+                "action": "prove",
+                "relation": "depends_on",
+                "arg1": src,
+                "arg2": dst,
+                "recursive": True,
+                "expected": True,
+            }
+        )
+    for src, dst in removed_imports:
+        still_reachable = src in after_graph["modules"] and dst in after_graph["modules"] and bool(
+            after_graph["program"].query("depends_on", src, dst, recursive=True)
+        )
+        checks.append(
+            {
+                "kind": "removed direct import" if still_reachable else "removed dependency",
+                "action": "prove" if still_reachable else "why-not",
+                "relation": "depends_on",
+                "arg1": src,
+                "arg2": dst,
+                "recursive": True,
+                "expected": still_reachable,
+            }
+        )
+    return checks[:12]
+
+
+def merge_metadata(before_metadata, after_metadata) -> dict:
+    merged = {"symbol_to_module": {}, "symbol_to_file": {}}
+    for metadata in (before_metadata, after_metadata):
+        if not isinstance(metadata, dict):
+            continue
+        for key in ("symbol_to_module", "symbol_to_file"):
+            values = metadata.get(key)
+            if isinstance(values, dict):
+                merged[key].update(values)
+    return merged
+
+
+def compare_risk_level(
+    added_imports: list[tuple[str, str]],
+    removed_imports: list[tuple[str, str]],
+    introduced_cycles: set[tuple[str, ...]],
+    blast_radius_deltas: list[dict],
+) -> str:
+    max_delta = max((abs(item["delta"]) for item in blast_radius_deltas), default=0)
+    change_count = len(added_imports) + len(removed_imports)
+    if introduced_cycles or max_delta >= 8 or change_count >= 12:
+        return "high"
+    if max_delta >= 3 or change_count >= 4:
+        return "medium"
+    return "low"
+
+
+def compare_summary(payload: dict) -> str:
+    return (
+        f"{len(payload['added_imports'])} imports added, {len(payload['removed_imports'])} removed, "
+        f"{len(payload['added_modules'])} modules added, {len(payload['removed_modules'])} removed."
+    )
+
+
+def change_risk_level(blast_radius: int, coupling: int) -> str:
+    if blast_radius >= 8 or coupling >= 12:
+        return "high"
+    if blast_radius >= 3 or coupling >= 6:
+        return "medium"
+    return "low"
+
+
+def unique_symbols(symbols: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for symbol in symbols:
+        if symbol and symbol not in seen:
+            seen.add(symbol)
+            ordered.append(symbol)
+    return ordered
+
+
+def detail_rows(symbols: list[str], details: dict) -> list[dict]:
+    return [details.get(symbol, {"symbol": symbol, "module": symbol, "file": None}) for symbol in symbols]
+
+
+def build_path_examples(impact: dict) -> list[dict]:
+    examples: list[dict] = []
+    for module, path in sorted(impact.get("dependent_paths", {}).items()):
+        examples.append({"kind": "dependent", "module": module, "path": path})
+    for module, path in sorted(impact.get("dependency_paths", {}).items()):
+        examples.append({"kind": "dependency", "module": module, "path": path})
+    return examples[:12]
+
+
+def build_proof_checks(impact: dict) -> list[dict]:
+    module = impact["module"]
+    checks: list[dict] = []
+    for dependent in unique_symbols(impact["direct_imported_by"] + impact["transitive_dependents"]):
+        checks.append({"relation": "depends_on", "arg1": dependent, "arg2": module, "recursive": True})
+    for dependency in unique_symbols(impact["direct_imports"] + impact["transitive_dependencies"]):
+        checks.append({"relation": "depends_on", "arg1": module, "arg2": dependency, "recursive": True})
+    return checks[:10]
+
+
+def attach_module_metadata(payload: dict, metadata) -> dict:
+    if not isinstance(metadata, dict):
+        return payload
+
+    symbols = {payload["module"]}
+    for key in (
+        "direct_imports",
+        "direct_imported_by",
+        "transitive_dependencies",
+        "transitive_dependents",
+    ):
+        symbols.update(payload.get(key, []))
+    for paths in (payload.get("dependency_paths", {}), payload.get("dependent_paths", {})):
+        for symbol, path in paths.items():
+            symbols.add(symbol)
+            symbols.update(path)
+
+    payload = dict(payload)
+    payload["module_details"] = module_details(symbols, metadata)
+    return payload
+
+
+def attach_overview_metadata(payload: dict, metadata) -> dict:
+    if not isinstance(metadata, dict):
+        return payload
+    symbols: set[str] = set(payload.get("entrypoints", [])) | set(payload.get("leaves", []))
+    for key in ("top_dependents", "top_dependencies", "direct_import_hubs", "direct_imported_hubs"):
+        symbols.update(item["module"] for item in payload.get(key, []))
+    for cycle in payload.get("cycles", []):
+        symbols.update(cycle)
+    payload = dict(payload)
+    payload["module_details"] = module_details(symbols, metadata)
+    return payload
+
+
+def module_details(symbols: set[str], metadata) -> dict:
+    if not isinstance(metadata, dict):
+        return {}
+    symbol_to_module = metadata.get("symbol_to_module")
+    symbol_to_file = metadata.get("symbol_to_file")
+    if not isinstance(symbol_to_module, dict):
+        symbol_to_module = {}
+    if not isinstance(symbol_to_file, dict):
+        symbol_to_file = {}
+    return {
+        symbol: {
+            "symbol": symbol,
+            "module": symbol_to_module.get(symbol, symbol),
+            "file": symbol_to_file.get(symbol),
+        }
+        for symbol in sorted(symbols)
+    }
+
+
+def path_map(
+    modules: tuple[str, ...],
+    imports: tuple[tuple[str, str], ...],
+    src: str | None,
+    destinations: list[str],
+    *,
+    target: str | None = None,
+) -> dict[str, list[str]]:
+    paths: dict[str, list[str]] = {}
+    for item in destinations:
+        start = src or item
+        end = target or item
+        path = imports_path(modules, imports, start, end)
+        if path is not None:
+            paths[item] = path
+    return paths
+
+
+def render_repo_impact_text(payload: dict) -> str:
+    detail = payload.get("module_details", {}).get(payload["module"], {})
+    module_label = detail.get("module") or payload["module"]
+    lines = [
+        f"impact({payload['module']})",
+        f"module: {module_label}",
+        f"direct imports: {format_list(payload['direct_imports'])}",
+        f"direct imported by: {format_list(payload['direct_imported_by'])}",
+        f"transitive dependencies ({len(payload['transitive_dependencies'])}): {format_list(payload['transitive_dependencies'])}",
+        f"transitive dependents ({len(payload['transitive_dependents'])}): {format_list(payload['transitive_dependents'])}",
+    ]
+    if payload["dependent_paths"]:
+        lines.append("dependent paths:")
+        for module, path in payload["dependent_paths"].items():
+            lines.append(f"- {module}: {' -> '.join(path)}")
+    if payload["dependency_paths"]:
+        lines.append("dependency paths:")
+        for module, path in payload["dependency_paths"].items():
+            lines.append(f"- {module}: {' -> '.join(path)}")
+    return "\n".join(lines)
+
+
+def render_repo_overview_text(payload: dict) -> str:
+    lines = [
+        "repo overview",
+        f"modules={payload['modules']} imports={payload['imports']} cycles={len(payload['cycles'])}",
+        "top blast radius:",
+    ]
+    lines.extend(render_ranked_lines(payload["top_dependents"]))
+    lines.append("top dependency fanout:")
+    lines.extend(render_ranked_lines(payload["top_dependencies"]))
+    lines.append(f"entrypoints: {format_list(payload['entrypoints'][:12])}")
+    lines.append(f"leaves: {format_list(payload['leaves'][:12])}")
+    if payload["cycles"]:
+        lines.append("cycles:")
+        for cycle in payload["cycles"][:8]:
+            lines.append("- " + " -> ".join(cycle))
+    return "\n".join(lines)
+
+
+def render_repo_brief_markdown(payload: dict) -> str:
+    module_detail = payload["module_details"].get(payload["module"], {})
+    lines = [
+        f"# Change brief: {display_module(module_detail)}",
+        "",
+        f"Risk: {payload['risk_level']} ({payload['blast_radius']} transitive dependents, {payload['coupling']} transitive dependencies)",
+    ]
+    if module_detail.get("file"):
+        lines.append(f"File: {module_detail['file']}")
+    lines.extend(["", "Read first:"])
+    lines.extend(render_detail_lines(payload["read_first"]))
+    lines.extend(["", "Regression watch:"])
+    lines.extend(render_detail_lines(payload["regression_targets"]))
+    if payload["path_examples"]:
+        lines.extend(["", "Proof paths:"])
+        for item in payload["path_examples"]:
+            lines.append(f"- {item['kind']}: {' -> '.join(item['path'])}")
+    if payload["proof_checks"]:
+        lines.extend(["", "Suggested Tensor Logic checks:"])
+        for check in payload["proof_checks"]:
+            lines.append(f"- prove {check['relation']}({check['arg1']}, {check['arg2']}) recursive")
+    return "\n".join(lines)
+
+
+def render_repo_compare_markdown(payload: dict) -> str:
+    lines = [
+        "# Repo graph compare",
+        "",
+        f"Risk: {payload['risk_level']}",
+        f"Before: {payload['before']['modules']} modules / {payload['before']['imports']} imports / {payload['before']['cycles']} cycles",
+        f"After: {payload['after']['modules']} modules / {payload['after']['imports']} imports / {payload['after']['cycles']} cycles",
+        "",
+        payload["summary"],
+        "",
+        "Added imports:",
+    ]
+    lines.extend(render_edge_lines(payload["added_imports"], payload.get("module_details", {})))
+    lines.extend(["", "Removed imports:"])
+    lines.extend(render_edge_lines(payload["removed_imports"], payload.get("module_details", {})))
+    lines.extend(["", "Blast-radius changes:"])
+    if payload["blast_radius_deltas"]:
+        for item in payload["blast_radius_deltas"]:
+            detail = payload.get("module_details", {}).get(item["module"], {})
+            lines.append(
+                f"- {display_module(detail)}: {item['before']} -> {item['after']} ({item['delta']:+d})"
+            )
+    else:
+        lines.append("- (none)")
+    if payload["introduced_cycles"]:
+        lines.extend(["", "Introduced cycles:"])
+        for cycle in payload["introduced_cycles"]:
+            lines.append("- " + " -> ".join(cycle))
+    if payload["resolved_cycles"]:
+        lines.extend(["", "Resolved cycles:"])
+        for cycle in payload["resolved_cycles"]:
+            lines.append("- " + " -> ".join(cycle))
+    if payload["suggested_checks"]:
+        lines.extend(["", "Suggested Tensor Logic checks:"])
+        for check in payload["suggested_checks"]:
+            lines.append(
+                f"- {check['action']} {check['relation']}({check['arg1']}, {check['arg2']}) recursive"
+            )
+    return "\n".join(lines)
+
+
+def render_edge_lines(edges: list[list[str]], details: dict) -> list[str]:
+    if not edges:
+        return ["- (none)"]
+    lines = []
+    for src, dst in edges:
+        src_label = display_module(details.get(src, {"symbol": src, "module": src}))
+        dst_label = display_module(details.get(dst, {"symbol": dst, "module": dst}))
+        lines.append(f"- {src_label} -> {dst_label}")
+    return lines
+
+
+def render_detail_lines(rows: list[dict]) -> list[str]:
+    if not rows:
+        return ["- (none)"]
+    lines = []
+    for row in rows:
+        text = display_module(row)
+        if row.get("file"):
+            text += f" - {row['file']}"
+        lines.append(f"- {text}")
+    return lines
+
+
+def display_module(detail: dict) -> str:
+    symbol = detail.get("symbol")
+    module = detail.get("module") or symbol
+    if symbol and module and symbol != module:
+        return f"{symbol} ({module})"
+    return module or symbol or "unknown"
+
+
+def render_ranked_lines(items: list[dict]) -> list[str]:
+    if not items:
+        return ["- (none)"]
+    return [f"- {item['module']}: {item['count']}" for item in items[:8]]
+
+
+def format_list(items: list[str]) -> str:
+    return ", ".join(items) if items else "(none)"
+
+
+def ingest_python_action(payload: dict) -> tuple[dict, HTTPStatus]:
+    path = str(payload.get("path") or "tensor_logic").strip()
+    target = resolve_repo_path(path)
+    if not target.exists():
+        return {"error": f"Path does not exist: {path}", "exit_code": 1}, HTTPStatus.BAD_REQUEST
+
+    start = time.perf_counter()
+    try:
+        graph = ingest_python(target)
+        source = render_python_imports_tl(graph)
+    except Exception as exc:
+        message = str(exc)
+        return {"error": message, "exit_code": 1, "stderr": message}, HTTPStatus.BAD_REQUEST
+
+    symbol_edges = tuple((graph.symbols[src], graph.symbols[dst]) for src, dst in graph.edges)
+    symbols = tuple(graph.symbols[module] for module in graph.modules)
+    symbol_to_module = {symbol: module for module, symbol in graph.symbols.items()}
+    symbol_to_file = {
+        graph.symbols[module]: graph.files[module]
+        for module in graph.modules
+        if module in graph.files
+    }
+    suggested_query = suggested_dependency_query(symbols, symbol_edges)
+    payload_out = {
+        "path": str(target),
+        "source": source,
+        "modules": list(symbols),
+        "imports": [list(edge) for edge in symbol_edges],
+        "module_names": list(graph.modules),
+        "symbols": graph.symbols,
+        "symbol_to_module": symbol_to_module,
+        "symbol_to_file": symbol_to_file,
+        "suggested_query": suggested_query,
+    }
+    stdout = (
+        f"Loaded Python import graph from {target}\n"
+        f"modules = {len(symbols)}\n"
+        f"imports = {len(symbol_edges)}"
+    )
+    if suggested_query is not None:
+        stdout += (
+            "\n"
+            f"suggested query = depends_on({suggested_query['arg1']}, {suggested_query['arg2']})\n"
+            f"path = {' -> '.join(suggested_query['path'])}"
+        )
+    return (
+        {
+            "action": "ingest-python",
+            "command": f"ingest-python {path}",
+            "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+            "exit_code": 0,
+            "stdout": stdout,
+            "stderr": "",
+            "payload": payload_out,
+        },
+        HTTPStatus.OK,
+    )
+
+
+def resolve_repo_path(path: str) -> Path:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = ROOT.parent / candidate
+    return candidate.resolve()
+
+
+def suggested_dependency_query(
+    modules: tuple[str, ...],
+    imports: tuple[tuple[str, str], ...],
+) -> dict | None:
+    best_path: list[str] | None = None
+    for src in modules:
+        for dst in modules:
+            if src == dst:
+                continue
+            path = imports_path(modules, imports, src, dst)
+            if path is None:
+                continue
+            if best_path is None or len(path) > len(best_path):
+                best_path = path
+    if best_path is None:
+        return None
+    return {
+        "relation": "depends_on",
+        "arg1": best_path[0],
+        "arg2": best_path[-1],
+        "recursive": True,
+        "path": best_path,
+    }
+
+
+def render_query_text(payload: dict) -> str:
+    relation = payload["relation"]
+    arg0, arg1 = payload["args"]
+    return f"{relation}({arg0}, {arg1}) = {payload['answer']}\nvalue = {payload['value']:.3f}"
+
+
+def render_proof_text(payload: dict, relation: str, args: list[str]) -> str:
+    proof = payload.get("proof")
+    if isinstance(proof, dict):
+        return render_proof_node(proof)
+    explanation = payload.get("explanation")
+    if isinstance(explanation, dict):
+        return f"{relation}({', '.join(args)}) = False\n{render_proof_node(explanation)}"
+    if proof is not None:
+        return str(proof)
+    return f"{relation}({', '.join(args)}) = {payload.get('answer', False)}"
+
+
+def render_proof_node(node: dict, depth: int = 0) -> str:
+    if isinstance(node.get("proof"), dict):
+        node = node["proof"]
+    if isinstance(node.get("explanation"), dict):
+        node = node["explanation"]
+    indent = "  " * depth
+    head = node.get("head", ["unknown", "?", "?"])
+    label = f"{head[0]}({head[1]}, {head[2]})"
+    suffix = ""
+    if "reason" in node:
+        suffix = f"  [{node['reason']}]"
+    elif source := node.get("source"):
+        suffix = f"  [{source['file']}:{source['lineno']}]"
+    lines = [f"{indent}{label}{suffix}"]
+    for child in node.get("body", []):
+        lines.append(render_proof_node(child, depth + 1))
+    return "\n".join(lines)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/web_workbench/static/app.js
+++ b/web_workbench/static/app.js
@@ -1,22 +1,511 @@
 const sourceEl = document.getElementById("source");
 const resultEl = document.getElementById("result");
+const jsonEl = document.getElementById("json-view");
+const proofEl = document.getElementById("proof-view");
 const relationEl = document.getElementById("relation");
 const arg1El = document.getElementById("arg1");
 const arg2El = document.getElementById("arg2");
 const recursiveEl = document.getElementById("recursive");
+const presetEl = document.getElementById("preset");
+const relationOptionsEl = document.getElementById("relation-options");
+const argumentOptionsEl = document.getElementById("argument-options");
+const programIndexEl = document.getElementById("program-index");
+const programSummaryEl = document.getElementById("program-summary");
+const lineCountEl = document.getElementById("line-count");
+const historyEl = document.getElementById("history");
+const answerStripEl = document.getElementById("answer-strip");
+const answerTitleEl = document.getElementById("answer-title");
+const durationEl = document.getElementById("duration");
+const exitCodeEl = document.getElementById("exit-code");
+const activePresetEl = document.getElementById("active-preset");
+const resetSourceEl = document.getElementById("reset-source");
+const clearHistoryEl = document.getElementById("clear-history");
+const ingestPathEl = document.getElementById("ingest-path");
+const loadRepoEl = document.getElementById("load-repo");
+const ingestSummaryEl = document.getElementById("ingest-summary");
+const impactModuleEl = document.getElementById("impact-module");
+const analyzeImpactEl = document.getElementById("analyze-impact");
+const impactSummaryEl = document.getElementById("impact-summary");
+const changeBriefEl = document.getElementById("change-brief");
+const briefSummaryEl = document.getElementById("brief-summary");
+const analyzeOverviewEl = document.getElementById("analyze-overview");
+const overviewSummaryEl = document.getElementById("overview-summary");
+const setBaselineEl = document.getElementById("set-baseline");
+const compareGraphEl = document.getElementById("compare-graph");
+const compareSummaryEl = document.getElementById("compare-summary");
 
-sourceEl.value = `domain Person { alice bob cara }
+const STORAGE_KEY = "tensor_logic_workbench_state";
+const HISTORY_LIMIT = 12;
+
+const EXAMPLES = [
+  {
+    id: "kinship",
+    name: "Kinship Closure",
+    relation: "ancestor",
+    arg1: "alice",
+    arg2: "cara",
+    recursive: true,
+    source: `domain Person { alice bob cara dave }
 
 relation parent(Person, Person)
 relation ancestor(Person, Person)
 
 fact parent(alice, bob)
 fact parent(bob, cara)
+fact parent(cara, dave)
 
 rule ancestor(x,z) := (parent(x,z) + ancestor(x,y) * parent(y,z)).step()
 
-query ancestor(alice, cara) recursive
-prove ancestor(alice, cara) recursive`;
+query ancestor(alice, dave) recursive
+prove ancestor(alice, dave) recursive`,
+  },
+  {
+    id: "permissions",
+    name: "Access Control",
+    relation: "can_access",
+    arg1: "alice",
+    arg2: "customer_record",
+    recursive: false,
+    source: `domain User { alice bob }
+domain Role { admin viewer }
+domain Resource { invoice dashboard customer_record }
+
+relation has_role(User, Role)
+relation role_can_access(Role, Resource)
+relation can_access(User, Resource)
+
+fact has_role(alice, admin)
+fact has_role(bob, viewer)
+
+fact role_can_access(admin, invoice)
+fact role_can_access(admin, customer_record)
+fact role_can_access(viewer, dashboard)
+
+rule can_access(u,r) := (has_role(u,role) * role_can_access(role,r)).step()
+
+query can_access(alice, customer_record)
+prove can_access(alice, customer_record)`,
+  },
+  {
+    id: "planning",
+    name: "Launch Plan",
+    relation: "must_finish_before",
+    arg1: "design",
+    arg2: "launch",
+    recursive: true,
+    source: `domain Task {
+  design
+  backend
+  frontend
+  tests
+  launch
+}
+
+relation blocks(Task, Task)
+relation must_finish_before(Task, Task)
+
+fact blocks(design, backend)
+fact blocks(backend, frontend)
+fact blocks(frontend, tests)
+fact blocks(tests, launch)
+
+rule must_finish_before(x,z) := (blocks(x,z) + must_finish_before(x,y) * blocks(y,z)).step()
+
+query must_finish_before(design, launch) recursive
+prove must_finish_before(design, launch) recursive`,
+  },
+  {
+    id: "repo",
+    name: "Repo Dependencies",
+    relation: "depends_on",
+    arg1: "worker",
+    arg2: "models",
+    recursive: true,
+    source: `domain Module {
+  api
+  db
+  models
+  worker
+  auth
+}
+
+relation imports(Module, Module)
+relation depends_on(Module, Module)
+
+fact imports(worker, api)
+fact imports(api, db)
+fact imports(db, models)
+fact imports(api, auth)
+
+rule depends_on(x,z) := (imports(x,z) + depends_on(x,y) * imports(y,z)).step()
+
+query depends_on(worker, models) recursive
+prove depends_on(worker, models) recursive`,
+  },
+  {
+    id: "memory",
+    name: "Follow Ups",
+    relation: "should_follow_up",
+    arg1: "ryan",
+    arg2: "tensor_demo",
+    recursive: false,
+    source: `domain Person { jwalin ryan steven }
+domain Topic { tensor_logic robotics local_ai openhuman }
+domain Project { openhuman tensor_demo jarvis }
+
+relation mentioned(Person, Topic)
+relation project_about(Project, Topic)
+relation should_follow_up(Person, Project)
+
+fact mentioned(ryan, tensor_logic)
+fact mentioned(ryan, robotics)
+fact mentioned(steven, local_ai)
+
+fact project_about(tensor_demo, tensor_logic)
+fact project_about(openhuman, local_ai)
+fact project_about(jarvis, robotics)
+
+rule should_follow_up(p,proj) := (mentioned(p,t) * project_about(proj,t)).step()
+
+query should_follow_up(ryan, tensor_demo)
+prove should_follow_up(ryan, tensor_demo)`,
+  },
+];
+
+let history = [];
+let saveTimer = 0;
+let repoMetadata = null;
+let repoBaseline = null;
+
+init();
+
+function init() {
+  renderPresets();
+  const saved = loadState();
+  if (saved?.source) {
+    presetEl.value = saved.presetId || EXAMPLES[0].id;
+    sourceEl.value = saved.source;
+    relationEl.value = saved.relation || EXAMPLES[0].relation;
+    arg1El.value = saved.arg1 || EXAMPLES[0].arg1;
+    arg2El.value = saved.arg2 || EXAMPLES[0].arg2;
+    recursiveEl.checked = saved.recursive ?? EXAMPLES[0].recursive;
+    repoMetadata = saved.repoMetadata || null;
+    repoBaseline = saved.repoBaseline || null;
+  } else {
+    applyPreset(EXAMPLES[0].id, false);
+  }
+
+  updateActivePreset();
+  analyzeSource();
+  renderHistory();
+  renderIdle();
+  updateBaselineSummary();
+  bindEvents();
+}
+
+function bindEvents() {
+  document.querySelectorAll("[data-action]").forEach((button) => {
+    button.addEventListener("click", () => invoke(button.dataset.action));
+  });
+
+  document.querySelectorAll("[data-tab]").forEach((button) => {
+    button.addEventListener("click", () => setTab(button.dataset.tab));
+  });
+
+  presetEl.addEventListener("change", () => applyPreset(presetEl.value));
+  resetSourceEl.addEventListener("click", () => applyPreset(presetEl.value));
+  clearHistoryEl.addEventListener("click", () => {
+    history = [];
+    renderHistory();
+  });
+  loadRepoEl.addEventListener("click", loadRepoGraph);
+  analyzeImpactEl.addEventListener("click", analyzeImpact);
+  changeBriefEl.addEventListener("click", buildChangeBrief);
+  analyzeOverviewEl.addEventListener("click", analyzeOverview);
+  setBaselineEl.addEventListener("click", setRepoBaseline);
+  compareGraphEl.addEventListener("click", compareRepoGraph);
+
+  sourceEl.addEventListener("input", () => {
+    repoMetadata = null;
+    analyzeSource();
+    queueSave();
+  });
+
+  [relationEl, arg1El, arg2El, recursiveEl].forEach((el) => {
+    el.addEventListener("input", queueSave);
+    el.addEventListener("change", queueSave);
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      event.preventDefault();
+      invoke(event.shiftKey ? "prove" : "run");
+    }
+  });
+}
+
+function renderPresets() {
+  presetEl.replaceChildren();
+  EXAMPLES.forEach((example) => {
+    const option = document.createElement("option");
+    option.value = example.id;
+    option.textContent = example.name;
+    presetEl.append(option);
+  });
+}
+
+function applyPreset(id, shouldSave = true) {
+  const example = EXAMPLES.find((item) => item.id === id) || EXAMPLES[0];
+  repoMetadata = null;
+  presetEl.value = example.id;
+  sourceEl.value = example.source;
+  relationEl.value = example.relation;
+  arg1El.value = example.arg1;
+  arg2El.value = example.arg2;
+  recursiveEl.checked = example.recursive;
+  updateActivePreset();
+  analyzeSource();
+  if (shouldSave) {
+    saveState();
+  }
+}
+
+async function loadRepoGraph() {
+  loadRepoEl.disabled = true;
+  loadRepoEl.textContent = "Loading...";
+  ingestSummaryEl.textContent = "Parsing Python imports...";
+  const started = performance.now();
+
+  try {
+    const res = await fetch("/api/ingest-python", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: ingestPathEl.value }),
+    });
+    const data = await res.json();
+    data.client_duration_ms = Math.round(performance.now() - started);
+
+    if (res.ok && data.payload?.source) {
+      const query = data.payload.suggested_query;
+      sourceEl.value = data.payload.source;
+      relationEl.value = query?.relation || "depends_on";
+      arg1El.value = query?.arg1 || data.payload.imports?.[0]?.[0] || "";
+      arg2El.value = query?.arg2 || data.payload.imports?.[0]?.[1] || "";
+      impactModuleEl.value = query?.arg2 || arg2El.value;
+      repoMetadata = repoMetadataFromPayload(data.payload);
+      recursiveEl.checked = query?.recursive ?? true;
+      activePresetEl.textContent = "Repo Import Graph";
+      ingestSummaryEl.textContent = `${data.payload.modules.length} modules / ${data.payload.imports.length} imports`;
+      analyzeSource();
+      saveState();
+    } else {
+      ingestSummaryEl.textContent = data.error || "Import graph failed";
+    }
+
+    renderResult(data, res.ok);
+    pushHistory(data, res.ok);
+    if (res.ok && data.payload?.suggested_query) {
+      await invoke("prove");
+      await analyzeImpact();
+      await analyzeOverview();
+    }
+  } catch (error) {
+    const data = {
+      action: "ingest-python",
+      error: String(error),
+      exit_code: 1,
+      stderr: String(error),
+      client_duration_ms: Math.round(performance.now() - started),
+    };
+    ingestSummaryEl.textContent = "Import graph failed";
+    renderResult(data, false);
+    pushHistory(data, false);
+  } finally {
+    loadRepoEl.disabled = false;
+    loadRepoEl.textContent = "Load Imports";
+  }
+}
+
+async function analyzeOverview() {
+  analyzeOverviewEl.disabled = true;
+  analyzeOverviewEl.textContent = "Ranking...";
+  overviewSummaryEl.textContent = "Computing repo overview...";
+  const started = performance.now();
+
+  try {
+    const res = await fetch("/api/repo-overview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source: sourceEl.value, metadata: repoMetadata }),
+    });
+    const data = await res.json();
+    data.client_duration_ms = Math.round(performance.now() - started);
+    if (res.ok && data.payload) {
+      overviewSummaryEl.textContent = `${data.payload.modules} modules / ${data.payload.cycles.length} cycles`;
+    } else {
+      overviewSummaryEl.textContent = data.error || "Overview failed";
+    }
+    renderResult(data, res.ok);
+    pushHistory(data, res.ok);
+  } catch (error) {
+    const data = {
+      action: "repo-overview",
+      error: String(error),
+      exit_code: 1,
+      stderr: String(error),
+      client_duration_ms: Math.round(performance.now() - started),
+    };
+    overviewSummaryEl.textContent = "Overview failed";
+    renderResult(data, false);
+    pushHistory(data, false);
+  } finally {
+    analyzeOverviewEl.disabled = false;
+    analyzeOverviewEl.textContent = "Repo Overview";
+  }
+}
+
+async function analyzeImpact() {
+  analyzeImpactEl.disabled = true;
+  analyzeImpactEl.textContent = "Analyzing...";
+  impactSummaryEl.textContent = "Computing blast radius...";
+  const started = performance.now();
+
+  try {
+    const res = await fetch("/api/repo-impact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source: sourceEl.value, module: impactModuleEl.value, metadata: repoMetadata }),
+    });
+    const data = await res.json();
+    data.client_duration_ms = Math.round(performance.now() - started);
+    if (res.ok && data.payload) {
+      impactSummaryEl.textContent = `${data.payload.transitive_dependents.length} dependents / ${data.payload.transitive_dependencies.length} dependencies`;
+    } else {
+      impactSummaryEl.textContent = data.error || "Impact analysis failed";
+    }
+    renderResult(data, res.ok);
+    pushHistory(data, res.ok);
+  } catch (error) {
+    const data = {
+      action: "repo-impact",
+      error: String(error),
+      exit_code: 1,
+      stderr: String(error),
+      client_duration_ms: Math.round(performance.now() - started),
+    };
+    impactSummaryEl.textContent = "Impact analysis failed";
+    renderResult(data, false);
+    pushHistory(data, false);
+  } finally {
+    analyzeImpactEl.disabled = false;
+    analyzeImpactEl.textContent = "Analyze Impact";
+  }
+}
+
+async function buildChangeBrief() {
+  changeBriefEl.disabled = true;
+  changeBriefEl.textContent = "Building...";
+  briefSummaryEl.textContent = "Building change brief...";
+  const started = performance.now();
+
+  try {
+    const res = await fetch("/api/repo-brief", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source: sourceEl.value, module: impactModuleEl.value, metadata: repoMetadata }),
+    });
+    const data = await res.json();
+    data.client_duration_ms = Math.round(performance.now() - started);
+    if (res.ok && data.payload) {
+      briefSummaryEl.textContent = `${data.payload.risk_level} risk / ${data.payload.blast_radius} dependents`;
+    } else {
+      briefSummaryEl.textContent = data.error || "Brief failed";
+    }
+    renderResult(data, res.ok);
+    pushHistory(data, res.ok);
+  } catch (error) {
+    const data = {
+      action: "repo-brief",
+      error: String(error),
+      exit_code: 1,
+      stderr: String(error),
+      client_duration_ms: Math.round(performance.now() - started),
+    };
+    briefSummaryEl.textContent = "Brief failed";
+    renderResult(data, false);
+    pushHistory(data, false);
+  } finally {
+    changeBriefEl.disabled = false;
+    changeBriefEl.textContent = "Change Brief";
+  }
+}
+
+function setRepoBaseline() {
+  repoBaseline = {
+    source: sourceEl.value,
+    metadata: repoMetadata,
+    summary: programSummaryEl.textContent,
+    at: new Date().toISOString(),
+  };
+  updateBaselineSummary();
+  saveState();
+}
+
+async function compareRepoGraph() {
+  if (!repoBaseline?.source) {
+    setRepoBaseline();
+    compareSummaryEl.textContent = "Baseline captured. Edit or reload, then compare.";
+    return;
+  }
+
+  compareGraphEl.disabled = true;
+  compareGraphEl.textContent = "Comparing...";
+  compareSummaryEl.textContent = "Comparing baseline to current graph...";
+  const started = performance.now();
+
+  try {
+    const res = await fetch("/api/repo-compare", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        before_source: repoBaseline.source,
+        after_source: sourceEl.value,
+        before_metadata: repoBaseline.metadata,
+        after_metadata: repoMetadata,
+      }),
+    });
+    const data = await res.json();
+    data.client_duration_ms = Math.round(performance.now() - started);
+    if (res.ok && data.payload) {
+      compareSummaryEl.textContent = `${data.payload.risk_level} risk / ${data.payload.summary}`;
+    } else {
+      compareSummaryEl.textContent = data.error || "Compare failed";
+    }
+    renderResult(data, res.ok);
+    pushHistory(data, res.ok);
+  } catch (error) {
+    const data = {
+      action: "repo-compare",
+      error: String(error),
+      exit_code: 1,
+      stderr: String(error),
+      client_duration_ms: Math.round(performance.now() - started),
+    };
+    compareSummaryEl.textContent = "Compare failed";
+    renderResult(data, false);
+    pushHistory(data, false);
+  } finally {
+    compareGraphEl.disabled = false;
+    compareGraphEl.textContent = "Compare Graph";
+  }
+}
+
+function repoMetadataFromPayload(payloadData) {
+  return {
+    symbol_to_module: payloadData.symbol_to_module || {},
+    symbol_to_file: payloadData.symbol_to_file || {},
+  };
+}
 
 function payload() {
   return {
@@ -29,7 +518,10 @@ function payload() {
 }
 
 async function invoke(action) {
-  resultEl.textContent = `$ ${action}...`;
+  const button = document.querySelector(`[data-action="${action}"]`);
+  setRunning(action, button);
+  const started = performance.now();
+
   try {
     const res = await fetch(`/api/${action}`, {
       method: "POST",
@@ -37,16 +529,889 @@ async function invoke(action) {
       body: JSON.stringify(payload()),
     });
     const data = await res.json();
-    if (!res.ok) {
-      resultEl.textContent = `HTTP ${res.status}\n${JSON.stringify(data, null, 2)}`;
-      return;
-    }
-    resultEl.textContent = `${data.stdout || ""}${data.stderr ? `\n[stderr]\n${data.stderr}` : ""}`.trim();
+    data.client_duration_ms = Math.round(performance.now() - started);
+    renderResult(data, res.ok);
+    pushHistory(data, res.ok);
   } catch (error) {
-    resultEl.textContent = String(error);
+    const data = {
+      action,
+      error: String(error),
+      exit_code: 1,
+      stderr: String(error),
+      client_duration_ms: Math.round(performance.now() - started),
+    };
+    renderResult(data, false);
+    pushHistory(data, false);
+  } finally {
+    setRunning(null, button);
   }
 }
 
-document.querySelectorAll("button[data-action]").forEach((button) => {
-  button.addEventListener("click", () => invoke(button.dataset.action));
-});
+function setRunning(action, button) {
+  document.querySelectorAll("[data-action]").forEach((el) => {
+    el.disabled = Boolean(action);
+    el.classList.toggle("loading", Boolean(action && el === button));
+  });
+  if (!action) {
+    return;
+  }
+  answerStripEl.className = "answer-strip running";
+  answerTitleEl.textContent = `${labelForAction(action)} running`;
+  durationEl.textContent = "...";
+  exitCodeEl.textContent = "running";
+  resultEl.textContent = `$ ${action} ${targetText()}`;
+  proofEl.replaceChildren(emptyState("Waiting for result"));
+  jsonEl.textContent = "";
+}
+
+function renderResult(data, ok) {
+  const payloadData = data.payload;
+  const answer = payloadData?.answer;
+  const hasAnswer = typeof answer === "boolean";
+  const action = data.action || "action";
+  const duration = data.duration_ms ?? data.client_duration_ms ?? 0;
+  const state = ok ? (hasAnswer && !answer ? "false" : "true") : "error";
+
+  answerStripEl.className = `answer-strip ${state}`;
+  answerTitleEl.textContent = resultTitle(action, answer, ok);
+  durationEl.textContent = `${duration} ms`;
+  exitCodeEl.textContent = ok ? "exit 0" : `exit ${data.exit_code ?? 1}`;
+
+  resultEl.textContent = data.stdout || data.stderr || data.error || "(no output)";
+  jsonEl.textContent = JSON.stringify(payloadData || data, null, 2);
+  renderProof(payloadData, data.stdout);
+  setTab(
+    action === "prove" ||
+      action === "why-not" ||
+      action === "repo-impact" ||
+      action === "repo-overview" ||
+      action === "repo-brief" ||
+      action === "repo-compare"
+      ? "proof"
+      : "output",
+  );
+}
+
+function renderIdle() {
+  answerStripEl.className = "answer-strip";
+  answerTitleEl.textContent = "Ready";
+  durationEl.textContent = "0 ms";
+  exitCodeEl.textContent = "idle";
+  resultEl.textContent = "Run the current program or inspect a query.";
+  jsonEl.textContent = "{}";
+  proofEl.replaceChildren(emptyState("No proof yet"));
+}
+
+function renderProof(payloadData, fallbackText = "") {
+  proofEl.replaceChildren();
+
+  if (!payloadData) {
+    proofEl.append(emptyState("No structured payload"));
+    return;
+  }
+
+  if (payloadData.proof && typeof payloadData.proof === "object") {
+    proofEl.append(renderProofNode(payloadData.proof, false));
+    return;
+  }
+
+  if (payloadData.explanation) {
+    proofEl.append(renderProofNode(payloadData.explanation, true));
+    return;
+  }
+
+  if (Array.isArray(payloadData.outputs)) {
+    const list = document.createElement("div");
+    list.className = "output-stack";
+    payloadData.outputs.forEach((text, index) => {
+      const item = document.createElement("pre");
+      item.textContent = text || `(command ${index + 1} produced no output)`;
+      list.append(item);
+    });
+    proofEl.append(list);
+    return;
+  }
+
+  if (typeof payloadData.proof === "string") {
+    const pre = document.createElement("pre");
+    pre.textContent = payloadData.proof || fallbackText;
+    proofEl.append(pre);
+    return;
+  }
+
+  if (payloadData.source && Array.isArray(payloadData.modules)) {
+    const summary = document.createElement("div");
+    summary.className = "query-summary";
+    summary.textContent = `${payloadData.modules.length} modules / ${payloadData.imports.length} imports`;
+    proofEl.append(summary);
+    return;
+  }
+
+  if (Array.isArray(payloadData.transitive_dependents)) {
+    proofEl.append(renderImpactView(payloadData));
+    return;
+  }
+
+  if (Array.isArray(payloadData.top_dependents)) {
+    proofEl.append(renderOverviewView(payloadData));
+    return;
+  }
+
+  if (Array.isArray(payloadData.read_first) && Array.isArray(payloadData.proof_checks)) {
+    proofEl.append(renderBriefView(payloadData));
+    return;
+  }
+
+  if (Array.isArray(payloadData.added_imports) && Array.isArray(payloadData.removed_imports)) {
+    proofEl.append(renderCompareView(payloadData));
+    return;
+  }
+
+  if ("answer" in payloadData) {
+    const summary = document.createElement("div");
+    summary.className = "query-summary";
+    summary.textContent = `${targetText()} = ${payloadData.answer}`;
+    proofEl.append(summary);
+    return;
+  }
+
+  proofEl.append(emptyState("No proof tree for this action"));
+}
+
+function renderProofNode(node, negative) {
+  node = normalizeProofNode(node);
+  const wrap = document.createElement("div");
+  wrap.className = `proof-node ${negative ? "negative" : "positive"}`;
+
+  const header = document.createElement("div");
+  header.className = "proof-head";
+  const title = document.createElement("strong");
+  title.textContent = formatHead(node.head);
+  header.append(title);
+
+  const meta = document.createElement("span");
+  meta.textContent = negative ? node.reason || "not derivable" : confidenceText(node.confidence);
+  header.append(meta);
+  wrap.append(header);
+
+  if (node.source) {
+    const source = document.createElement("div");
+    source.className = "proof-source";
+    source.textContent = `${node.source.file}:${node.source.lineno}`;
+    wrap.append(source);
+  }
+
+  if (Array.isArray(node.body) && node.body.length) {
+    const children = document.createElement("div");
+    children.className = "proof-children";
+    node.body.forEach((child) => children.append(renderProofNode(child, negative)));
+    wrap.append(children);
+  }
+
+  return wrap;
+}
+
+function renderImpactView(payloadData) {
+  const wrap = document.createElement("div");
+  wrap.className = "impact-view";
+
+  const headline = document.createElement("div");
+  headline.className = "query-summary";
+  headline.textContent = `${formatModule(payloadData.module, payloadData)}: ${payloadData.transitive_dependents.length} transitive dependents, ${payloadData.transitive_dependencies.length} transitive dependencies`;
+  wrap.append(headline);
+
+  [
+    ["Direct imports", payloadData.direct_imports],
+    ["Direct imported by", payloadData.direct_imported_by],
+    ["Transitive dependents", payloadData.transitive_dependents],
+    ["Transitive dependencies", payloadData.transitive_dependencies],
+  ].forEach(([label, items]) => {
+    wrap.append(renderListBlock(label, items, payloadData));
+  });
+
+  wrap.append(renderPathBlock("Dependent paths", payloadData.dependent_paths, payloadData));
+  wrap.append(renderPathBlock("Dependency paths", payloadData.dependency_paths, payloadData));
+  return wrap;
+}
+
+function renderOverviewView(payloadData) {
+  const wrap = document.createElement("div");
+  wrap.className = "impact-view";
+
+  const headline = document.createElement("div");
+  headline.className = "query-summary";
+  headline.textContent = `${payloadData.modules} modules, ${payloadData.imports} imports, ${payloadData.cycles.length} cycles`;
+  wrap.append(headline);
+
+  wrap.append(renderRankBlock("Highest blast radius", payloadData.top_dependents, payloadData, "dependents"));
+  wrap.append(renderRankBlock("Highest dependency fanout", payloadData.top_dependencies, payloadData, "dependencies"));
+  wrap.append(renderRankBlock("Most direct imports", payloadData.direct_import_hubs, payloadData, "imports"));
+  wrap.append(renderRankBlock("Most directly imported", payloadData.direct_imported_hubs, payloadData, "callers"));
+  wrap.append(renderListBlock("Entrypoints", payloadData.entrypoints.slice(0, 12), payloadData));
+  wrap.append(renderListBlock("Leaves", payloadData.leaves.slice(0, 12), payloadData));
+  wrap.append(renderCyclesBlock(payloadData.cycles, payloadData));
+
+  return wrap;
+}
+
+function renderBriefView(payloadData) {
+  const wrap = document.createElement("div");
+  wrap.className = "impact-view";
+
+  const headline = document.createElement("div");
+  headline.className = "query-summary";
+  headline.textContent = `${formatModule(payloadData.module, payloadData)}: ${payloadData.risk_level} risk, ${payloadData.blast_radius} dependents, ${payloadData.coupling} dependencies`;
+  wrap.append(headline);
+
+  wrap.append(renderDetailRowsBlock("Read first", payloadData.read_first));
+  wrap.append(renderDetailRowsBlock("Regression watch", payloadData.regression_targets));
+  wrap.append(renderBriefPathBlock("Proof paths", payloadData.path_examples, payloadData));
+  wrap.append(renderProofChecksBlock(payloadData.proof_checks, payloadData));
+
+  const pre = document.createElement("pre");
+  pre.textContent = payloadData.markdown;
+  wrap.append(pre);
+  return wrap;
+}
+
+function renderCompareView(payloadData) {
+  const wrap = document.createElement("div");
+  wrap.className = "impact-view";
+
+  const headline = document.createElement("div");
+  headline.className = "query-summary";
+  headline.textContent = `${payloadData.risk_level} risk: ${payloadData.summary}`;
+  wrap.append(headline);
+
+  wrap.append(renderCompareStats(payloadData));
+  wrap.append(renderEdgeBlock("Added imports", payloadData.added_imports, payloadData, "added"));
+  wrap.append(renderEdgeBlock("Removed imports", payloadData.removed_imports, payloadData, "removed"));
+  wrap.append(renderListBlock("Added modules", payloadData.added_modules, payloadData));
+  wrap.append(renderListBlock("Removed modules", payloadData.removed_modules, payloadData));
+  wrap.append(renderDeltaBlock(payloadData.blast_radius_deltas, payloadData));
+  wrap.append(renderCompareCyclesBlock("Introduced cycles", payloadData.introduced_cycles, payloadData));
+  wrap.append(renderCompareCyclesBlock("Resolved cycles", payloadData.resolved_cycles, payloadData));
+  wrap.append(renderProofChecksBlock(payloadData.suggested_checks, payloadData));
+
+  const pre = document.createElement("pre");
+  pre.textContent = payloadData.markdown;
+  wrap.append(pre);
+  return wrap;
+}
+
+function renderCompareStats(payloadData) {
+  const block = document.createElement("div");
+  block.className = "compare-stats";
+  [
+    ["Before", payloadData.before],
+    ["After", payloadData.after],
+  ].forEach(([label, stats]) => {
+    const item = document.createElement("div");
+    item.className = "stat-card";
+    const title = document.createElement("strong");
+    title.textContent = label;
+    const body = document.createElement("span");
+    body.textContent = `${stats.modules} modules / ${stats.imports} imports / ${stats.cycles} cycles`;
+    item.append(title, body);
+    block.append(item);
+  });
+  return block;
+}
+
+function renderEdgeBlock(label, edges, payloadData, className) {
+  const block = document.createElement("div");
+  block.className = "impact-block";
+  const title = document.createElement("strong");
+  title.textContent = `${label} (${edges.length})`;
+  block.append(title);
+  if (!edges.length) {
+    block.append(emptyState("none"));
+    return block;
+  }
+  const list = document.createElement("div");
+  list.className = "edge-list";
+  edges.forEach(([src, dst]) => {
+    const button = document.createElement("button");
+    button.className = `edge-item ${className}`;
+    button.type = "button";
+    button.textContent = `${formatModule(src, payloadData)} -> ${formatModule(dst, payloadData)}`;
+    button.addEventListener("click", () => {
+      relationEl.value = "depends_on";
+      arg1El.value = src;
+      arg2El.value = dst;
+      recursiveEl.checked = true;
+      queueSave();
+      invoke(className === "removed" ? "why-not" : "prove");
+    });
+    list.append(button);
+  });
+  block.append(list);
+  return block;
+}
+
+function renderDeltaBlock(items, payloadData) {
+  const block = document.createElement("div");
+  block.className = "impact-block";
+  const title = document.createElement("strong");
+  title.textContent = `Blast-radius changes (${items.length})`;
+  block.append(title);
+  if (!items.length) {
+    block.append(emptyState("none"));
+    return block;
+  }
+  const list = document.createElement("div");
+  list.className = "rank-list";
+  items.forEach((item) => {
+    const button = document.createElement("button");
+    button.className = "rank-item";
+    button.type = "button";
+    button.textContent = `${formatModule(item.module, payloadData)}: ${item.before} -> ${item.after} (${formatSigned(item.delta)})`;
+    button.addEventListener("click", () => {
+      impactModuleEl.value = item.module;
+      analyzeImpact();
+    });
+    list.append(button);
+  });
+  block.append(list);
+  return block;
+}
+
+function renderCompareCyclesBlock(label, cycles, payloadData) {
+  const block = document.createElement("div");
+  block.className = "impact-block";
+  const title = document.createElement("strong");
+  title.textContent = `${label} (${cycles.length})`;
+  block.append(title);
+  if (!cycles.length) {
+    block.append(emptyState("none"));
+    return block;
+  }
+  const list = document.createElement("div");
+  list.className = "path-list";
+  cycles.forEach((cycle) => {
+    const item = document.createElement("button");
+    item.className = "path-item";
+    item.type = "button";
+    item.textContent = cycle.map((symbol) => formatModule(symbol, payloadData)).join(" -> ");
+    item.addEventListener("click", () => {
+      impactModuleEl.value = cycle[0];
+      analyzeImpact();
+    });
+    list.append(item);
+  });
+  block.append(list);
+  return block;
+}
+
+function renderRankBlock(label, items, payloadData, unit) {
+  const block = document.createElement("div");
+  block.className = "impact-block";
+  const title = document.createElement("strong");
+  title.textContent = label;
+  block.append(title);
+  if (!items.length) {
+    block.append(emptyState("none"));
+    return block;
+  }
+  const list = document.createElement("div");
+  list.className = "rank-list";
+  items.forEach((item) => {
+    const button = document.createElement("button");
+    button.className = "rank-item";
+    button.type = "button";
+    button.textContent = `${formatModule(item.module, payloadData)}: ${item.count} ${unit}`;
+    const detail = moduleDetail(item.module, payloadData);
+    if (detail?.file) {
+      button.title = detail.file;
+    }
+    button.addEventListener("click", () => {
+      impactModuleEl.value = item.module;
+      analyzeImpact();
+    });
+    list.append(button);
+  });
+  block.append(list);
+  return block;
+}
+
+function renderDetailRowsBlock(label, rows) {
+  const block = document.createElement("div");
+  block.className = "impact-block";
+  const title = document.createElement("strong");
+  title.textContent = `${label} (${rows.length})`;
+  block.append(title);
+  if (!rows.length) {
+    block.append(emptyState("none"));
+    return block;
+  }
+  const list = document.createElement("div");
+  list.className = "detail-list";
+  rows.forEach((row) => {
+    const button = document.createElement("button");
+    button.className = "detail-item";
+    button.type = "button";
+    button.textContent = formatModule(row.symbol, { module_details: { [row.symbol]: row } });
+    if (row.file) {
+      button.title = row.file;
+      const file = document.createElement("span");
+      file.textContent = row.file;
+      button.append(file);
+    }
+    button.addEventListener("click", () => {
+      impactModuleEl.value = row.symbol;
+      analyzeImpact();
+    });
+    list.append(button);
+  });
+  block.append(list);
+  return block;
+}
+
+function renderBriefPathBlock(label, paths, payloadData) {
+  const block = document.createElement("div");
+  block.className = "impact-block";
+  const title = document.createElement("strong");
+  title.textContent = `${label} (${paths.length})`;
+  block.append(title);
+  if (!paths.length) {
+    block.append(emptyState("none"));
+    return block;
+  }
+  const list = document.createElement("div");
+  list.className = "path-list";
+  paths.forEach((item) => {
+    const button = document.createElement("button");
+    button.className = "path-item";
+    button.type = "button";
+    button.textContent = `${item.kind}: ${item.path.map((symbol) => formatModule(symbol, payloadData)).join(" -> ")}`;
+    button.addEventListener("click", () => {
+      relationEl.value = "depends_on";
+      arg1El.value = item.path[0];
+      arg2El.value = item.path[item.path.length - 1];
+      recursiveEl.checked = true;
+      queueSave();
+      invoke("prove");
+    });
+    list.append(button);
+  });
+  block.append(list);
+  return block;
+}
+
+function renderProofChecksBlock(checks, payloadData) {
+  const block = document.createElement("div");
+  block.className = "impact-block";
+  const title = document.createElement("strong");
+  title.textContent = `Suggested checks (${checks.length})`;
+  block.append(title);
+  if (!checks.length) {
+    block.append(emptyState("none"));
+    return block;
+  }
+  const list = document.createElement("div");
+  list.className = "check-list";
+  checks.forEach((check) => {
+    const button = document.createElement("button");
+    button.className = "check-item";
+    button.type = "button";
+    const action = check.action || "prove";
+    const prefix = check.kind ? `${check.kind}: ` : "";
+    button.textContent = `${prefix}${action} ${check.relation}(${formatModule(check.arg1, payloadData)}, ${formatModule(check.arg2, payloadData)})`;
+    button.addEventListener("click", () => {
+      relationEl.value = check.relation;
+      arg1El.value = check.arg1;
+      arg2El.value = check.arg2;
+      recursiveEl.checked = Boolean(check.recursive);
+      queueSave();
+      invoke(action);
+    });
+    list.append(button);
+  });
+  block.append(list);
+  return block;
+}
+
+function renderCyclesBlock(cycles, payloadData) {
+  const block = document.createElement("div");
+  block.className = "impact-block";
+  const title = document.createElement("strong");
+  title.textContent = `Cycles (${cycles.length})`;
+  block.append(title);
+  if (!cycles.length) {
+    block.append(emptyState("none"));
+    return block;
+  }
+  const list = document.createElement("div");
+  list.className = "path-list";
+  cycles.slice(0, 8).forEach((cycle) => {
+    const item = document.createElement("button");
+    item.className = "path-item";
+    item.type = "button";
+    item.textContent = cycle.map((symbol) => formatModule(symbol, payloadData)).join(" -> ");
+    item.addEventListener("click", () => {
+      impactModuleEl.value = cycle[0];
+      analyzeImpact();
+    });
+    list.append(item);
+  });
+  block.append(list);
+  return block;
+}
+
+function renderListBlock(label, items, payloadData) {
+  const block = document.createElement("div");
+  block.className = "impact-block";
+  const title = document.createElement("strong");
+  title.textContent = `${label} (${items.length})`;
+  block.append(title);
+  if (!items.length) {
+    block.append(emptyState("none"));
+    return block;
+  }
+  const chips = document.createElement("div");
+  chips.className = "impact-chips";
+  items.forEach((item) => {
+    const button = document.createElement("button");
+    button.className = "chip";
+    button.type = "button";
+    button.textContent = formatModule(item, payloadData);
+    const detail = moduleDetail(item, payloadData);
+    if (detail?.file) {
+      button.title = detail.file;
+    }
+    button.addEventListener("click", () => {
+      impactModuleEl.value = item;
+      analyzeImpact();
+    });
+    chips.append(button);
+  });
+  block.append(chips);
+  return block;
+}
+
+function renderPathBlock(label, paths, payloadData) {
+  const block = document.createElement("div");
+  block.className = "impact-block";
+  const title = document.createElement("strong");
+  title.textContent = label;
+  block.append(title);
+  const entries = Object.entries(paths || {});
+  if (!entries.length) {
+    block.append(emptyState("none"));
+    return block;
+  }
+  const list = document.createElement("div");
+  list.className = "path-list";
+  entries.slice(0, 12).forEach(([module, path]) => {
+    const item = document.createElement("button");
+    item.className = "path-item";
+    item.type = "button";
+    item.textContent = `${formatModule(module, payloadData)}: ${path.map((symbol) => formatModule(symbol, payloadData)).join(" -> ")}`;
+    item.addEventListener("click", () => {
+      relationEl.value = "depends_on";
+      arg1El.value = path[0];
+      arg2El.value = path[path.length - 1];
+      recursiveEl.checked = true;
+      queueSave();
+      invoke("prove");
+    });
+    list.append(item);
+  });
+  if (entries.length > 12) {
+    const more = document.createElement("div");
+    more.className = "muted";
+    more.textContent = `+${entries.length - 12} more paths`;
+    list.append(more);
+  }
+  block.append(list);
+  return block;
+}
+
+function formatModule(symbol, payloadData) {
+  const detail = moduleDetail(symbol, payloadData);
+  if (!detail || !detail.module || detail.module === symbol) {
+    return symbol;
+  }
+  return `${symbol} (${detail.module})`;
+}
+
+function moduleDetail(symbol, payloadData) {
+  return payloadData?.module_details?.[symbol] || null;
+}
+
+function normalizeProofNode(node) {
+  if (node?.proof && typeof node.proof === "object") {
+    return node.proof;
+  }
+  if (node?.explanation && typeof node.explanation === "object") {
+    return node.explanation;
+  }
+  return node || {};
+}
+
+function analyzeSource() {
+  const lines = sourceEl.value.split("\n");
+  const logicalLines = lines.map((line) => line.trim()).filter((line) => line && !line.startsWith("#"));
+  const groups = {
+    domains: [],
+    relations: [],
+    facts: [],
+    rules: [],
+    commands: [],
+  };
+
+  logicalLines.forEach((line) => {
+    collectMatch(groups.domains, line, /^domain\s+(\w+)/);
+    collectMatch(groups.relations, line, /^relation\s+(\w+)/);
+    collectMatch(groups.facts, line, /^fact\s+([\w(,\s)]+)/);
+    collectMatch(groups.rules, line, /^rule\s+(.+)/);
+    if (/^(query|prove)\s+/.test(line)) {
+      groups.commands.push(line);
+    }
+  });
+
+  const summary = `${groups.domains.length} domains / ${groups.relations.length} relations / ${groups.facts.length} facts / ${groups.rules.length} rules`;
+  programSummaryEl.textContent = summary;
+  lineCountEl.textContent = `${logicalLines.length} lines`;
+  renderProgramIndex(groups);
+  renderRelationOptions(groups.relations);
+  renderArgumentOptions(extractDomainSymbols(sourceEl.value));
+}
+
+function collectMatch(target, line, pattern) {
+  const match = line.match(pattern);
+  if (match) {
+    target.push(match[1].replace(/\s+/g, " ").trim());
+  }
+}
+
+function renderProgramIndex(groups) {
+  programIndexEl.replaceChildren();
+  const sections = [
+    ["domains", groups.domains],
+    ["relations", groups.relations],
+    ["facts", groups.facts],
+    ["rules", groups.rules],
+    ["commands", groups.commands],
+  ];
+
+  sections.forEach(([label, items]) => {
+    const block = document.createElement("div");
+    block.className = "index-group";
+    const head = document.createElement("div");
+    head.className = "index-head";
+    head.textContent = `${label} ${items.length}`;
+    block.append(head);
+
+    if (items.length === 0) {
+      const empty = document.createElement("span");
+      empty.className = "muted";
+      empty.textContent = "none";
+      block.append(empty);
+    } else {
+      items.slice(0, 8).forEach((item) => {
+        const chip = document.createElement("button");
+        chip.className = "chip";
+        chip.type = "button";
+        chip.textContent = item;
+        chip.addEventListener("click", () => {
+          if (label === "relations") {
+            relationEl.value = item;
+            queueSave();
+          }
+        });
+        block.append(chip);
+      });
+      if (items.length > 8) {
+        const more = document.createElement("span");
+        more.className = "muted";
+        more.textContent = `+${items.length - 8} more`;
+        block.append(more);
+      }
+    }
+    programIndexEl.append(block);
+  });
+}
+
+function renderRelationOptions(relations) {
+  relationOptionsEl.replaceChildren();
+  relations.forEach((relation) => {
+    const option = document.createElement("option");
+    option.value = relation;
+    relationOptionsEl.append(option);
+  });
+}
+
+function renderArgumentOptions(symbols) {
+  argumentOptionsEl.replaceChildren();
+  symbols.forEach((symbol) => {
+    const option = document.createElement("option");
+    option.value = symbol;
+    argumentOptionsEl.append(option);
+  });
+}
+
+function extractDomainSymbols(source) {
+  const symbols = [];
+  const pattern = /domain\s+\w+\s*\{([\s\S]*?)\}/g;
+  let match;
+  while ((match = pattern.exec(source)) !== null) {
+    match[1]
+      .split(/[\s,]+/)
+      .map((symbol) => symbol.trim())
+      .filter(Boolean)
+      .forEach((symbol) => symbols.push(symbol));
+  }
+  return [...new Set(symbols)].sort();
+}
+
+function pushHistory(data, ok) {
+  history.unshift({
+    id: globalThis.crypto?.randomUUID?.() || String(Date.now() + Math.random()),
+    ok,
+    data,
+    at: new Date(),
+  });
+  history = history.slice(0, HISTORY_LIMIT);
+  renderHistory();
+}
+
+function renderHistory() {
+  historyEl.replaceChildren();
+  if (!history.length) {
+    historyEl.append(emptyState("No runs yet"));
+    return;
+  }
+  history.forEach((entry) => {
+    const button = document.createElement("button");
+    button.className = `history-item ${entry.ok ? "ok" : "bad"}`;
+    button.type = "button";
+    button.addEventListener("click", () => renderResult(entry.data, entry.ok));
+
+    const top = document.createElement("span");
+    top.textContent = `${labelForAction(entry.data.action)} ${historyAnswer(entry.data)}`;
+    const bottom = document.createElement("small");
+    bottom.textContent = `${entry.data.command || targetText()} / ${entry.at.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    })}`;
+
+    button.append(top, bottom);
+    historyEl.append(button);
+  });
+}
+
+function setTab(name) {
+  document.querySelectorAll("[data-tab]").forEach((button) => {
+    button.classList.toggle("active", button.dataset.tab === name);
+  });
+  document.querySelectorAll("[data-panel]").forEach((panel) => {
+    panel.classList.toggle("active", panel.dataset.panel === name);
+  });
+}
+
+function saveState() {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        presetId: presetEl.value,
+        source: sourceEl.value,
+        relation: relationEl.value,
+        arg1: arg1El.value,
+        arg2: arg2El.value,
+        recursive: recursiveEl.checked,
+        repoMetadata,
+        repoBaseline,
+      }),
+    );
+  } catch {
+    // Local storage is optional for the workbench.
+  }
+}
+
+function queueSave() {
+  clearTimeout(saveTimer);
+  saveTimer = window.setTimeout(saveState, 150);
+}
+
+function loadState() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || "null");
+  } catch {
+    return null;
+  }
+}
+
+function updateActivePreset() {
+  const example = EXAMPLES.find((item) => item.id === presetEl.value) || EXAMPLES[0];
+  activePresetEl.textContent = example.name;
+}
+
+function updateBaselineSummary() {
+  if (!repoBaseline?.source) {
+    compareSummaryEl.textContent = "Set a baseline before editing or reloading imports.";
+    return;
+  }
+  const time = new Date(repoBaseline.at).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  compareSummaryEl.textContent = `Baseline: ${repoBaseline.summary || "saved graph"} at ${time}`;
+}
+
+function targetText() {
+  return `${relationEl.value || "relation"}(${arg1El.value || "arg1"}, ${arg2El.value || "arg2"})`;
+}
+
+function resultTitle(action, answer, ok) {
+  if (!ok) {
+    return `${labelForAction(action)} failed`;
+  }
+  if (typeof answer === "boolean") {
+    return `${targetText()} = ${answer}`;
+  }
+  return `${labelForAction(action)} complete`;
+}
+
+function historyAnswer(data) {
+  const answer = data.payload?.answer;
+  if (typeof answer === "boolean") {
+    return answer ? "true" : "false";
+  }
+  return data.exit_code === 0 ? "ok" : "failed";
+}
+
+function labelForAction(action = "") {
+  return action
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function confidenceText(confidence) {
+  if (typeof confidence !== "number") {
+    return "derived";
+  }
+  return `${Math.round(confidence * 1000) / 1000}`;
+}
+
+function formatSigned(value) {
+  return value > 0 ? `+${value}` : String(value);
+}
+
+function formatHead(head) {
+  if (!Array.isArray(head) || head.length < 3) {
+    return "unknown";
+  }
+  return `${head[0]}(${head[1]}, ${head[2]})`;
+}
+
+function emptyState(text) {
+  const node = document.createElement("div");
+  node.className = "empty";
+  node.textContent = text;
+  return node;
+}

--- a/web_workbench/static/index.html
+++ b/web_workbench/static/index.html
@@ -7,26 +7,144 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <header class="toolbar">
-      <button data-action="run">Run</button>
-      <button data-action="query">Query</button>
-      <button data-action="prove">Prove</button>
-      <button data-action="why-not">Why Not</button>
-      <label>relation <input id="relation" value="ancestor" /></label>
-      <label>arg1 <input id="arg1" value="alice" /></label>
-      <label>arg2 <input id="arg2" value="cara" /></label>
-      <label class="toggle"><input id="recursive" type="checkbox" checked /> recursive</label>
+    <header class="app-shell">
+      <div class="brand">
+        <span class="brand-mark">tl</span>
+        <div>
+          <h1>tensor_logic</h1>
+          <p id="program-summary">0 domains / 0 relations / 0 facts / 0 rules</p>
+        </div>
+      </div>
+
+      <div class="command-bar" aria-label="Workbench actions">
+        <button class="primary" data-action="run" type="button">Run</button>
+        <button data-action="query" type="button">Query</button>
+        <button data-action="prove" type="button">Prove</button>
+        <button data-action="why-not" type="button">Why Not</button>
+      </div>
     </header>
-    <main class="split">
-      <section>
-        <div class="pane-title">source.tl</div>
+
+    <main class="workbench">
+      <aside class="rail" aria-label="Program controls">
+        <label class="field">
+          <span>preset</span>
+          <select id="preset"></select>
+        </label>
+
+        <div class="repo-loader">
+          <label class="field">
+            <span>python path</span>
+            <input id="ingest-path" value="tensor_logic" />
+          </label>
+          <button id="load-repo" type="button">Load Imports</button>
+          <p id="ingest-summary">Load a Python package to ask dependency questions.</p>
+        </div>
+
+        <div class="overview-card">
+          <button id="analyze-overview" type="button">Repo Overview</button>
+          <p id="overview-summary">Rank hotspots after loading imports.</p>
+        </div>
+
+        <div class="compare-card">
+          <button id="set-baseline" type="button">Set Baseline</button>
+          <button id="compare-graph" type="button">Compare Graph</button>
+          <p id="compare-summary">Set a baseline before editing or reloading imports.</p>
+        </div>
+
+        <div class="query-card">
+          <label class="field">
+            <span>relation</span>
+            <input id="relation" list="relation-options" value="ancestor" />
+          </label>
+          <datalist id="relation-options"></datalist>
+
+          <div class="arg-grid">
+            <label class="field">
+              <span>arg 1</span>
+              <input id="arg1" list="argument-options" value="alice" />
+            </label>
+            <label class="field">
+              <span>arg 2</span>
+              <input id="arg2" list="argument-options" value="cara" />
+            </label>
+            <datalist id="argument-options"></datalist>
+          </div>
+
+          <label class="switch">
+            <input id="recursive" type="checkbox" checked />
+            <span>recursive</span>
+          </label>
+        </div>
+
+        <div class="impact-card">
+          <label class="field">
+            <span>impact module</span>
+            <input id="impact-module" list="argument-options" value="language" />
+          </label>
+          <button id="analyze-impact" type="button">Analyze Impact</button>
+          <button id="change-brief" type="button">Change Brief</button>
+          <p id="impact-summary">No impact yet.</p>
+          <p id="brief-summary">No brief yet.</p>
+        </div>
+
+        <section class="inspector" aria-label="Program index">
+          <div class="section-title">
+            <span>program</span>
+            <span id="line-count">0 lines</span>
+          </div>
+          <div id="program-index" class="index-list"></div>
+        </section>
+
+        <section class="inspector" aria-label="History">
+          <div class="section-title">
+            <span>history</span>
+            <button id="clear-history" class="ghost" type="button">Clear</button>
+          </div>
+          <div id="history" class="history-list"></div>
+        </section>
+      </aside>
+
+      <section class="editor-pane" aria-label="Source editor">
+        <div class="pane-header">
+          <div>
+            <span class="eyebrow">source.tl</span>
+            <strong id="active-preset">Kinship Closure</strong>
+          </div>
+          <button id="reset-source" class="ghost" type="button">Reset</button>
+        </div>
         <textarea id="source" spellcheck="false"></textarea>
       </section>
-      <section>
-        <div class="pane-title">result</div>
-        <pre id="result"></pre>
+
+      <section class="result-pane" aria-label="Result">
+        <div class="answer-strip" id="answer-strip">
+          <div>
+            <span class="eyebrow">result</span>
+            <strong id="answer-title">Ready</strong>
+          </div>
+          <div class="metrics">
+            <span id="duration">0 ms</span>
+            <span id="exit-code">idle</span>
+          </div>
+        </div>
+
+        <nav class="tabs" aria-label="Result views">
+          <button class="tab active" data-tab="output" type="button">Output</button>
+          <button class="tab" data-tab="proof" type="button">Proof</button>
+          <button class="tab" data-tab="json" type="button">JSON</button>
+        </nav>
+
+        <div class="tab-panel active" data-panel="output">
+          <pre id="result"></pre>
+        </div>
+        <div class="tab-panel" data-panel="proof">
+          <div id="proof-view" class="proof-view"></div>
+        </div>
+        <div class="tab-panel" data-panel="json">
+          <pre id="json-view"></pre>
+        </div>
       </section>
     </main>
+
     <script src="./app.js" type="module"></script>
   </body>
 </html>

--- a/web_workbench/static/styles.css
+++ b/web_workbench/static/styles.css
@@ -1,84 +1,386 @@
 :root {
   color-scheme: dark;
-  --bg: #0f1115;
-  --panel: #161b22;
-  --line: #31363f;
-  --text: #d7dde8;
-  --muted: #8b95a7;
-  --accent: #4e8cff;
+  --bg: #101110;
+  --panel: #171817;
+  --panel-strong: #20211f;
+  --line: #343631;
+  --line-soft: #262822;
+  --text: #f1efe7;
+  --muted: #aaa69a;
+  --quiet: #777469;
+  --green: #36d399;
+  --cyan: #38bdf8;
+  --amber: #f5b84b;
+  --rose: #fb7185;
+  --shadow: rgba(0, 0, 0, 0.3);
+  --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 * {
   box-sizing: border-box;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
 }
 
 body {
-  margin: 0;
   min-height: 100vh;
   background: var(--bg);
   color: var(--text);
   display: grid;
   grid-template-rows: auto 1fr;
-}
-
-.toolbar {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.5rem;
-  border-bottom: 1px solid var(--line);
-  background: #0c0f13;
-  flex-wrap: wrap;
+  font-family: var(--sans);
+  overflow: hidden;
 }
 
 button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button,
+select,
 input {
-  background: var(--panel);
-  color: var(--text);
-  border: 1px solid var(--line);
-  padding: 0.25rem 0.45rem;
-  font-size: 12px;
+  min-width: 0;
 }
 
 button {
+  border: 1px solid var(--line);
+  background: var(--panel-strong);
+  color: var(--text);
+  border-radius: 7px;
   cursor: pointer;
+  min-height: 34px;
+  padding: 0 0.75rem;
 }
 
-button:hover {
-  border-color: var(--accent);
+button:hover,
+button:focus-visible,
+select:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  border-color: var(--cyan);
+  outline: none;
 }
 
-label {
-  color: var(--muted);
+button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+.app-shell {
+  min-height: 76px;
+  padding: 0.85rem 1rem;
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-  font-size: 12px;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--line);
+  background: #0c0d0c;
 }
 
-.split {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  min-height: 0;
+.brand {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 0.75rem;
 }
 
-section {
+.brand-mark {
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(54, 211, 153, 0.5);
+  border-radius: 8px;
+  color: var(--green);
+  font-family: var(--mono);
+  font-size: 0.95rem;
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.15);
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(1.05rem, 1.3vw, 1.35rem);
+  font-weight: 700;
+}
+
+.brand p,
+.eyebrow,
+.section-title,
+.metrics,
+.proof-source,
+.muted,
+small {
+  color: var(--muted);
+}
+
+.brand p {
+  margin-top: 0.2rem;
+  font-family: var(--mono);
+  font-size: 0.76rem;
+}
+
+.command-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.command-bar button {
+  font-weight: 700;
+}
+
+.command-bar .primary {
+  background: var(--green);
+  border-color: var(--green);
+  color: #08110c;
+}
+
+.ghost {
+  min-height: 28px;
+  padding: 0 0.55rem;
+  background: transparent;
+  color: var(--muted);
+}
+
+.repo-loader,
+.overview-card,
+.compare-card,
+.impact-card {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.85rem;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 8px;
+  background: #111514;
+}
+
+.impact-card {
+  border-color: rgba(245, 184, 75, 0.28);
+}
+
+.repo-loader button,
+.overview-card button,
+.compare-card button,
+.impact-card button {
+  width: 100%;
+}
+
+.repo-loader button {
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.compare-card button {
+  border-color: rgba(54, 211, 153, 0.38);
+}
+
+.impact-card button {
+  border-color: rgba(245, 184, 75, 0.48);
+}
+
+.repo-loader p,
+.overview-card p,
+.compare-card p,
+.impact-card p {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.workbench {
   min-height: 0;
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-columns: minmax(230px, 285px) minmax(360px, 1.08fr) minmax(360px, 0.92fr);
+  height: calc(100vh - 76px);
+}
+
+.rail,
+.editor-pane,
+.result-pane {
+  min-height: 0;
   border-right: 1px solid var(--line);
+  background: var(--panel);
 }
 
-section:last-child {
+.rail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 0.85rem;
+  overflow: auto;
+}
+
+.result-pane {
   border-right: 0;
 }
 
-.pane-title {
-  padding: 0.35rem 0.5rem;
-  border-bottom: 1px solid var(--line);
+.field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.field span,
+.switch,
+.eyebrow,
+.index-head {
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.field span,
+.switch,
+.eyebrow,
+.index-head {
   color: var(--muted);
-  font-size: 12px;
+}
+
+input,
+select {
+  width: 100%;
+  height: 34px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #101210;
+  color: var(--text);
+  padding: 0 0.65rem;
+}
+
+.query-card {
+  display: grid;
+  gap: 0.7rem;
+  padding: 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #131513;
+}
+
+.arg-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0.55rem;
+}
+
+.switch {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.switch input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--green);
+}
+
+.inspector {
+  display: grid;
+  gap: 0.55rem;
+  min-height: 0;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.index-list,
+.history-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.index-group {
+  display: grid;
+  gap: 0.35rem;
+  padding-bottom: 0.65rem;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.index-head {
+  color: var(--quiet);
+}
+
+.chip {
+  display: block;
+  width: 100%;
+  height: auto;
+  min-height: 28px;
+  padding: 0.3rem 0.5rem;
+  overflow-wrap: anywhere;
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--text);
+  background: #111311;
+}
+
+.history-item {
+  width: 100%;
+  height: auto;
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.55rem;
+  text-align: left;
+  border-color: var(--line-soft);
+  background: #111311;
+}
+
+.history-item span,
+.history-item small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-item.ok {
+  border-left: 3px solid var(--green);
+}
+
+.history-item.bad {
+  border-left: 3px solid var(--rose);
+}
+
+.editor-pane,
+.result-pane {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.pane-header,
+.answer-strip {
+  min-height: 64px;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  border-bottom: 1px solid var(--line);
+  background: #131513;
+}
+
+.pane-header strong,
+.answer-strip strong {
+  display: block;
+  margin-top: 0.2rem;
+  overflow-wrap: anywhere;
 }
 
 textarea,
@@ -87,23 +389,380 @@ pre {
   width: 100%;
   height: 100%;
   border: 0;
-  background: var(--panel);
   color: var(--text);
-  padding: 0.65rem;
+  font-family: var(--mono);
+  font-size: 0.83rem;
+  line-height: 1.55;
+}
+
+textarea {
+  min-height: 0;
   resize: none;
   outline: none;
-  font-size: 13px;
-  line-height: 1.25;
+  padding: 1rem;
+  background:
+    linear-gradient(to right, rgba(245, 184, 75, 0.08), transparent 1px) 0 0 / 40px 100%,
+    #111210;
+  tab-size: 2;
+}
+
+.result-pane {
+  grid-template-rows: auto auto minmax(0, 1fr);
+}
+
+.answer-strip.true {
+  box-shadow: inset 4px 0 0 var(--green);
+}
+
+.answer-strip.false {
+  box-shadow: inset 4px 0 0 var(--amber);
+}
+
+.answer-strip.error {
+  box-shadow: inset 4px 0 0 var(--rose);
+}
+
+.answer-strip.running {
+  box-shadow: inset 4px 0 0 var(--cyan);
+}
+
+.metrics {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  font-family: var(--mono);
+  font-size: 0.76rem;
+}
+
+.metrics span {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.22rem 0.5rem;
+  background: #101210;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.2rem;
+  padding: 0.45rem 0.55rem 0;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+}
+
+.tab {
+  min-height: 32px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted);
+}
+
+.tab.active {
+  color: var(--text);
+  border-color: var(--line);
+  border-bottom-color: var(--panel-strong);
+  background: var(--panel-strong);
+}
+
+.tab-panel {
+  display: none;
+  min-height: 0;
   overflow: auto;
+  background: var(--panel-strong);
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+#result,
+#json-view,
+.proof-view {
+  padding: 1rem;
 }
 
 pre {
+  overflow: auto;
   white-space: pre-wrap;
+  word-break: break-word;
+  background: transparent;
+}
+
+.proof-view {
+  min-height: 100%;
+}
+
+.proof-node {
+  position: relative;
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #141614;
+  box-shadow: 0 10px 24px var(--shadow);
+}
+
+.proof-node + .proof-node {
+  margin-top: 0.55rem;
+}
+
+.proof-node.positive {
+  border-left: 3px solid var(--green);
+}
+
+.proof-node.negative {
+  border-left: 3px solid var(--amber);
+}
+
+.proof-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  min-width: 0;
+}
+
+.proof-head strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+}
+
+.proof-head span {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.75rem;
+}
+
+.proof-source {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+}
+
+.proof-children {
+  display: grid;
+  gap: 0.55rem;
+  padding-left: 0.9rem;
+  border-left: 1px solid var(--line);
+}
+
+.output-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.output-stack pre,
+.query-summary,
+.empty {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #141614;
+  padding: 0.75rem;
+}
+
+.query-summary {
+  font-family: var(--mono);
+}
+
+.impact-view,
+.path-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.rank-list {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.detail-list,
+.edge-list,
+.check-list {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.rank-item {
+  width: 100%;
+  height: auto;
+  min-height: 32px;
+  text-align: left;
+  padding: 0.45rem 0.6rem;
+  border-left: 3px solid var(--amber);
+  background: #101210;
+  font-family: var(--mono);
+  font-size: 0.76rem;
+  overflow-wrap: anywhere;
+}
+
+.detail-item,
+.edge-item,
+.check-item {
+  width: 100%;
+  height: auto;
+  min-height: 34px;
+  display: grid;
+  gap: 0.2rem;
+  text-align: left;
+  padding: 0.45rem 0.6rem;
+  background: #101210;
+  font-family: var(--mono);
+  font-size: 0.76rem;
+  overflow-wrap: anywhere;
+}
+
+.detail-item {
+  border-left: 3px solid var(--green);
+}
+
+.check-item {
+  border-left: 3px solid var(--cyan);
+}
+
+.edge-item.added {
+  border-left: 3px solid var(--green);
+}
+
+.edge-item.removed {
+  border-left: 3px solid var(--rose);
+}
+
+.detail-item span {
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+
+.compare-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 0.55rem;
+}
+
+.stat-card {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.65rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #141614;
+  font-family: var(--mono);
+}
+
+.stat-card strong {
+  color: var(--text);
+  font-size: 0.78rem;
+}
+
+.stat-card span {
+  color: var(--muted);
+  font-size: 0.74rem;
+}
+
+.impact-block {
+  display: grid;
+  gap: 0.45rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #141614;
+  padding: 0.75rem;
+}
+
+.impact-block strong {
+  font-size: 0.78rem;
+}
+
+.impact-chips {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(135px, 1fr));
+  gap: 0.45rem;
+}
+
+.path-item {
+  width: 100%;
+  height: auto;
+  min-height: 0;
+  text-align: left;
+  border-left: 3px solid var(--cyan);
+  padding: 0.45rem 0.6rem;
+  background: #101210;
+  border-radius: 6px;
+  font-family: var(--mono);
+  font-size: 0.76rem;
+  overflow-wrap: anywhere;
+}
+
+.empty {
+  color: var(--muted);
+}
+
+@media (max-width: 1160px) {
+  body {
+    overflow: auto;
+  }
+
+  .workbench {
+    height: auto;
+    min-height: calc(100vh - 76px);
+    grid-template-columns: minmax(230px, 285px) minmax(0, 1fr);
+  }
+
+  .result-pane {
+    grid-column: 1 / -1;
+    min-height: 520px;
+    border-top: 1px solid var(--line);
+  }
+
+  .editor-pane {
+    min-height: 580px;
+  }
 }
 
 @media (max-width: 760px) {
-  .split {
+  .app-shell {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .command-bar {
+    justify-content: stretch;
+  }
+
+  .command-bar button {
+    flex: 1 1 120px;
+  }
+
+  .workbench {
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr 1fr;
+  }
+
+  .rail,
+  .editor-pane,
+  .result-pane {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .rail {
+    max-height: none;
+  }
+
+  .editor-pane {
+    min-height: 520px;
+  }
+
+  .answer-strip,
+  .pane-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .metrics {
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- preserve the local web workbench updates from the dirty workspace
- add workbench tests and remote-job/claims documentation
- rebase the work on current main after the merged validation/report PRs
- package the `web_workbench` module, static assets, and console script so the wheel actually contains the workbench

## Validation
- `python3 -m pytest tests/test_web_workbench.py tests/test_tensor_logic_core.py -q` (`62 passed`)
- `python3 -m pytest tests/test_packaging_ci.py tests/test_web_workbench.py tests/test_tensor_logic_core.py::TensorLogicCoreTest::test_web_workbench_sample_is_valid_tl -q` (`18 passed`)
- GitHub Actions `CI` succeeded on head `aaf0fe2`

## Notes
Recovered local work is now connector-published, the packaging blocker found during review is fixed, and CI is green.