### PR TITLE
[codex] Narrow Tensor Logic public API boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ Beyond the headline demos, the repo also contains `experiments/exp1`–`exp54` a
 
 `tensor_logic/` is the first reusable extraction from the experiment arc: a small named-index language layer, dense/sparse closure, binary Datalog-style rule joins, stratified negation, provenance proof trees, and a few semiring helpers. New experiments should import from this package rather than copying logic out of older `exp*.py` files.
 
+## Public API
+
+The supported root import surface is intentionally narrow and mirrors
+`tensor_logic.core`: `Domain`, `Relation`, `Program`, `FactSource`, proof
+types/functions, proof-result formatting, closure helpers, `evaluate_expr`,
+and `facts`. Adapter helpers for file loading, CLI/HTTP execution, repo import
+graphs, proof-tree viewing, legacy graph-dict rules, and research utilities are
+module-scoped rather than root API. See `docs/PUBLIC_API.md`.
+
+Proof and query boundaries are currently binary even though the canonical
+`Atom.args` representation is variadic. CLI/HTTP proof/query adapters and
+legacy graph-dict rule evaluation support `relation(arg0, arg1)` goals only;
+future higher-arity proof/query support should land as a focused arity slice.
+
 ## Memos & writing
 
 | File | What it is |

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -1,0 +1,76 @@
+# Tensor Logic Public API
+
+`tensor_logic` now treats the package root as the supported import surface for
+the reusable semantics layer. It mirrors `tensor_logic.core` and intentionally
+excludes local adapters, repo-graph helpers, legacy graph-dict evaluators, and
+research utilities.
+
+## Supported root exports
+
+These names are supported from both `tensor_logic` and `tensor_logic.core`:
+
+- Data model: `Domain`, `Relation`, `Program`, `FactSource`.
+- Proof model: `Proof`, `NegativeProof`.
+- Proof functions: `prove`, `prove_negative`, `prove_with_do`,
+  `prove_binary_relation_result`, `format_proof_result`.
+- Tensor/relation helpers: `bfs_query`, `bfs_per_source_closure`,
+  `dense_closure`, `evaluate_expr`, `facts`.
+
+`tensor_logic.__all__` is the contract for wildcard imports and public root
+exports.
+
+## Module-scoped helpers
+
+The following helpers are useful, but they are not part of the supported root
+API. Import them from their owning modules when a caller really needs them:
+
+- Rule representation helpers: `tensor_logic.program.Atom`,
+  `tensor_logic.program.Rule`.
+- File, CLI, and HTTP adapters: `tensor_logic.file_format.load_tl`,
+  `tensor_logic.execution.execute_command`,
+  `tensor_logic.http_api.ingest_python_source`,
+  `tensor_logic.http_api.prove_source`, `tensor_logic.http_api.query_source`,
+  `tensor_logic.http_api.run_source`, `tensor_logic.http_api.serve`.
+- Python import-graph adapters: `tensor_logic.ingest.PythonImportGraph`,
+  `tensor_logic.ingest.ingest_python`,
+  `tensor_logic.ingest.render_python_imports_tl`,
+  `tensor_logic.repo_graph_view.RepoGraphData`,
+  `tensor_logic.repo_graph_view.dependency_report`,
+  `tensor_logic.repo_graph_view.load_repo_graph`.
+- Legacy graph-dict rule/provenance helpers:
+  `tensor_logic.rules.parse_rule`, `tensor_logic.rules.evaluate_rule`,
+  `tensor_logic.rules.query_relation`,
+  `tensor_logic.provenance.evaluate_with_provenance`,
+  `tensor_logic.provenance.fmt_proof`,
+  `tensor_logic.provenance.proof_score`.
+- Proof tree rendering helpers: `tensor_logic.proofs.fmt_proof_tree`,
+  `tensor_logic.proofs.fmt_negative_proof_tree`,
+  `tensor_logic.proof_tree_viewer.ProofTreeNode`,
+  `tensor_logic.proof_tree_viewer.build_proof_tree_view`,
+  `tensor_logic.proof_tree_viewer.render_proof_tree`.
+- Research-only utilities: `tensor_logic.research`.
+
+Some old root-level helper imports are still resolved lazily for compatibility,
+but they are not listed in `__all__` and should not be expanded as public API.
+
+## Rule and proof boundaries
+
+`tensor_logic.program.Atom` is the canonical rule atom shape and stores
+`args: tuple[str, ...]`, so the representation itself is variadic. Keep that
+shape when adding future arity work.
+
+The current proof and query boundaries are still binary:
+
+- `prove`, `prove_negative`, `prove_with_do`, and
+  `prove_binary_relation_result` operate on `relation(arg0, arg1)` goals.
+- `Proof.head` and `NegativeProof.head` are triples:
+  `(relation_name, arg0, arg1)`.
+- CLI and HTTP query/proof adapters validate exactly two query/proof args.
+- Legacy `<tl_rule ...>` parsing and graph-dict evaluation in
+  `tensor_logic.rules` only support binary atom syntax and binary relation
+  tensors.
+- `Atom.left` and `Atom.right` are binary convenience properties. Use
+  `Atom.args` at shared rule boundaries.
+
+Expanding proofs, query adapters, or legacy graph-dict rule evaluation beyond
+binary relations should be a dedicated arity slice with focused tests.

--- a/tensor_logic/__init__.py
+++ b/tensor_logic/__init__.py
@@ -1,66 +1,57 @@
-"""Reusable tensor-logic substrate pieces."""
+"""Supported root import surface for Tensor Logic.
 
-from .closure import bfs_query, bfs_per_source_closure, dense_closure
-from .language import Domain, Relation, evaluate_expr, facts
-from .program import Program, FactSource
-from .file_format import load_tl
-from .execution import execute_command
-from .http_api import ingest_python_source, prove_source, query_source, run_source, serve
-from .ingest import PythonImportGraph, ingest_python, render_python_imports_tl
-from .proof_result import format_proof_result, prove_binary_relation_result
-from .proofs import fmt_proof_tree, fmt_negative_proof_tree, prove, prove_negative, prove_with_do, Proof, NegativeProof
-from .proof_tree_viewer import ProofTreeNode, build_proof_tree_view, render_proof_tree
-from .provenance import evaluate_with_provenance, fmt_proof, proof_score
-from .repo_graph_view import RepoGraphData, dependency_report, load_repo_graph
-from .rules import (
-    Atom,
-    Rule,
-    evaluate_rule,
-    parse_rule,
-    query_relation,
-)
+The package root intentionally mirrors ``tensor_logic.core``. Adapter,
+research, repo-graph, and legacy graph-dict helpers remain importable from
+their owning modules. A small lazy compatibility layer below keeps older
+``from tensor_logic import ...`` callers working without treating those names
+as supported public exports.
+"""
 
-__all__ = [
-    "Atom",
-    "Domain",
-    "Relation",
-    "Rule",
-    "Program",
-    "FactSource",
-    "PythonImportGraph",
-    "ProofTreeNode",
-    "RepoGraphData",
-    "Proof",
-    "NegativeProof",
-    "bfs_query",
-    "bfs_per_source_closure",
-    "dense_closure",
-    "evaluate_rule",
-    "evaluate_expr",
-    "evaluate_with_provenance",
-    "execute_command",
-    "facts",
-    "fmt_proof_tree",
-    "fmt_negative_proof_tree",
-    "format_proof_result",
-    "prove_binary_relation_result",
-    "load_tl",
-    "ingest_python",
-    "ingest_python_source",
-    "render_python_imports_tl",
-    "run_source",
-    "query_source",
-    "prove_source",
-    "serve",
-    "build_proof_tree_view",
-    "render_proof_tree",
-    "load_repo_graph",
-    "dependency_report",
-    "prove",
-    "prove_negative",
-    "prove_with_do",
-    "fmt_proof",
-    "parse_rule",
-    "proof_score",
-    "query_relation",
-]
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+from .core import *  # noqa: F403
+from .core import __all__ as _CORE_ALL
+
+__all__ = list(_CORE_ALL)
+
+_INTERNAL_COMPAT_EXPORTS = {
+    "Atom": ("tensor_logic.program", "Atom"),
+    "Rule": ("tensor_logic.program", "Rule"),
+    "PythonImportGraph": ("tensor_logic.ingest", "PythonImportGraph"),
+    "ProofTreeNode": ("tensor_logic.proof_tree_viewer", "ProofTreeNode"),
+    "RepoGraphData": ("tensor_logic.repo_graph_view", "RepoGraphData"),
+    "evaluate_rule": ("tensor_logic.rules", "evaluate_rule"),
+    "evaluate_with_provenance": ("tensor_logic.provenance", "evaluate_with_provenance"),
+    "execute_command": ("tensor_logic.execution", "execute_command"),
+    "fmt_proof_tree": ("tensor_logic.proofs", "fmt_proof_tree"),
+    "fmt_negative_proof_tree": ("tensor_logic.proofs", "fmt_negative_proof_tree"),
+    "load_tl": ("tensor_logic.file_format", "load_tl"),
+    "ingest_python": ("tensor_logic.ingest", "ingest_python"),
+    "ingest_python_source": ("tensor_logic.http_api", "ingest_python_source"),
+    "render_python_imports_tl": ("tensor_logic.ingest", "render_python_imports_tl"),
+    "run_source": ("tensor_logic.http_api", "run_source"),
+    "query_source": ("tensor_logic.http_api", "query_source"),
+    "prove_source": ("tensor_logic.http_api", "prove_source"),
+    "serve": ("tensor_logic.http_api", "serve"),
+    "build_proof_tree_view": ("tensor_logic.proof_tree_viewer", "build_proof_tree_view"),
+    "render_proof_tree": ("tensor_logic.proof_tree_viewer", "render_proof_tree"),
+    "load_repo_graph": ("tensor_logic.repo_graph_view", "load_repo_graph"),
+    "dependency_report": ("tensor_logic.repo_graph_view", "dependency_report"),
+    "fmt_proof": ("tensor_logic.provenance", "fmt_proof"),
+    "parse_rule": ("tensor_logic.rules", "parse_rule"),
+    "proof_score": ("tensor_logic.provenance", "proof_score"),
+    "query_relation": ("tensor_logic.rules", "query_relation"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    target = _INTERNAL_COMPAT_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attr_name = target
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    return value

--- a/tensor_logic/core.py
+++ b/tensor_logic/core.py
@@ -1,7 +1,7 @@
-"""Narrow import surface for Tensor Logic semantics (programs, proofs, closure).
+"""Supported import surface for Tensor Logic semantics.
 
-Use this when you want programmatic access without HTTP, ingest, or repo-graph
-adapters. The package root ``tensor_logic`` still re-exports the full toolkit.
+Use this surface, or the equivalent package root ``tensor_logic``, when you
+want programmatic access without HTTP, ingest, repo-graph, or research helpers.
 """
 
 from .closure import bfs_query, bfs_per_source_closure, dense_closure

--- a/tensor_logic/program.py
+++ b/tensor_logic/program.py
@@ -21,11 +21,19 @@ class Atom:
 
     @property
     def left(self) -> str:
-        return self.args[0]
+        return self._require_binary_args()[0]
 
     @property
     def right(self) -> str:
-        return self.args[1]
+        return self._require_binary_args()[1]
+
+    def _require_binary_args(self) -> tuple[str, str]:
+        if len(self.args) != 2:
+            raise ValueError(
+                f"Atom.left/right are only defined for binary atoms; "
+                f"{self.relation} has {len(self.args)} args"
+            )
+        return self.args[0], self.args[1]
 
 
 @dataclass(frozen=True)

--- a/tensor_logic/proof_result.py
+++ b/tensor_logic/proof_result.py
@@ -34,7 +34,7 @@ def prove_binary_relation_result(
     why_not: bool = False,
     format_type: str = "tree",
 ) -> dict[str, Any]:
-    """Run ``prove`` / optional ``prove_negative`` and format; shared by CLI and HTTP adapters."""
+    """Run and format proof results for binary proof/query adapter boundaries."""
     proof = prove(program, relation, arg0, arg1, recursive=recursive)
     if proof is not None:
         return format_proof_result(proof=proof, format_type=format_type)

--- a/tensor_logic/proofs.py
+++ b/tensor_logic/proofs.py
@@ -44,6 +44,12 @@ class NegativeProof:
 def prove(program: Program, relation_name: str, src: str, dst: str,
           recursive: bool = False, _table: dict | None = None,
           _do: dict | None = None) -> Proof | None:
+    """Return a proof for a binary relation goal ``relation_name(src, dst)``.
+
+    ``Program`` and ``Atom.args`` can represent other arities, but this proof
+    engine currently formats proof heads as ``(relation, src, dst)`` triples
+    and only evaluates binary body atoms.
+    """
     if relation_name not in program.relations:
         raise ValueError(f"relation '{relation_name}' not defined")
     relation = program.relations[relation_name]
@@ -79,6 +85,7 @@ def prove_negative(program: Program, relation_name: str, src: str, dst: str,
                    recursive: bool = False,
                    _table: dict | None = None,
                    _neg_table: dict | None = None) -> NegativeProof | None:
+    """Return a negative proof for a binary relation goal when one is known."""
     if relation_name not in program.relations:
         raise ValueError(f"relation '{relation_name}' not defined")
     relation = program.relations[relation_name]
@@ -308,7 +315,7 @@ def _try_prove_body_atoms(program: Program, atoms: tuple[Atom, ...], bindings: d
 def prove_with_do(program: Program, relation_name: str, src: str, dst: str,
                   do: dict[tuple[str, str, str], float],
                   recursive: bool = False) -> Proof | None:
-    """prove() under Pearl do()-interventions.
+    """prove() under Pearl do()-interventions for binary relation goals.
 
     do: {(relation_name, src, dst): value} — each entry asserts the fact at
     the given value and severs all rule derivations that would re-derive it.

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,66 @@
+import pytest
+
+import tensor_logic
+from tensor_logic import core
+from tensor_logic.program import Atom
+
+
+def test_package_root_exports_supported_core_api_only():
+    assert tensor_logic.__all__ == core.__all__
+    assert set(tensor_logic.__all__) == {
+        "Domain",
+        "Relation",
+        "Program",
+        "FactSource",
+        "Proof",
+        "NegativeProof",
+        "prove",
+        "prove_negative",
+        "prove_with_do",
+        "prove_binary_relation_result",
+        "format_proof_result",
+        "bfs_query",
+        "bfs_per_source_closure",
+        "dense_closure",
+        "evaluate_expr",
+        "facts",
+    }
+
+
+def test_supported_root_exports_are_importable():
+    for name in tensor_logic.__all__:
+        assert getattr(tensor_logic, name) is getattr(core, name)
+
+
+def test_wildcard_import_excludes_adapter_and_research_helpers():
+    namespace: dict[str, object] = {}
+    exec("from tensor_logic import *", namespace)
+
+    assert "Program" in namespace
+    assert "prove" in namespace
+    assert "execute_command" not in namespace
+    assert "load_tl" not in namespace
+    assert "parse_rule" not in namespace
+    assert "evaluate_with_provenance" not in namespace
+
+
+def test_module_scoped_helpers_remain_available_at_owning_modules():
+    from tensor_logic.execution import execute_command
+    from tensor_logic.file_format import load_tl
+    from tensor_logic.rules import evaluate_rule, parse_rule, query_relation
+
+    assert callable(execute_command)
+    assert callable(load_tl)
+    assert callable(parse_rule)
+    assert callable(evaluate_rule)
+    assert callable(query_relation)
+
+
+def test_atom_args_are_variadic_but_left_right_are_binary_only():
+    atom = Atom("ternary", ("x", "y", "z"))
+
+    assert atom.args == ("x", "y", "z")
+    with pytest.raises(ValueError, match="only defined for binary atoms"):
+        _ = atom.left
+    with pytest.raises(ValueError, match="only defined for binary atoms"):
+        _ = atom.right

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -3,25 +3,20 @@ import unittest
 import torch
 
 from tensor_logic import (
-    Atom,
     Domain,
     Program,
     Relation,
-    Rule,
     bfs_per_source_closure,
     bfs_query,
     dense_closure,
-    evaluate_rule,
-    evaluate_with_provenance,
-    parse_rule,
-    proof_score,
-    query_relation,
-    load_tl,
     prove,
     prove_negative,
-    fmt_negative_proof_tree,
-    fmt_proof_tree,
 )
+from tensor_logic.file_format import load_tl
+from tensor_logic.program import Atom, Rule
+from tensor_logic.proofs import fmt_negative_proof_tree, fmt_proof_tree
+from tensor_logic.provenance import evaluate_with_provenance, proof_score
+from tensor_logic.rules import evaluate_rule, parse_rule, query_relation
 from tensor_logic.semirings import gf2_matmul
 
 
@@ -868,7 +863,7 @@ class TensorLogicCoreTest(unittest.TestCase):
 
 
     def test_execute_command_returns_query_output(self):
-        from tensor_logic import execute_command
+        from tensor_logic.execution import execute_command
         from tensor_logic.file_format import Command
         from tensor_logic.program import Program
 
@@ -881,7 +876,7 @@ class TensorLogicCoreTest(unittest.TestCase):
         self.assertEqual(result.text, "edge(a, b) = True")
 
     def test_execute_command_returns_proof_output(self):
-        from tensor_logic import execute_command
+        from tensor_logic.execution import execute_command
         from tensor_logic.file_format import Command
         from tensor_logic.program import Program
 
@@ -895,7 +890,7 @@ class TensorLogicCoreTest(unittest.TestCase):
 
     def test_execute_command_returns_json_proof_output(self):
         import json
-        from tensor_logic import execute_command
+        from tensor_logic.execution import execute_command
         from tensor_logic.file_format import Command
         from tensor_logic.program import Program
 
@@ -908,7 +903,7 @@ class TensorLogicCoreTest(unittest.TestCase):
         self.assertEqual(json.loads(result.text)["proof"]["head"], ["edge", "a", "b"])
 
     def test_execute_command_returns_negative_proof_output_when_requested(self):
-        from tensor_logic import execute_command
+        from tensor_logic.execution import execute_command
         from tensor_logic.file_format import Command
         from tensor_logic.program import Program
 


### PR DESCRIPTION
## Summary

- Narrow the package-root public export contract to the supported `tensor_logic.core` surface while keeping old helper imports as lazy compatibility aliases.
- Add `docs/PUBLIC_API.md` and README notes that mark supported root exports versus module-scoped adapter/research/legacy helpers.
- Document binary proof/query boundaries and guard `Atom.left`/`Atom.right` so variadic `Atom.args` remains the shared rule shape.
- Add focused public API import tests and update core tests to import module-scoped helpers from their owning modules.

## Validation

- `python3 -m pytest tests/test_public_api.py -q` -> 5 passed
- `python3 -m pytest tests/test_proof_recursion.py tests/test_reason.py tests/test_tensor_logic_core.py -q` -> 66 passed

Linear: SYM-282