### PR TITLE
Add executable validation tier registry

### DIFF
--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,8 +1,31 @@
 # Validation Matrix
 
-Use this matrix to choose the cheapest proof that matches the change. The default
-validation path must stay local, CPU-friendly, and free of package-download,
-model-download, GPU, remote-job, or external FAFSA/ISIR data requirements.
+Use the parseable registry at
+[`docs/validation-registry.json`](validation-registry.json) as the source of
+truth for change classes, validation tiers, command selection, costs, and non-CI
+boundaries. This page is the human guide to the same policy.
+
+The default validation path must stay local, CPU-friendly, and free of
+package-download, model-download, GPU, remote-job, or external FAFSA/ISIR data
+requirements.
+
+## Change Classes
+
+Agents should select the smallest sufficient proof from the registry's
+`change_classes` map:
+
+| Change class | Registry tiers |
+| --- | --- |
+| `docs-only` | `packaging-ci` |
+| `validation-policy` | `packaging-ci`, then `full-ci` |
+| `packaging` | `packaging-ci`, `import-proof`, then `full-ci` |
+| `code-index` | `code-index`, then `packaging-ci` |
+| `tensor-logic-core` | `code-index`, then `full-ci` |
+| `demo` | `demo-smoke`, then `full-ci` |
+| `lm-or-training-experiment` | `heavy-experiment` only |
+
+Do not duplicate or reinterpret the full policy here when changing it. Update
+the registry first, then keep this page aligned with the registry.
 
 ## Canonical CI Validation
 
@@ -22,10 +45,11 @@ python3 -m pip install -e ".[dev]"
 python3 -m pytest tests/ -v
 ```
 
-For documentation, packaging, or validation-boundary changes, this narrower proof
-is the canonical cheap preflight before the full test tree:
+For documentation, packaging, or validation-boundary changes, the registry tier
+`packaging-ci` defines this canonical cheap preflight before the full test tree:
 
 ```bash
+python -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v
 python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v
 python3 -m pytest tests/ -v
 ```
@@ -54,11 +78,13 @@ The structured API index is local tooling for agent planning. It writes
 python tools/code_index.py --status
 python tools/code_index.py --lookup Program
 python tools/code_index.py --rebuild
+python tools/code_index.py --validation-registry
 ```
 
 Use `--lookup <RelevantSymbol>` before planning changes that touch
 `tensor_logic/`. Rebuild the index only when it is stale or a validation command
-needs a fresh index.
+needs a fresh index. Use `--validation-registry` to locate the parseable
+validation tier registry.
 
 ## Lightweight Build/Import Proof
 

--- a/docs/validation-registry.json
+++ b/docs/validation-registry.json
@@ -1,0 +1,225 @@
+{
+  "version": 1,
+  "description": "Machine-readable validation policy for tensor-logic workers.",
+  "default_policy": {
+    "select": "smallest-sufficient-proof",
+    "default_ci_tier": "full-ci",
+    "local_constraints": [
+      "cpu-friendly",
+      "no package-download experiments",
+      "no model downloads",
+      "no GPU-only execution",
+      "no remote jobs",
+      "no external FAFSA/ISIR datasets"
+    ],
+    "expected_cheap_artifacts": [
+      "tools/index.json"
+    ]
+  },
+  "tiers": {
+    "full-ci": {
+      "title": "Canonical CI validation",
+      "cost": "cheap",
+      "ci": true,
+      "heavyweight": false,
+      "commands": [
+        "python -m pip install -e \".[dev]\"",
+        "python -m pytest tests/ -v"
+      ],
+      "fallback_commands": [
+        "python3 -m pip install -e \".[dev]\"",
+        "python3 -m pytest tests/ -v"
+      ],
+      "boundaries": [
+        "deterministic unit and smoke tests only",
+        "no remote services",
+        "no external datasets",
+        "no model downloads",
+        "no GPU-only training"
+      ]
+    },
+    "packaging-ci": {
+      "title": "Packaging and validation-boundary preflight",
+      "cost": "cheap",
+      "ci": true,
+      "heavyweight": false,
+      "commands": [
+        "python -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v"
+      ],
+      "fallback_commands": [
+        "python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v"
+      ],
+      "boundaries": [
+        "no remote services",
+        "no external datasets",
+        "no model downloads",
+        "no GPU-only training"
+      ]
+    },
+    "code-index": {
+      "title": "Structured API index",
+      "cost": "cheap",
+      "ci": true,
+      "heavyweight": false,
+      "commands": [
+        "python tools/code_index.py --status",
+        "python tools/code_index.py --lookup Program",
+        "python tools/code_index.py --rebuild",
+        "python tools/code_index.py --validation-registry"
+      ],
+      "artifacts": [
+        "tools/index.json"
+      ],
+      "boundaries": [
+        "local AST parsing only",
+        "writes only gitignored tools/index.json"
+      ]
+    },
+    "import-proof": {
+      "title": "Editable install and import proof",
+      "cost": "cheap",
+      "ci": false,
+      "heavyweight": false,
+      "commands": [
+        "python -m pip install -e \".[dev]\"",
+        "python -c \"import tensor_logic; from tensor_logic import Program; print('tensor_logic import ok')\""
+      ],
+      "fallback_commands": [
+        "python3 -m pip install -e \".[dev]\"",
+        "python3 -c \"import tensor_logic; from tensor_logic import Program; print('tensor_logic import ok')\""
+      ],
+      "boundaries": [
+        "no wheel build",
+        "no demos",
+        "no remote services",
+        "no model downloads"
+      ]
+    },
+    "demo-smoke": {
+      "title": "Demo smoke commands",
+      "cost": "medium",
+      "ci": false,
+      "heavyweight": false,
+      "commands": [
+        "uv run --with torch python demos/transitive_closure.py",
+        "uv run --with torch python demos/tensor_language.py",
+        "uv run --with torch python demos/program_rules.py",
+        "uv run --with torch python demos/provenance_kb.py"
+      ],
+      "boundaries": [
+        "non-CI",
+        "run only when examples, demos, or tensor-language ergonomics changed"
+      ]
+    },
+    "heavy-experiment": {
+      "title": "Heavyweight and remote experiments",
+      "cost": "heavy",
+      "ci": false,
+      "heavyweight": true,
+      "commands": [],
+      "requires_explicit_work_order": true,
+      "boundaries": [
+        "non-CI",
+        "may require Hugging Face, MLX, Kaggle, Colab, Modal, or other remote/provider artifacts",
+        "may require GPU/MPS training, long sweeps, or batch experiment runners",
+        "may download external packages for import-graph benchmarks",
+        "may require official or private FAFSA/ISIR validation datasets"
+      ],
+      "record_required": [
+        "command",
+        "dependency set",
+        "runtime location",
+        "input dataset/model references",
+        "output path",
+        "blockers"
+      ]
+    }
+  },
+  "change_classes": {
+    "docs-only": {
+      "description": "Documentation-only changes that do not alter validation policy.",
+      "tiers": [
+        "packaging-ci"
+      ]
+    },
+    "validation-policy": {
+      "description": "Validation docs, registry, CI packaging tests, or validation-boundary edits.",
+      "tiers": [
+        "packaging-ci",
+        "full-ci"
+      ]
+    },
+    "packaging": {
+      "description": "pyproject metadata, dependency groups, editable install contract, or import surface.",
+      "tiers": [
+        "packaging-ci",
+        "import-proof",
+        "full-ci"
+      ]
+    },
+    "code-index": {
+      "description": "Structured API index tooling or tests.",
+      "tiers": [
+        "code-index",
+        "packaging-ci"
+      ]
+    },
+    "tensor-logic-core": {
+      "description": "Reusable tensor_logic package behavior.",
+      "tiers": [
+        "code-index",
+        "full-ci"
+      ]
+    },
+    "demo": {
+      "description": "Demo scripts or research-facing examples.",
+      "tiers": [
+        "demo-smoke",
+        "full-ci"
+      ]
+    },
+    "lm-or-training-experiment": {
+      "description": "LM/VLM inference, SFT, long training, GPU/MPS, remote, or external data experiments.",
+      "tiers": [
+        "heavy-experiment"
+      ]
+    }
+  },
+  "dependency_boundaries": {
+    "ci_allowed_extras": [
+      "dev"
+    ],
+    "non_ci_extras": {
+      "lm": {
+        "packages": [
+          "transformers"
+        ],
+        "reason": "local LM-backed experiments; may download models"
+      },
+      "sft": {
+        "packages": [
+          "transformers",
+          "peft",
+          "datasets",
+          "accelerate"
+        ],
+        "reason": "LoRA/SFT training and evaluation; download/GPU/remote candidate"
+      },
+      "science": {
+        "packages": [
+          "scipy"
+        ],
+        "reason": "scientific helpers; non-CI unless promoted by a future issue"
+      }
+    },
+    "non_ci_local_only_packages": [
+      "mlx-lm",
+      "networkx",
+      "sqlalchemy",
+      "django",
+      "fastapi",
+      "sympy",
+      "scikit-learn"
+    ]
+  }
+}

--- a/docs/validation-registry.json
+++ b/docs/validation-registry.json
@@ -67,6 +67,12 @@
         "python tools/code_index.py --rebuild",
         "python tools/code_index.py --validation-registry"
       ],
+      "fallback_commands": [
+        "python3 tools/code_index.py --status",
+        "python3 tools/code_index.py --lookup Program",
+        "python3 tools/code_index.py --rebuild",
+        "python3 tools/code_index.py --validation-registry"
+      ],
       "artifacts": [
         "tools/index.json"
       ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,6 @@ include = ["tensor_logic*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.tensor-logic.validation]
+registry = "docs/validation-registry.json"

--- a/tests/test_code_index.py
+++ b/tests/test_code_index.py
@@ -17,6 +17,7 @@ def test_validation_doc_documents_code_index_commands():
     assert "python tools/code_index.py --status" in validation
     assert "python tools/code_index.py --lookup Program" in validation
     assert "python tools/code_index.py --rebuild" in validation
+    assert "python tools/code_index.py --validation-registry" in validation
     assert "`tools/index.json`" in validation
 
 
@@ -174,3 +175,12 @@ def test_cli_lookup_missing_exits_1():
     )
     assert result.returncode == 1
     assert "symbol not found" in result.stderr
+
+
+def test_cli_validation_registry_prints_registry_path():
+    result = subprocess.run(
+        [sys.executable, "tools/code_index.py", "--validation-registry"],
+        capture_output=True, text=True, cwd=str(REPO_ROOT)
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "docs/validation-registry.json"

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -148,6 +148,10 @@ def test_validation_registry_maps_change_classes_to_executable_tiers():
             assert "heavyweight" in tier
             if tier["ci"]:
                 assert tier["commands"], tier_name
+            if tier["cost"] == "cheap":
+                assert tier.get("fallback_commands"), tier_name
+                for command in tier["commands"]:
+                    assert command.replace("python ", "python3 ", 1) in tier["fallback_commands"]
 
 
 def test_validation_registry_encodes_non_ci_boundaries():

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import re
 import subprocess
 import sys
@@ -7,6 +8,7 @@ import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 VALIDATION_DOC = REPO_ROOT / "docs" / "VALIDATION.md"
+VALIDATION_REGISTRY = REPO_ROOT / "docs" / "validation-registry.json"
 
 
 def _requirement_names(requirements: list[str]) -> set[str]:
@@ -26,6 +28,10 @@ def test_pyproject_declares_worker_dev_install_contract():
     assert "torch" in dependencies
     assert {"pytest", "numpy", "matplotlib"} <= dev_dependencies
     assert "tensor_logic*" in package_include
+    assert (
+        pyproject["tool"]["tensor-logic"]["validation"]["registry"]
+        == "docs/validation-registry.json"
+    )
 
 
 def test_heavy_ml_dependencies_are_optional_not_default_ci():
@@ -95,9 +101,16 @@ def test_validation_doc_defines_local_tiers_and_boundaries():
     assert "python -m pytest tests/ -v" in validation
     assert 'python3 -m pip install -e ".[dev]"' in validation
     assert "python3 -m pytest tests/ -v" in validation
-    assert "python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v" in validation
+    registry = json.loads(VALIDATION_REGISTRY.read_text())
+    cheap_commands = (
+        registry["tiers"]["packaging-ci"]["commands"]
+        + registry["tiers"]["packaging-ci"]["fallback_commands"]
+    )
+    for command in cheap_commands:
+        assert command in validation
     assert "remote services, external datasets, model" in validation
     assert "External FAFSA/ISIR validation" in validation
+    assert "[`docs/validation-registry.json`](validation-registry.json)" in validation
 
 
 def test_validation_doc_maps_heavy_dependencies_outside_ci():
@@ -110,6 +123,62 @@ def test_validation_doc_maps_heavy_dependencies_outside_ci():
         assert extra in validation
 
     assert "Do not add `transformers`, `peft`, `datasets`, `accelerate`, `scipy`" in validation
+
+
+def test_validation_registry_maps_change_classes_to_executable_tiers():
+    registry = json.loads(VALIDATION_REGISTRY.read_text())
+
+    expected_change_classes = {
+        "docs-only",
+        "validation-policy",
+        "packaging",
+        "code-index",
+        "tensor-logic-core",
+        "demo",
+        "lm-or-training-experiment",
+    }
+    assert expected_change_classes <= registry["change_classes"].keys()
+
+    for change_class, metadata in registry["change_classes"].items():
+        assert metadata["tiers"], change_class
+        for tier_name in metadata["tiers"]:
+            tier = registry["tiers"][tier_name]
+            assert "cost" in tier
+            assert "ci" in tier
+            assert "heavyweight" in tier
+            if tier["ci"]:
+                assert tier["commands"], tier_name
+
+
+def test_validation_registry_encodes_non_ci_boundaries():
+    registry = json.loads(VALIDATION_REGISTRY.read_text())
+
+    heavy_tier = registry["tiers"]["heavy-experiment"]
+    assert heavy_tier["ci"] is False
+    assert heavy_tier["heavyweight"] is True
+    assert heavy_tier["requires_explicit_work_order"] is True
+    assert "command" in heavy_tier["record_required"]
+    assert any("FAFSA/ISIR" in boundary for boundary in heavy_tier["boundaries"])
+
+    dependency_boundaries = registry["dependency_boundaries"]
+    assert dependency_boundaries["ci_allowed_extras"] == ["dev"]
+    for extra in ["lm", "sft", "science"]:
+        assert extra in dependency_boundaries["non_ci_extras"]
+
+
+def test_validation_registry_matches_documented_cheap_commands():
+    registry = json.loads(VALIDATION_REGISTRY.read_text())
+    validation = VALIDATION_DOC.read_text()
+
+    cheap_tiers = [
+        tier
+        for tier in registry["tiers"].values()
+        if tier["cost"] == "cheap" and tier["commands"]
+    ]
+    assert cheap_tiers
+    for tier in cheap_tiers:
+        for command in tier["commands"]:
+            assert command in validation
 
 
 def test_lightweight_import_proof_runs_without_remote_or_gpu():

--- a/tools/code_index.py
+++ b/tools/code_index.py
@@ -7,6 +7,7 @@ Usage:
     python tools/code_index.py --lookup Schema
     python tools/code_index.py --dump
     python tools/code_index.py --status
+    python tools/code_index.py --validation-registry
 """
 from __future__ import annotations
 
@@ -22,6 +23,7 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SOURCE_DIR = _REPO_ROOT / "tensor_logic"
 _INDEX_PATH = Path(__file__).resolve().parent / "index.json"
+_VALIDATION_REGISTRY_PATH = _REPO_ROOT / "docs" / "validation-registry.json"
 
 
 def _extract_module(path: Path, module_prefix: str = "tensor_logic") -> dict:
@@ -167,6 +169,12 @@ def status(source_dir: Path = _SOURCE_DIR, index_path: Path = _INDEX_PATH) -> in
     return 0
 
 
+def validation_registry() -> int:
+    """Print the parseable validation registry path."""
+    print(_VALIDATION_REGISTRY_PATH.relative_to(_REPO_ROOT))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="tensor_logic/ code index")
     group = parser.add_mutually_exclusive_group(required=True)
@@ -174,6 +182,11 @@ def main(argv: list[str] | None = None) -> int:
     group.add_argument("--lookup", metavar="SYMBOL", help="Look up a symbol")
     group.add_argument("--dump", action="store_true", help="Print all symbols")
     group.add_argument("--status", action="store_true", help="Check staleness")
+    group.add_argument(
+        "--validation-registry",
+        action="store_true",
+        help="Print validation registry path",
+    )
     args = parser.parse_args(argv)
 
     if args.rebuild:
@@ -187,6 +200,8 @@ def main(argv: list[str] | None = None) -> int:
         return dump()
     if args.status:
         return status()
+    if args.validation_registry:
+        return validation_registry()
     return 0
 
 


### PR DESCRIPTION
## Summary
- add `docs/validation-registry.json` as parseable validation metadata mapping change classes to tiers, commands, costs, and CI/heavyweight boundaries
- point `pyproject.toml` and `docs/VALIDATION.md` at the registry as the source of truth
- expose the registry path through `tools/code_index.py --validation-registry`
- add tests that parse the registry and assert cheap command/doc consistency

## Validation
- `python -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v` failed locally because `python` is not installed in this shell
- `python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v` passed: 28 passed
