### PR TITLE
WP-004 retire superseded domain context branch

### DIFF
--- a/CODEX_WORKPAD.md
+++ b/CODEX_WORKPAD.md
@@ -1,0 +1,11 @@
+# WP-004 Workpad
+
+## Closed Branch Decision
+
+- Closed PR: <https://github.com/jwalin-shah/tensor-logic/pull/59>
+- Branch: `codex/worker-h-domain-context`
+- Decision: retire the closed branch as superseded.
+- Reason: the branch's useful domain-context payload was `CONTEXT.md`; `origin/main`
+  already contains a richer version from PR #60.
+- Preservation change: add an executable guard in `tests/test_packaging_ci.py`
+  so the agent domain map sections, terms, and package paths remain present.

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -145,6 +145,44 @@ def test_context_doc_defines_no_overclaim_rules_and_agent_boundary():
     assert "`AGENTS.md` is memjuice-managed" in context
 
 
+def test_context_doc_preserves_agent_domain_map():
+    context = CONTEXT_DOC.read_text()
+
+    for section in [
+        "## Repo Identity",
+        "## Domain Vocabulary",
+        "## Package Map",
+        "## Experiment Map",
+        "## Maintainer Notes For Agents",
+    ]:
+        assert section in context
+
+    for required_term in [
+        "**Tensor Logic (TL)**",
+        "**Program**",
+        "**Domain**",
+        "**Relation**",
+        "**Fact**",
+        "**Rule**",
+        "**Atom**",
+        "**Proof**",
+        "**TL file**",
+        "**Repo graph**",
+    ]:
+        assert required_term in context
+
+    for required_path in [
+        "`tensor_logic/language.py`",
+        "`tensor_logic/program.py`",
+        "`tensor_logic/file_format.py`",
+        "`tensor_logic/execution.py`",
+        "`tensor_logic/proofs.py`",
+        "`tensor_logic/research/`",
+        "`web_workbench/`",
+    ]:
+        assert required_path in context
+
+
 def test_experiment_provenance_doc_maps_current_artifacts_and_claim_boundaries():
     provenance = PROVENANCE_DOC.read_text()
 


### PR DESCRIPTION
## Summary
- Retire closed PR #59 as superseded by the richer CONTEXT.md already on main from PR #60.
- Add an executable guard that keeps the preserved agent domain map sections, terms, and package paths in CONTEXT.md.
- Record the closed-branch decision in CODEX_WORKPAD.md.

## Validation
- python3 -m pytest tests/test_packaging_ci.py -q
- python3 -m pytest -q
- git diff --check