### PR TITLE
[codex] Enforce exp87 OOD margin gate

### DIFF
--- a/experiments/exp87_support_eval.py
+++ b/experiments/exp87_support_eval.py
@@ -362,6 +362,17 @@ def run_evaluation(config: EvalConfig, output_path: Path | None = None) -> dict[
         raise RuntimeError("TL deterministic label accuracy fell below 100%")
     if not bool(gates["tl_counterfactual_retraction_accuracy_100"]["passed"]):
         raise RuntimeError("TL counterfactual retraction accuracy fell below 100%")
+    ood_margin_gate = gates["tl_ood_margin_vs_best_neural_at_least_10pp"]
+    if not bool(ood_margin_gate["passed"]):
+        failed_splits = []
+        for split, split_gate in ood_margin_gate["splits"].items():
+            if not bool(split_gate["passed"]):
+                failed_splits.append(
+                    f"{split}: margin={float(split_gate['margin']):.3f}, "
+                    f"threshold={float(ood_margin_gate['threshold']):.3f}"
+                )
+        details = "; ".join(failed_splits) if failed_splits else "no split details available"
+        raise RuntimeError(f"TL OOD margin vs best neural fell below 10pp ({details})")
 
     results = {
         "experiment": "exp87_support_eval",

--- a/tests/test_exp87_support_eval.py
+++ b/tests/test_exp87_support_eval.py
@@ -1,5 +1,8 @@
 import json
 
+import pytest
+
+import experiments.exp87_support_eval as exp87
 from experiments.exp87_support_eval import EvalConfig, make_splits, run_evaluation
 
 
@@ -39,3 +42,64 @@ def test_run_evaluation_writes_expected_results_schema(tmp_path):
     assert gates["tl_deterministic_label_accuracy_100"]["passed"] is True
     assert gates["tl_counterfactual_retraction_accuracy_100"]["passed"] is True
     assert set(gates["tl_ood_margin_vs_best_neural_at_least_10pp"]["splits"]) == {"larger_ood", "deeper_ood"}
+
+
+def test_run_evaluation_raises_when_ood_margin_gate_fails(monkeypatch, tmp_path):
+    output = tmp_path / "results.json"
+    config = EvalConfig(quick=True, train_scenes=2, eval_scenes=1, epochs=1, hidden_dim=8)
+
+    def fake_train_and_eval_baselines(train, eval_splits, config):
+        del train, config
+        baseline = {"loss_start": 0.0, "loss_end": 0.0}
+        for split, scenes in eval_splits.items():
+            total = sum(len(scene["objects"]) for scene in scenes)
+            baseline[split] = {"accuracy": 1.0, "correct": total, "total": total}
+        return {"mlp": dict(baseline), "deepsets": dict(baseline), "metadata": {"max_objects": 8}}
+
+    def fake_build_gates(tl, baselines):
+        del tl, baselines
+        return {
+            "tl_deterministic_label_accuracy_100": {
+                "passed": True,
+                "accuracy": 1.0,
+                "correct": 1,
+                "total": 1,
+                "threshold": 1.0,
+            },
+            "tl_counterfactual_retraction_accuracy_100": {
+                "passed": True,
+                "accuracy": 1.0,
+                "correct": 1,
+                "total": 1,
+                "threshold": 1.0,
+            },
+            "tl_ood_margin_vs_best_neural_at_least_10pp": {
+                "passed": False,
+                "threshold": 0.10,
+                "splits": {
+                    "larger_ood": {
+                        "tl_accuracy": 1.0,
+                        "best_neural": "mlp",
+                        "best_neural_accuracy": 0.95,
+                        "margin": 0.05,
+                        "passed": False,
+                    },
+                    "deeper_ood": {
+                        "tl_accuracy": 1.0,
+                        "best_neural": "deepsets",
+                        "best_neural_accuracy": 0.85,
+                        "margin": 0.15,
+                        "passed": True,
+                    },
+                },
+            },
+            "v1_passed": False,
+        }
+
+    monkeypatch.setattr(exp87, "_train_and_eval_baselines", fake_train_and_eval_baselines)
+    monkeypatch.setattr(exp87, "_build_gates", fake_build_gates)
+
+    with pytest.raises(RuntimeError, match=r"OOD margin.*larger_ood.*margin=0\.050.*threshold=0\.100"):
+        run_evaluation(config, output_path=output)
+
+    assert not output.exists()


### PR DESCRIPTION
## Summary

Raises when exp87 OOD margin gates fail and adds a negative-path test where deterministic and counterfactual gates pass but OOD margin fails.

## Impact

Prevents falsified exp87 results from exiting successfully.

## Validation

```bash
python3 -m pytest tests/test_exp87_support_eval.py -v
```

Wave I branch: `codex/100x-impl-tensor-logic-exp87-ood-gate`
Commit: `fa472ad43a78e8cbe64587bc4fb97c242302958f`

Opened as draft for review; no deploys, merges, or tracker mutations were performed.