### PR TITLE
docs: add experiment provenance contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,53 @@
+# Tensor Experiments Context
+
+This repository is a research workspace and reusable `tensor_logic` package, not
+a product benchmark suite. Treat checked-in experiments as evidence with
+provenance requirements, not as license to make broader claims.
+
+## Domain Vocabulary
+
+- **Tensor Logic (TL)**: the named-index tensor/einsum rule substrate in
+  `tensor_logic/` and the experiment scripts that probe its limits.
+- **Experiment**: a numbered `experiments/expN_*.py` script with an explicit
+  hypothesis, local or remote run command, and recorded result row in
+  `notes/EXPERIMENTS.md`.
+- **Result artifact**: a committed JSON/plot/manifest under an
+  `experiments/*_data/` directory. A result artifact is evidence only for the
+  exact script, inputs, command, dependency set, and commit that produced it.
+- **Claim**: any README, note, PR, issue, or comment statement that generalizes
+  from experiment results.
+- **No-overclaim rule**: every claim must state its evidence tier, scope, and
+  caveats. Do not promote a toy, simulated, oracle, synthetic, internally
+  validated, or remote-only result into a general capability claim.
+
+## Current Provenance Rules
+
+- Use `docs/EXPERIMENT_PROVENANCE.md` before changing README claims,
+  experiment-status notes, result tables, or benchmark language.
+- Use `docs/VALIDATION.md` before selecting a validation command.
+- Use `docs/RUN_PROTOCOL.md` for remote/Kaggle/model-training runs and for any
+  run that can create durable experiment artifacts.
+- Keep `notes/EXPERIMENTS.md` append-only in spirit: failed, mixed, superseded,
+  and invalid experiments are evidence and should remain visible.
+
+## Claim Boundaries
+
+- `exp87` through `exp95` are support/stability research slices. They establish
+  specific toy/simulated object-table and pixel-facing interface behavior, not
+  real-world physics, production perception, or end-to-end vision.
+- `exp94` is an oracle/simulated upper-bound structural recovery result. Cite it
+  as an upper bound unless the claim also references non-oracle follow-up.
+- `exp95` is non-oracle and mixed: it improves false-positive ranking but still
+  exposes missing-object and merge identity/cardinality gaps.
+- `exp78`, `exp79`, and `exp83` have committed result artifacts, but their
+  status and gates must be read from the result artifact plus
+  `notes/EXPERIMENTS.md`, not inferred from old planning docs.
+- `exp53` and `exp54` headline import-graph numbers depend on external package
+  source downloads unless frozen manifests are added. Do not present them as
+  locally reproducible from checked-in artifacts alone.
+
+## Agent File Note
+
+`AGENTS.md` is memjuice-managed per `CLAUDE.md`. Do not hand-edit it when a
+repo-local context or validation rule can live in `CONTEXT.md`,
+`docs/VALIDATION.md`, or `docs/EXPERIMENT_PROVENANCE.md`.

--- a/docs/EXPERIMENT_PROVENANCE.md
+++ b/docs/EXPERIMENT_PROVENANCE.md
@@ -1,0 +1,92 @@
+# Experiment Provenance And No-Overclaim Contract
+
+This contract keeps experiment claims tied to the evidence that produced them.
+Use it for README edits, issue descriptions, PR summaries, research notes, and
+future experiment handoffs.
+
+## Evidence Tiers
+
+| Tier | Meaning | Claim wording allowed |
+| --- | --- | --- |
+| T0 docs-only | Planning note, spec, or audit with no fresh run | "planned", "hypothesized", "audit found" |
+| T1 local deterministic | Runs on CPU from repo code with default/dev deps and no network | "locally validated by `<command>`" |
+| T2 local optional | Requires optional extras such as `lm`, `sft`, `science`, MLX, or longer training | "validated with optional deps", plus dependency/runtime notes |
+| T3 external data/model | Downloads packages, uses official/private datasets, or loads model/provider artifacts | "validated against `<dataset/model>`", plus version/pointer |
+| T4 remote/accelerated | Kaggle/Colab/Modal/HF/GPU/MPS run or saved adapter/checkpoint | "remote run produced", plus provider and durable artifact pointer |
+
+Claims may not be worded above their evidence tier. A T1 toy result cannot imply
+production readiness, real-world validity, or robustness to inputs it did not
+test.
+
+## Required Provenance For New Results
+
+Every new or refreshed result claim must record:
+
+- Experiment script path.
+- Exact command, including flags and whether `--quick` was used.
+- Git commit SHA at run time.
+- Python version and dependency set (`default`, `dev`, `lm`, `sft`, `science`,
+  or external environment).
+- Input dataset/model/package references, including versions or immutable
+  pointers when available.
+- Output artifact paths committed to the repo or durable external artifact URLs.
+- Falsification criterion or pass/fail gate.
+- Caveats that limit the claim.
+
+If an experiment writes weights, adapters, large outputs, or remote artifacts,
+do not commit those binaries. Commit `results.json` and a pointer file such as
+`ADAPTER.md` or `PROVENANCE.md` instead.
+
+## Current Result Artifact Index
+
+This is a repo-local pointer index, not a full metric table. Read the linked
+artifact and `notes/EXPERIMENTS.md` before quoting numbers.
+
+| Experiment range | Committed evidence | Claim boundary |
+| --- | --- | --- |
+| `exp53`, `exp54` import graphs | No checked-in `exp53_data/results.json` or `exp54_data/results.json` | Headline numbers depend on external package downloads; do not call them fully locally reproducible without frozen manifests. |
+| `exp78` | `experiments/exp78_data/results.json` | Rule-induction result for the recorded targets/settings; LM-pruner claims require model/dependency context. |
+| `exp79` | `experiments/exp79_data/results.json` and tests | Use current implementation/results, not stale "pending" planning text. |
+| `exp83` | `experiments/exp83_slot_data/results.json` | Slot-attention probe gate is mixed; do not imply the probe solved the exp79 limitation unless the artifact gate supports it. |
+| `exp87` | `experiments/exp87_support_data/results.json` plus `results_quick.json` | Perfect object-state support/stability substrate, not perception or real physics. |
+| `exp88` | `experiments/exp88_support_noisy_relations_data/results.json` plus `results_quick.json` | Noise boundary mapping; exact TL is brittle under geometry jitter. |
+| `exp89` | `experiments/exp89_support_primitive_confidence_data/results.json` plus `results_quick.json` | Primitive confidence is a triage/abstention signal, not a perception fix. |
+| `exp90` | `experiments/exp90_support_repair_sweep_data/results.json` plus `results_quick.json` | Repair helps boundary noise but is not a full pixel/object uncertainty solution. |
+| `exp91` | `experiments/exp91_interval_support_uncertainty_data/results.json` plus `results_quick.json` | Calibrated coordinate intervals support abstain/recover; under-calibration leaks errors. |
+| `exp92` | `experiments/exp92_pixel_abstain_recover_data/results.json` plus `results_quick.json` | Pixel-facing detector stub/interface proof, not production vision. |
+| `exp93` | `experiments/exp93_detector_calibration_stress_data/results.json` plus `results_quick.json` | Structural detector failures require health/identity/cardinality signals. |
+| `exp94` | `experiments/exp94_object_hypothesis_layer_data/results.json` plus `results_quick.json` | Oracle/simulated object-hypothesis upper bound. |
+| `exp95` | `experiments/exp95_scored_object_hypotheses_data/results.json` plus `results_quick.json` | Non-oracle mixed result: useful false-positive ranking, unresolved missing/merge gaps. |
+
+## No-Overclaim Rules
+
+- State the tested input regime: toy, synthetic, simulated, oracle,
+  internally generated, external package corpus, official dataset, or remote
+  model run.
+- Preserve negative and mixed results. They are not cleanup targets.
+- Distinguish substrate claims from application claims. Exact TL behavior over
+  perfect object tables is not evidence that perception is solved.
+- Distinguish interface proofs from production systems. A detector stub or
+  simulated anomaly signal is not an end-to-end vision model.
+- Distinguish reproducible local artifacts from historical remote results.
+  Remote claims need durable provider/artifact pointers.
+- Quote metrics from artifacts or `notes/EXPERIMENTS.md`; do not round them into
+  stronger language such as "solves", "robust", "general", or "production" unless
+  the gate actually tested that.
+
+## Validation For Claim Edits
+
+For docs-only claim/provenance edits, run:
+
+```bash
+python3 -m pytest tests/test_packaging_ci.py -v
+```
+
+If a claim edit touches code-index or validation-contract wording, also run:
+
+```bash
+python3 -m pytest tests/test_code_index.py -v
+```
+
+If a claim edit changes experiment numbers, run the exact experiment command or
+state why the artifact is historical and not being refreshed.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -4,6 +4,11 @@ Use this matrix to choose the cheapest proof that matches the change. The defaul
 validation path must stay local, CPU-friendly, and free of package-download,
 model-download, GPU, remote-job, or external FAFSA/ISIR data requirements.
 
+Before changing experiment claims, result tables, README benchmark language, or
+status summaries, read `CONTEXT.md` and `docs/EXPERIMENT_PROVENANCE.md`. The
+validation command proves that files still parse and contract checks still pass;
+it does not upgrade the evidence tier behind a claim.
+
 ## Canonical CI Validation
 
 GitHub Actions validates pull requests and pushes to `main` with the editable dev
@@ -132,6 +137,28 @@ The following checks are outside the default `tests/` path:
 
 Run these only from an explicit work order. Record the command, dependency set,
 runtime location, input dataset/model references, output path, and blockers.
+For durable outputs, follow `docs/RUN_PROTOCOL.md` and record enough provenance
+to satisfy `docs/EXPERIMENT_PROVENANCE.md`.
+
+## Claim And Provenance Checks
+
+Docs-only changes that touch provenance, experiment claims, validation wording,
+or no-overclaim rules should use the narrow contract check first:
+
+```bash
+python3 -m pytest tests/test_packaging_ci.py -v
+```
+
+When those changes also touch code-index guidance, add:
+
+```bash
+python3 -m pytest tests/test_code_index.py -v
+```
+
+This is sufficient for docs-only contract edits. It is not sufficient when a
+metric, result table, or experiment verdict changes; those edits require the
+exact experiment command or an explicit note that the artifact is historical and
+was not refreshed.
 
 ## Expected Artifacts
 

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -7,6 +7,8 @@ import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 VALIDATION_DOC = REPO_ROOT / "docs" / "VALIDATION.md"
+CONTEXT_DOC = REPO_ROOT / "CONTEXT.md"
+PROVENANCE_DOC = REPO_ROOT / "docs" / "EXPERIMENT_PROVENANCE.md"
 
 
 def _requirement_names(requirements: list[str]) -> set[str]:
@@ -86,6 +88,7 @@ def test_validation_doc_defines_local_tiers_and_boundaries():
         "## Demo Smoke Commands",
         "## Optional Dependency Boundaries",
         "## Heavyweight And Remote Experiments",
+        "## Claim And Provenance Checks",
         "## Expected Artifacts",
     ]
     for section in expected_sections:
@@ -98,6 +101,7 @@ def test_validation_doc_defines_local_tiers_and_boundaries():
     assert "python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v" in validation
     assert "remote services, external datasets, model" in validation
     assert "External FAFSA/ISIR validation" in validation
+    assert "docs/EXPERIMENT_PROVENANCE.md" in validation
 
 
 def test_validation_doc_maps_heavy_dependencies_outside_ci():
@@ -126,3 +130,39 @@ def test_lightweight_import_proof_runs_without_remote_or_gpu():
 
     assert result.returncode == 0, result.stderr
     assert "tensor_logic import ok" in result.stdout
+
+
+def test_context_doc_defines_no_overclaim_rules_and_agent_boundary():
+    context = CONTEXT_DOC.read_text()
+
+    assert "No-overclaim rule" in context
+    assert "docs/EXPERIMENT_PROVENANCE.md" in context
+    assert "exp87" in context
+    assert "exp95" in context
+    assert "exp53" in context
+    assert "exp54" in context
+    assert "`AGENTS.md` is memjuice-managed" in context
+
+
+def test_experiment_provenance_doc_maps_current_artifacts_and_claim_boundaries():
+    provenance = PROVENANCE_DOC.read_text()
+
+    expected_sections = [
+        "## Evidence Tiers",
+        "## Required Provenance For New Results",
+        "## Current Result Artifact Index",
+        "## No-Overclaim Rules",
+        "## Validation For Claim Edits",
+    ]
+    for section in expected_sections:
+        assert section in provenance
+
+    for exp_id in range(87, 96):
+        assert f"`exp{exp_id}`" in provenance
+        assert f"experiments/exp{exp_id}" in provenance
+
+    assert "experiments/exp78_data/results.json" in provenance
+    assert "experiments/exp79_data/results.json" in provenance
+    assert "experiments/exp83_slot_data/results.json" in provenance
+    assert "No checked-in `exp53_data/results.json`" in provenance
+    assert "python3 -m pytest tests/test_packaging_ci.py -v" in provenance


### PR DESCRIPTION
## Summary
- add repo-local CONTEXT.md with provenance vocabulary, no-overclaim rules, and AGENTS.md boundary
- add docs/EXPERIMENT_PROVENANCE.md with evidence tiers, current artifact index, and claim-edit validation rules
- extend docs/VALIDATION.md and tests/test_packaging_ci.py so provenance/no-overclaim contracts stay checked

## Validation
- python3 -m pytest tests/test_packaging_ci.py -v
- git diff --check

## Secondary Review
- Gemini CLI was available but hung without returning findings; process was stopped and local diff review found only the intended docs/contract/check files changed.

## Residual Risk
- Docs-only contract change; no experiment artifacts or metrics were refreshed.