### PR TITLE
Add authoritative local validation gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ to get current constructor signatures and function args. This prevents plan/code
 pytest tests/ -v
 ```
 
+Canonical local PR handoff validation is:
+
+```bash
+python3 tools/local_validation.py
+```
+
 Canonical CI validation is:
 
 ```bash
@@ -23,10 +29,9 @@ python -m pip install -e ".[dev]"
 python -m pytest tests/ -v
 ```
 
-Use `python3` for the same commands when `python` is absent locally. See
-`docs/VALIDATION.md` for the validation tiers, code-index proof commands,
-optional dependency boundaries, and the checks that must stay outside default
-CI because they require model downloads, GPU/remote execution, external package
+See `docs/VALIDATION.md` for the validation tiers, code-index proof commands,
+optional dependency boundaries, and the checks that must stay outside default CI
+because they require model downloads, GPU/remote execution, external package
 download experiments, or FAFSA/ISIR validation data.
 
 ## LM Backend Support

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -105,6 +105,8 @@ files.
 
 Use `docs/VALIDATION.md` as the source of truth for validation tiers.
 
+- **Local handoff gate**: `python3 tools/local_validation.py`, which runs the
+  full suite and `git diff --check`.
 - **Full suite**: `python3 -m pytest tests/ -v` locally, or the documented
   `python -m pytest tests/ -v` in CI environments where `python` exists.
 - **Packaging/code-index preflight**:

--- a/README.md
+++ b/README.md
@@ -84,15 +84,24 @@ Beyond the headline demos, the repo also contains `experiments/exp1`–`exp54` a
 
 ## Worker validation
 
-Symphony workers should validate a clean checkout with the same commands used by
-CI:
+After installing dev dependencies, Symphony workers should run one local gate
+before PR handoff:
+
+```bash
+python3 tools/local_validation.py
+```
+
+The gate uses the active Python interpreter to run the full pytest suite, then
+runs `git diff --check`. It exits nonzero on the first failing check.
+
+CI runs the same test command after an editable dev install:
 
 ```bash
 python -m pip install -e ".[dev]"
 python -m pytest tests/ -v
 ```
 
-Support/stability fast path:
+Support/stability fast path for narrower research-support changes:
 
 ```bash
 python -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v
@@ -102,11 +111,10 @@ python experiments/exp86_support_baselines.py --quick
 `exp86` is a neural baseline smoke run and should stay out of CI unless it is
 kept quick and deterministic.
 
-If `python` is absent locally, use the equivalent `python3` fallback:
+If the checkout does not already have dev dependencies installed:
 
 ```bash
 python3 -m pip install -e ".[dev]"
-python3 -m pytest tests/ -v
 ```
 
 See `docs/VALIDATION.md` for the tiered matrix covering cheap CI tests, code

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -9,6 +9,24 @@ status summaries, read `CONTEXT.md` and `docs/EXPERIMENT_PROVENANCE.md`. The
 validation command proves that files still parse and contract checks still pass;
 it does not upgrade the evidence tier behind a claim.
 
+## Canonical Local Handoff Gate
+
+After installing dev dependencies, workers should run one local gate before PR
+handoff:
+
+```bash
+python3 tools/local_validation.py
+```
+
+The gate uses the active Python interpreter to run `pytest tests/ -v`, then runs
+`git diff --check`. It exits nonzero on the first failing check.
+
+If the checkout does not already have dev dependencies installed:
+
+```bash
+python3 -m pip install -e ".[dev]"
+```
+
 ## Canonical CI Validation
 
 GitHub Actions validates pull requests and pushes to `main` with the editable dev
@@ -17,14 +35,6 @@ install and the full default test tree:
 ```bash
 python -m pip install -e ".[dev]"
 python -m pytest tests/ -v
-```
-
-If a local machine does not provide `python`, use the equivalent `python3`
-fallback:
-
-```bash
-python3 -m pip install -e ".[dev]"
-python3 -m pytest tests/ -v
 ```
 
 For documentation, packaging, or validation-boundary changes, this narrower proof

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -142,7 +142,7 @@ def test_local_validation_gate_runs_executable_checks_and_fails_fast(monkeypatch
     ]
 
 
-def test_local_validation_gate_checks_diff_after_tests_pass(monkeypatch):
+def test_local_validation_gate_checks_pr_diff_after_tests_pass(monkeypatch):
     local_validation = _load_local_validation_module()
     calls = []
     returncodes = iter([0, 9])
@@ -163,6 +163,33 @@ def test_local_validation_gate_checks_diff_after_tests_pass(monkeypatch):
             [sys.executable, "-m", "pytest", "tests/", "-v"],
             REPO_ROOT,
         ),
+        (["git", "diff", "--check", "origin/main...HEAD"], REPO_ROOT),
+    ]
+
+
+def test_local_validation_gate_checks_staged_and_worktree_diffs(monkeypatch):
+    local_validation = _load_local_validation_module()
+    calls = []
+    returncodes = iter([0, 0, 0, 11])
+
+    class Result:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def fake_run(command, cwd):
+        calls.append((command, cwd))
+        return Result(next(returncodes))
+
+    monkeypatch.setattr(local_validation.subprocess, "run", fake_run)
+
+    assert local_validation.main() == 11
+    assert calls == [
+        (
+            [sys.executable, "-m", "pytest", "tests/", "-v"],
+            REPO_ROOT,
+        ),
+        (["git", "diff", "--check", "origin/main...HEAD"], REPO_ROOT),
+        (["git", "diff", "--cached", "--check"], REPO_ROOT),
         (["git", "diff", "--check"], REPO_ROOT),
     ]
 

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import importlib.util
 import re
 import subprocess
 import sys
@@ -10,6 +11,18 @@ VALIDATION_DOC = REPO_ROOT / "docs" / "VALIDATION.md"
 CONTEXT_DOC = REPO_ROOT / "CONTEXT.md"
 PROVENANCE_DOC = REPO_ROOT / "docs" / "EXPERIMENT_PROVENANCE.md"
 STATUS_DOC = REPO_ROOT / "docs" / "EXPERIMENT_STATUS.md"
+LOCAL_VALIDATION_SCRIPT = REPO_ROOT / "tools" / "local_validation.py"
+
+
+def _load_local_validation_module():
+    spec = importlib.util.spec_from_file_location(
+        "local_validation", LOCAL_VALIDATION_SCRIPT
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _requirement_names(requirements: list[str]) -> set[str]:
@@ -59,12 +72,12 @@ def test_github_actions_runs_worker_validation_commands():
 def test_readme_documents_worker_validation_commands():
     readme = (REPO_ROOT / "README.md").read_text()
 
+    assert "python3 tools/local_validation.py" in readme
     assert 'python -m pip install -e ".[dev]"' in readme
     assert "python -m pytest tests/ -v" in readme
     assert "tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v" in readme
     assert "python experiments/exp86_support_baselines.py --quick" in readme
     assert 'python3 -m pip install -e ".[dev]"' in readme
-    assert "python3 -m pytest tests/ -v" in readme
     assert "docs/VALIDATION.md" in readme
 
 
@@ -95,14 +108,63 @@ def test_validation_doc_defines_local_tiers_and_boundaries():
     for section in expected_sections:
         assert section in validation
 
+    assert "## Canonical Local Handoff Gate" in validation
+    assert "python3 tools/local_validation.py" in validation
+    assert "`git diff --check`" in validation
     assert 'python -m pip install -e ".[dev]"' in validation
     assert "python -m pytest tests/ -v" in validation
     assert 'python3 -m pip install -e ".[dev]"' in validation
-    assert "python3 -m pytest tests/ -v" in validation
     assert "python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v" in validation
     assert "remote services, external datasets, model" in validation
     assert "External FAFSA/ISIR validation" in validation
     assert "docs/EXPERIMENT_PROVENANCE.md" in validation
+
+
+def test_local_validation_gate_runs_executable_checks_and_fails_fast(monkeypatch):
+    local_validation = _load_local_validation_module()
+    calls = []
+
+    class FailedResult:
+        returncode = 7
+
+    def fake_run(command, cwd):
+        calls.append((command, cwd))
+        return FailedResult()
+
+    monkeypatch.setattr(local_validation.subprocess, "run", fake_run)
+
+    assert local_validation.main() == 7
+    assert calls == [
+        (
+            [sys.executable, "-m", "pytest", "tests/", "-v"],
+            REPO_ROOT,
+        )
+    ]
+
+
+def test_local_validation_gate_checks_diff_after_tests_pass(monkeypatch):
+    local_validation = _load_local_validation_module()
+    calls = []
+    returncodes = iter([0, 9])
+
+    class Result:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def fake_run(command, cwd):
+        calls.append((command, cwd))
+        return Result(next(returncodes))
+
+    monkeypatch.setattr(local_validation.subprocess, "run", fake_run)
+
+    assert local_validation.main() == 9
+    assert calls == [
+        (
+            [sys.executable, "-m", "pytest", "tests/", "-v"],
+            REPO_ROOT,
+        ),
+        (["git", "diff", "--check"], REPO_ROOT),
+    ]
 
 
 def test_validation_doc_maps_heavy_dependencies_outside_ci():

--- a/tools/local_validation.py
+++ b/tools/local_validation.py
@@ -18,7 +18,9 @@ def _run(label: str, command: Sequence[str]) -> int:
 def main() -> int:
     checks = [
         ("Full pytest suite", [sys.executable, "-m", "pytest", "tests/", "-v"]),
-        ("Whitespace diff check", ["git", "diff", "--check"]),
+        ("PR whitespace diff check", ["git", "diff", "--check", "origin/main...HEAD"]),
+        ("Staged whitespace diff check", ["git", "diff", "--cached", "--check"]),
+        ("Working tree whitespace diff check", ["git", "diff", "--check"]),
     ]
 
     for label, command in checks:

--- a/tools/local_validation.py
+++ b/tools/local_validation.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run(label: str, command: Sequence[str]) -> int:
+    print(f"==> {label}")
+    print("$ " + " ".join(command))
+    return subprocess.run(command, cwd=REPO_ROOT).returncode
+
+
+def main() -> int:
+    checks = [
+        ("Full pytest suite", [sys.executable, "-m", "pytest", "tests/", "-v"]),
+        ("Whitespace diff check", ["git", "diff", "--check"]),
+    ]
+
+    for label, command in checks:
+        returncode = _run(label, command)
+        if returncode != 0:
+            print(f"{label} failed with exit code {returncode}")
+            return returncode
+
+    print("Local validation gate passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a single local validation gate at `python3 tools/local_validation.py`
- document the gate in worker-facing validation docs and project context
- extend packaging/CI contract tests to prove the gate runs executable checks and exits nonzero on failures

## Validation
- `python3 -m pytest tests/test_packaging_ci.py -q` -> 13 passed
- `python3 -m pytest -q` -> 209 passed
- `git diff --check` -> passed
- `python3 tools/local_validation.py` -> 209 passed, `git diff --check` passed