### PR TITLE
Add experiment status contract snapshot

### DIFF
--- a/docs/EXPERIMENT_STATUS.md
+++ b/docs/EXPERIMENT_STATUS.md
@@ -1,0 +1,36 @@
+# Experiment Status Snapshot
+
+Last reviewed: 2026-05-13
+
+This snapshot is a small status artifact for agents and reviewers. It does not
+upgrade any experiment's evidence tier. Treat `docs/EXPERIMENT_PROVENANCE.md`,
+`docs/VALIDATION.md`, and `notes/EXPERIMENTS.md` as the authority before
+quoting numbers or changing claim language.
+
+## Current Contract Status
+
+| Area | Status | Evidence boundary |
+| --- | --- | --- |
+| Provenance contract | Active | New or refreshed claims must record command, commit, dependency set, inputs, outputs, gate, and caveats. |
+| No-overclaim rule | Active | Toy, synthetic, simulated, oracle, remote-only, or historical results must stay scoped to the exact tested regime. |
+| Validation matrix | Active | Docs-only contract edits use the narrow parse/package checks; metric changes need the exact experiment command or a historical-artifact note. |
+| Result artifact index | Partial | `exp78`, `exp79`, `exp83`, and `exp87`-`exp95` have local pointers; earlier headline import-graph claims still need frozen manifests before calling them fully locally reproducible. |
+
+## Claim Status Summary
+
+| Claim family | Current status | Allowed wording |
+| --- | --- | --- |
+| Reusable `tensor_logic` package | Locally testable package surface | May claim local package/import/test validation when backed by the CI command in `docs/VALIDATION.md`. |
+| Transitive-closure import graph headline | Historical experiment result with external package-download dependency | May describe as historical evidence; do not claim fully reproducible from checked-in artifacts alone until manifests/results are committed. |
+| Support/stability experiments `exp87`-`exp95` | Locally indexed artifact-backed research slices | May cite exact artifact-backed behavior and caveats; do not imply production perception, real-world physics, or end-to-end vision. |
+| Oracle/simulated object hypotheses `exp94` | Upper-bound simulated result | Must call it oracle/simulated or upper-bound when cited. |
+| Non-oracle scored hypotheses `exp95` | Mixed non-oracle result | May cite false-positive ranking improvement; must retain missing-object and merge/cardinality caveats. |
+
+## Required Next Review Triggers
+
+- README headline metrics or benchmark language changes.
+- Any new `experiments/exp*_data/results.json` or refreshed plot/result file.
+- Any PR/issue claim that broadens from a local artifact to a general capability.
+- Any remote, GPU, model-download, external dataset, or package-download run.
+
+Run the command selected from `docs/VALIDATION.md` after updating this status.

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -9,6 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 VALIDATION_DOC = REPO_ROOT / "docs" / "VALIDATION.md"
 CONTEXT_DOC = REPO_ROOT / "CONTEXT.md"
 PROVENANCE_DOC = REPO_ROOT / "docs" / "EXPERIMENT_PROVENANCE.md"
+STATUS_DOC = REPO_ROOT / "docs" / "EXPERIMENT_STATUS.md"
 
 
 def _requirement_names(requirements: list[str]) -> set[str]:
@@ -166,3 +167,33 @@ def test_experiment_provenance_doc_maps_current_artifacts_and_claim_boundaries()
     assert "experiments/exp83_slot_data/results.json" in provenance
     assert "No checked-in `exp53_data/results.json`" in provenance
     assert "python3 -m pytest tests/test_packaging_ci.py -v" in provenance
+
+
+def test_experiment_status_snapshot_records_active_contract_boundaries():
+    status = STATUS_DOC.read_text()
+
+    expected_sections = [
+        "# Experiment Status Snapshot",
+        "## Current Contract Status",
+        "## Claim Status Summary",
+        "## Required Next Review Triggers",
+    ]
+    for section in expected_sections:
+        assert section in status
+
+    for linked_doc in [
+        "docs/EXPERIMENT_PROVENANCE.md",
+        "docs/VALIDATION.md",
+        "notes/EXPERIMENTS.md",
+    ]:
+        assert linked_doc in status
+
+    for required_phrase in [
+        "Provenance contract",
+        "No-overclaim rule",
+        "Validation matrix",
+        "Result artifact index",
+        "do not claim fully reproducible from checked-in artifacts alone",
+        "must retain missing-object and merge/cardinality caveats",
+    ]:
+        assert required_phrase in status


### PR DESCRIPTION
## Summary
- Add docs/EXPERIMENT_STATUS.md as a small repo-local status artifact for provenance, no-overclaim, and validation boundaries.
- Add a packaging/contract test that ensures the status snapshot keeps the required sections, links, and caveats.

## Validation
- python3 -m pytest tests/test_packaging_ci.py -v
- Gemini CLI secondary review: No findings.

## Commit
- 8779498 Add experiment status contract snapshot

## Residual risk
- Docs/test-only change; does not refresh or validate experiment metrics.