### PR TITLE
docs: add architecture review artifacts

### DIFF
--- a/docs/architecture/architecture-findings.json
+++ b/docs/architecture/architecture-findings.json
@@ -1,0 +1,49 @@
+{
+  "schema": "architecture-findings.v1",
+  "repo": "experiments",
+  "generated_at": "2026-05-12",
+  "notes": [
+    "Read AGENTS.md, CLAUDE.md, README.md, llm-tldr tree output, and sampled tensor_logic modules/tests.",
+    "No docs/adr directory was present.",
+    "No git blocker was reported by git status."
+  ],
+  "candidate_count": 3,
+  "candidates": [
+    {
+      "id": "rule-surface",
+      "title": "Make rule parsing and rule execution one deep Module",
+      "files": ["tensor_logic/program.py", "tensor_logic/rules.py", "tensor_logic/proofs.py", "tensor_logic/provenance.py", "tests/test_tensor_logic_core.py", "tests/test_reason.py"],
+      "problem": "The rule Interface is split across Program.rule(), RuleParser, tensor_logic.rules.parse_rule(), proof search, and provenance helpers. Callers need to know which grammar, arity rule, negation behavior, and evaluation path they are on, which makes the Modules shallow.",
+      "solution": "Create a single rule-front-end Module that owns parsing into one Rule representation, validates arity/negation/method calls once, and exposes adapters for tensor evaluation, proof search, and provenance.",
+      "benefits": "Locality improves because grammar and invariant changes stop spreading across Program, rules, proofs, and provenance. Leverage improves because callers get one Interface for the same domain concept.",
+      "test_impact": "Move parser, AST, proof, and provenance tests to the shared rule Interface, then keep adapter tests small.",
+      "risk": "Moderate: current experiments may depend on quirks of both grammars.",
+      "suggested_validation": "python -m pytest tests/test_tensor_logic_core.py tests/test_reason.py tests/test_proof_recursion.py -v",
+      "adr_conflict": null
+    },
+    {
+      "id": "proof-engine",
+      "title": "Deepen proof search around a proof engine seam",
+      "files": ["tensor_logic/proofs.py", "tensor_logic/proof_result.py", "tensor_logic/proof_tree_viewer.py", "tensor_logic/execution.py", "tensor_logic/http_api.py"],
+      "problem": "Positive proof, negative proof, recursive fallback, do-interventions, formatting, and API result shaping are coupled through direct function calls and shared assumptions about binary relations. The proof Module exposes many operational details as its Interface.",
+      "solution": "Introduce a proof engine Module whose Interface is goal + options -> typed proof result. Keep recursion strategy, witness enumeration, negative explanations, and do-intervention handling behind that seam.",
+      "benefits": "Locality improves for proof bugs because search tables, cycle guards, recursive fallbacks, and negative explanations live together. Leverage improves because CLI, HTTP, and web callers stop coordinating proof modes themselves.",
+      "test_impact": "Tests can assert proof result semantics through one Interface instead of private helper behavior.",
+      "risk": "Moderate: binary-only assumptions are entrenched in CLI and proof formatting.",
+      "suggested_validation": "python -m pytest tests/test_proof_recursion.py tests/test_reason.py tests/test_web_workbench.py -v",
+      "adr_conflict": null
+    },
+    {
+      "id": "experiment-harness",
+      "title": "Extract a reusable experiment harness from exp79-exp83 patterns",
+      "files": ["experiments/exp79_self_play_loop.py", "experiments/exp81_sweep.py", "experiments/exp81_optimize_rule_induction.py", "experiments/exp83_slot_attention.py", "tensor_logic/research/utils.py"],
+      "problem": "Experiment scripts carry their own config, caching, result writing, and validation conventions. The Interface of each script is nearly as complex as the Implementation, so results are harder to compare and reproduce.",
+      "solution": "Move common experiment lifecycle concerns into a research harness Module: config, deterministic seeding, result paths, quick/full modes, and metric summaries. Keep individual experiments focused on domain logic.",
+      "benefits": "Locality improves for artifact and sweep behavior. Leverage improves because a new experiment gets reproducible output and validation without copying boilerplate.",
+      "test_impact": "Add small harness tests plus keep representative experiment smoke tests.",
+      "risk": "Low to moderate: experiments are research code, so over-formalizing could slow iteration.",
+      "suggested_validation": "python -m pytest tests/test_exp79.py tests/test_exp81.py tests/test_exp83_slot_attention.py -v",
+      "adr_conflict": null
+    }
+  ]
+}

--- a/docs/architecture/index.html
+++ b/docs/architecture/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Architecture Reports</title></head>
+<body>
+  <h1>Architecture Reports</h1>
+  <ul>
+    <li><a href="report-2026-05-12.html">2026-05-12 Architecture Report</a></li>
+  </ul>
+</body>
+</html>

--- a/docs/architecture/linear-issue-candidates.md
+++ b/docs/architecture/linear-issue-candidates.md
@@ -1,0 +1,36 @@
+# Architecture Issue Candidates - 2026-05-12
+
+Do not implement yet. These are planning candidates from a read-only architecture review.
+
+## 1. Deepen the rule surface
+
+Files: `tensor_logic/program.py`, `tensor_logic/rules.py`, `tensor_logic/proofs.py`, `tensor_logic/provenance.py`
+
+Acceptance criteria:
+- One canonical Rule representation is used by parsing, tensor evaluation, proof search, and provenance adapters.
+- Existing Program rule examples still pass.
+- Parser tests cover arity, negation, disjunction, and expression methods.
+
+Validation: `python -m pytest tests/test_tensor_logic_core.py tests/test_reason.py tests/test_proof_recursion.py -v`
+
+## 2. Add a proof engine seam
+
+Files: `tensor_logic/proofs.py`, `tensor_logic/proof_result.py`, `tensor_logic/execution.py`, `tensor_logic/http_api.py`
+
+Acceptance criteria:
+- CLI, HTTP, and web paths call one proof engine Interface.
+- Positive, negative, recursive, and do-intervention proof modes keep current behavior.
+- Binary-relation limitations are explicit in the Interface.
+
+Validation: `python -m pytest tests/test_proof_recursion.py tests/test_reason.py tests/test_web_workbench.py -v`
+
+## 3. Extract experiment harness conventions
+
+Files: `experiments/exp79_self_play_loop.py`, `experiments/exp81_sweep.py`, `experiments/exp81_optimize_rule_induction.py`, `tensor_logic/research/`
+
+Acceptance criteria:
+- Common config/result/quick-mode behavior lives in a research harness Module.
+- Existing experiment outputs keep their file locations.
+- New harness tests prove deterministic result metadata.
+
+Validation: `python -m pytest tests/test_exp79.py tests/test_exp81.py -v`

--- a/docs/architecture/linear-issue-candidates.md
+++ b/docs/architecture/linear-issue-candidates.md
@@ -4,7 +4,7 @@ Do not implement yet. These are planning candidates from a read-only architectur
 
 ## 1. Deepen the rule surface
 
-Files: `tensor_logic/program.py`, `tensor_logic/rules.py`, `tensor_logic/proofs.py`, `tensor_logic/provenance.py`
+Files: `tensor_logic/program.py`, `tensor_logic/rules.py`, `tensor_logic/proofs.py`, `tensor_logic/provenance.py`, `tests/test_tensor_logic_core.py`, `tests/test_reason.py`
 
 Acceptance criteria:
 - One canonical Rule representation is used by parsing, tensor evaluation, proof search, and provenance adapters.
@@ -15,7 +15,7 @@ Validation: `python -m pytest tests/test_tensor_logic_core.py tests/test_reason.
 
 ## 2. Add a proof engine seam
 
-Files: `tensor_logic/proofs.py`, `tensor_logic/proof_result.py`, `tensor_logic/execution.py`, `tensor_logic/http_api.py`
+Files: `tensor_logic/proofs.py`, `tensor_logic/proof_result.py`, `tensor_logic/proof_tree_viewer.py`, `tensor_logic/execution.py`, `tensor_logic/http_api.py`
 
 Acceptance criteria:
 - CLI, HTTP, and web paths call one proof engine Interface.
@@ -26,11 +26,11 @@ Validation: `python -m pytest tests/test_proof_recursion.py tests/test_reason.py
 
 ## 3. Extract experiment harness conventions
 
-Files: `experiments/exp79_self_play_loop.py`, `experiments/exp81_sweep.py`, `experiments/exp81_optimize_rule_induction.py`, `tensor_logic/research/`
+Files: `experiments/exp79_self_play_loop.py`, `experiments/exp81_sweep.py`, `experiments/exp81_optimize_rule_induction.py`, `experiments/exp83_slot_attention.py`, `tensor_logic/research/utils.py`
 
 Acceptance criteria:
 - Common config/result/quick-mode behavior lives in a research harness Module.
 - Existing experiment outputs keep their file locations.
 - New harness tests prove deterministic result metadata.
 
-Validation: `python -m pytest tests/test_exp79.py tests/test_exp81.py -v`
+Validation: `python -m pytest tests/test_exp79.py tests/test_exp81.py tests/test_exp83_slot_attention.py -v`

--- a/docs/architecture/report-2026-05-12.html
+++ b/docs/architecture/report-2026-05-12.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Architecture Report - experiments - 2026-05-12</title>
+  <style>body{font-family:system-ui,sans-serif;max-width:980px;margin:40px auto;padding:0 24px;line-height:1.5}code{background:#f3f4f6;padding:2px 4px;border-radius:4px}.note{border-left:4px solid #b91c1c;padding:8px 12px;background:#fef2f2}.card{border:1px solid #ddd;border-radius:8px;padding:16px;margin:18px 0}h1,h2{line-height:1.2}</style>
+</head>
+<body>
+  <h1>Architecture Report: experiments</h1>
+  <p><strong>Date:</strong> 2026-05-12</p>
+  <p class="note"><strong>Do not implement yet.</strong> This Phase 1 report identifies deepening opportunities only. No production code was changed.</p>
+  <h2>Review Scope</h2>
+  <p>Read repo-local instructions, README, compact tree output, and sampled the reusable <code>tensor_logic</code> package, proof/search Modules, experiment scripts, and tests. No ADR conflicts were found.</p>
+  <p>The review uses the architecture vocabulary: Module, Interface, Implementation, Depth, Shallow, Seam, Adapter, Leverage, and Locality.</p>
+  <div class="card">
+    <h2>1. Make Rule Parsing And Rule Execution One Deep Module</h2>
+    <p><strong>Files:</strong> <code>tensor_logic/program.py</code>, <code>tensor_logic/rules.py</code>, <code>tensor_logic/proofs.py</code>, <code>tensor_logic/provenance.py</code></p>
+    <p><strong>Problem:</strong> The rule Interface is split across multiple grammars and execution paths. The caller must understand parser shape, arity limits, negation support, and proof compatibility.</p>
+    <p><strong>Solution:</strong> Deepen a rule-front-end Module with one Rule representation and adapters for tensor evaluation, proof search, and provenance.</p>
+    <p><strong>Benefits:</strong> Better Locality for grammar changes and higher Leverage for callers. The deletion test suggests the current split is shallow because deleting one parser would move complexity into another caller.</p>
+    <p><strong>Test Impact:</strong> Parser, AST, proof, and provenance behavior become testable through one Interface.</p>
+    <p><strong>Risk:</strong> Moderate; experiments may rely on quirks in both current grammars.</p>
+    <p><strong>Suggested Validation:</strong> <code>python -m pytest tests/test_tensor_logic_core.py tests/test_reason.py tests/test_proof_recursion.py -v</code></p>
+  </div>
+  <div class="card">
+    <h2>2. Deepen Proof Search Around A Proof Engine Seam</h2>
+    <p><strong>Files:</strong> <code>tensor_logic/proofs.py</code>, <code>tensor_logic/proof_result.py</code>, <code>tensor_logic/execution.py</code>, <code>tensor_logic/http_api.py</code></p>
+    <p><strong>Problem:</strong> Positive proof, negative proof, recursion, interventions, and formatting leak across callers. The Interface exposes much of the Implementation.</p>
+    <p><strong>Solution:</strong> Add a proof engine Module whose Interface is goal plus options to typed proof result. CLI, HTTP, and web become adapters.</p>
+    <p><strong>Benefits:</strong> Better Locality for proof bugs and more Leverage for external callers.</p>
+    <p><strong>Test Impact:</strong> Tests assert proof-result semantics through the proof engine seam.</p>
+    <p><strong>Risk:</strong> Moderate; binary-relation assumptions are widespread.</p>
+    <p><strong>Suggested Validation:</strong> <code>python -m pytest tests/test_proof_recursion.py tests/test_reason.py tests/test_web_workbench.py -v</code></p>
+  </div>
+  <div class="card">
+    <h2>3. Extract A Reusable Experiment Harness</h2>
+    <p><strong>Files:</strong> <code>experiments/exp79_self_play_loop.py</code>, <code>experiments/exp81_sweep.py</code>, <code>experiments/exp81_optimize_rule_induction.py</code>, <code>tensor_logic/research/</code></p>
+    <p><strong>Problem:</strong> Experiment scripts repeat lifecycle concerns, so each script's Interface is shallow and reproduction knowledge is scattered.</p>
+    <p><strong>Solution:</strong> Put config, deterministic seeding, result paths, quick/full modes, and metric summaries behind a research harness Module.</p>
+    <p><strong>Benefits:</strong> Higher Locality for run behavior and higher Leverage for future experiments.</p>
+    <p><strong>Test Impact:</strong> Harness tests can prove deterministic metadata; experiment tests stay focused.</p>
+    <p><strong>Risk:</strong> Low to moderate; keep the seam light because this is research code.</p>
+    <p><strong>Suggested Validation:</strong> <code>python -m pytest tests/test_exp79.py tests/test_exp81.py -v</code></p>
+  </div>
+</body>
+</html>

--- a/docs/architecture/report-2026-05-12.html
+++ b/docs/architecture/report-2026-05-12.html
@@ -14,7 +14,7 @@
   <p>The review uses the architecture vocabulary: Module, Interface, Implementation, Depth, Shallow, Seam, Adapter, Leverage, and Locality.</p>
   <div class="card">
     <h2>1. Make Rule Parsing And Rule Execution One Deep Module</h2>
-    <p><strong>Files:</strong> <code>tensor_logic/program.py</code>, <code>tensor_logic/rules.py</code>, <code>tensor_logic/proofs.py</code>, <code>tensor_logic/provenance.py</code></p>
+    <p><strong>Files:</strong> <code>tensor_logic/program.py</code>, <code>tensor_logic/rules.py</code>, <code>tensor_logic/proofs.py</code>, <code>tensor_logic/provenance.py</code>, <code>tests/test_tensor_logic_core.py</code>, <code>tests/test_reason.py</code></p>
     <p><strong>Problem:</strong> The rule Interface is split across multiple grammars and execution paths. The caller must understand parser shape, arity limits, negation support, and proof compatibility.</p>
     <p><strong>Solution:</strong> Deepen a rule-front-end Module with one Rule representation and adapters for tensor evaluation, proof search, and provenance.</p>
     <p><strong>Benefits:</strong> Better Locality for grammar changes and higher Leverage for callers. The deletion test suggests the current split is shallow because deleting one parser would move complexity into another caller.</p>
@@ -24,7 +24,7 @@
   </div>
   <div class="card">
     <h2>2. Deepen Proof Search Around A Proof Engine Seam</h2>
-    <p><strong>Files:</strong> <code>tensor_logic/proofs.py</code>, <code>tensor_logic/proof_result.py</code>, <code>tensor_logic/execution.py</code>, <code>tensor_logic/http_api.py</code></p>
+    <p><strong>Files:</strong> <code>tensor_logic/proofs.py</code>, <code>tensor_logic/proof_result.py</code>, <code>tensor_logic/proof_tree_viewer.py</code>, <code>tensor_logic/execution.py</code>, <code>tensor_logic/http_api.py</code></p>
     <p><strong>Problem:</strong> Positive proof, negative proof, recursion, interventions, and formatting leak across callers. The Interface exposes much of the Implementation.</p>
     <p><strong>Solution:</strong> Add a proof engine Module whose Interface is goal plus options to typed proof result. CLI, HTTP, and web become adapters.</p>
     <p><strong>Benefits:</strong> Better Locality for proof bugs and more Leverage for external callers.</p>
@@ -34,13 +34,13 @@
   </div>
   <div class="card">
     <h2>3. Extract A Reusable Experiment Harness</h2>
-    <p><strong>Files:</strong> <code>experiments/exp79_self_play_loop.py</code>, <code>experiments/exp81_sweep.py</code>, <code>experiments/exp81_optimize_rule_induction.py</code>, <code>tensor_logic/research/</code></p>
+    <p><strong>Files:</strong> <code>experiments/exp79_self_play_loop.py</code>, <code>experiments/exp81_sweep.py</code>, <code>experiments/exp81_optimize_rule_induction.py</code>, <code>experiments/exp83_slot_attention.py</code>, <code>tensor_logic/research/utils.py</code></p>
     <p><strong>Problem:</strong> Experiment scripts repeat lifecycle concerns, so each script's Interface is shallow and reproduction knowledge is scattered.</p>
     <p><strong>Solution:</strong> Put config, deterministic seeding, result paths, quick/full modes, and metric summaries behind a research harness Module.</p>
     <p><strong>Benefits:</strong> Higher Locality for run behavior and higher Leverage for future experiments.</p>
     <p><strong>Test Impact:</strong> Harness tests can prove deterministic metadata; experiment tests stay focused.</p>
     <p><strong>Risk:</strong> Low to moderate; keep the seam light because this is research code.</p>
-    <p><strong>Suggested Validation:</strong> <code>python -m pytest tests/test_exp79.py tests/test_exp81.py -v</code></p>
+    <p><strong>Suggested Validation:</strong> <code>python -m pytest tests/test_exp79.py tests/test_exp81.py tests/test_exp83_slot_attention.py -v</code></p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add docs/architecture review artifacts for tensor experiments.
- Include HTML report, JSON findings, index page, and Linear issue candidates.

## Validation
- git diff --cached --check

## Branch / Commit
- Branch: codex/tensor-experiments-architecture-review
- Commit: 9c64205

## Residual Risk
- Docs-only artifact packaging; architecture recommendations were not independently validated with the suggested pytest suites.
