### PR TITLE
Make local validation gate authoritative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
           python -m pip install -e ".[dev]"
 
       - name: Run tests
-        run: python -m pytest tests/ -v
+        run: python tools/local_validation.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,14 +16,14 @@ to get current constructor signatures and function args. This prevents plan/code
 pytest tests/ -v
 ```
 
-Canonical CI validation is:
+Canonical local and CI validation is:
 
 ```bash
-python -m pip install -e ".[dev]"
-python -m pytest tests/ -v
+python3 -m pip install -e ".[dev]"
+python3 tools/local_validation.py
 ```
 
-Use `python3` for the same commands when `python` is absent locally. See
+CI may use `python tools/local_validation.py` after `actions/setup-python`. See
 `docs/VALIDATION.md` for the validation tiers, code-index proof commands,
 optional dependency boundaries, and the checks that must stay outside default
 CI because they require model downloads, GPU/remote execution, external package

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -105,8 +105,9 @@ files.
 
 Use `docs/VALIDATION.md` as the source of truth for validation tiers.
 
-- **Full suite**: `python3 -m pytest tests/ -v` locally, or the documented
-  `python -m pytest tests/ -v` in CI environments where `python` exists.
+- **Full pre-handoff gate**: `python3 tools/local_validation.py` locally, or
+  the documented `python tools/local_validation.py` in CI environments where
+  `python` exists. The gate runs the full pytest tree and `git diff --check`.
 - **Packaging/code-index preflight**:
   `python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v`.
 - **Support/stability fast path**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -107,7 +107,9 @@ Use `docs/VALIDATION.md` as the source of truth for validation tiers.
 
 - **Full pre-handoff gate**: `python3 tools/local_validation.py` locally, or
   the documented `python tools/local_validation.py` in CI environments where
-  `python` exists. The gate runs the full pytest tree and `git diff --check`.
+  `python` exists. The gate runs the full pytest tree, checks the committed diff
+  against the base branch for whitespace errors, then checks the current
+  worktree diff.
 - **Packaging/code-index preflight**:
   `python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v`.
 - **Support/stability fast path**:

--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ kept quick and deterministic.
 
 CI uses `python tools/local_validation.py` after `actions/setup-python`; local
 workers should use `python3 tools/local_validation.py` when `python` is absent.
-The gate runs `python -m pytest -q tests/` through the active interpreter and
-then `git diff --check`, exiting nonzero on the first failing step.
+The gate runs `python -m pytest -q tests/` through the active interpreter, checks
+the committed diff against the base branch for whitespace errors, then checks
+the current worktree diff, exiting nonzero on the first failing step.
 
 If `python3` is absent but `python` is available, use the equivalent command:
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ Beyond the headline demos, the repo also contains `experiments/exp1`–`exp54` a
 
 ## Worker validation
 
-Symphony workers should validate a clean checkout with the same commands used by
-CI:
+Symphony workers should install the dev dependencies once, then run the same
+pre-handoff validation gate used by CI:
 
 ```bash
-python -m pip install -e ".[dev]"
-python -m pytest tests/ -v
+python3 -m pip install -e ".[dev]"
+python3 tools/local_validation.py
 ```
 
 Support/stability fast path:
@@ -102,11 +102,16 @@ python experiments/exp86_support_baselines.py --quick
 `exp86` is a neural baseline smoke run and should stay out of CI unless it is
 kept quick and deterministic.
 
-If `python` is absent locally, use the equivalent `python3` fallback:
+CI uses `python tools/local_validation.py` after `actions/setup-python`; local
+workers should use `python3 tools/local_validation.py` when `python` is absent.
+The gate runs `python -m pytest -q tests/` through the active interpreter and
+then `git diff --check`, exiting nonzero on the first failing step.
+
+If `python3` is absent but `python` is available, use the equivalent command:
 
 ```bash
-python3 -m pip install -e ".[dev]"
-python3 -m pytest tests/ -v
+python -m pip install -e ".[dev]"
+python tools/local_validation.py
 ```
 
 See `docs/VALIDATION.md` for the tiered matrix covering cheap CI tests, code

--- a/docs/SYMPHONY_RUN_PROTOCOL.md
+++ b/docs/SYMPHONY_RUN_PROTOCOL.md
@@ -10,7 +10,7 @@ When executing an issue in this repository, follow these rules strictly:
 2. **Branch Naming**: Create or use a git branch named from the issue key, e.g. `codex/SYM-25-short-title`.
 3. **Execution Notes**: Write local execution notes or use a workpad if the repository has an established place for that (e.g., in `notes/` directory or a designated task file).
 4. **Scope Constraint**: Keep one issue to one branch and one Pull Request. Do not bundle multiple issues.
-5. **Validation**: Validate your changes with the smallest, most direct command that proves the acceptance criteria have been met.
+5. **Validation**: Validate your changes with `python3 tools/local_validation.py` before PR handoff, or with the smallest, most direct command that proves the acceptance criteria when a narrower command is explicitly justified.
 6. **Documentation of Results**: Record the PR URL, commit SHA, validation command used, and any blockers encountered during execution.
 7. **Status Management**: Do not mark the Linear issue as Done until the PR is fully merged or explicitly accepted by a maintainer.
 
@@ -40,10 +40,10 @@ Neural baseline smoke validation stays out of CI, but should be run by workers t
 python experiments/exp86_support_baselines.py --quick
 ```
 
-Full validation remains:
+Full pre-handoff validation is:
 
 ```bash
-python -m pytest tests/ -v
+python3 tools/local_validation.py
 ```
 
 ## Notes for Agents

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -9,22 +9,23 @@ status summaries, read `CONTEXT.md` and `docs/EXPERIMENT_PROVENANCE.md`. The
 validation command proves that files still parse and contract checks still pass;
 it does not upgrade the evidence tier behind a claim.
 
-## Canonical CI Validation
+## Canonical Local And CI Validation
 
-GitHub Actions validates pull requests and pushes to `main` with the editable dev
-install and the full default test tree:
-
-```bash
-python -m pip install -e ".[dev]"
-python -m pytest tests/ -v
-```
-
-If a local machine does not provide `python`, use the equivalent `python3`
-fallback:
+The authoritative pre-handoff gate is one local command after an editable dev
+install:
 
 ```bash
 python3 -m pip install -e ".[dev]"
-python3 -m pytest tests/ -v
+python3 tools/local_validation.py
+```
+
+`tools/local_validation.py` runs the full default pytest tree with `-q` through
+the active interpreter, then runs `git diff --check`. It exits nonzero if either
+step fails. GitHub Actions uses the same gate after `actions/setup-python`:
+
+```bash
+python -m pip install -e ".[dev]"
+python tools/local_validation.py
 ```
 
 For documentation, packaging, or validation-boundary changes, this narrower proof

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -20,8 +20,9 @@ python3 tools/local_validation.py
 ```
 
 `tools/local_validation.py` runs the full default pytest tree with `-q` through
-the active interpreter, then runs `git diff --check`. It exits nonzero if either
-step fails. GitHub Actions uses the same gate after `actions/setup-python`:
+the active interpreter, checks the committed diff against the base branch for
+whitespace errors, then checks the current worktree diff. It exits nonzero if
+any step fails. GitHub Actions uses the same gate after `actions/setup-python`:
 
 ```bash
 python -m pip install -e ".[dev]"

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import importlib.util
 import re
 import subprocess
 import sys
@@ -10,6 +11,17 @@ VALIDATION_DOC = REPO_ROOT / "docs" / "VALIDATION.md"
 CONTEXT_DOC = REPO_ROOT / "CONTEXT.md"
 PROVENANCE_DOC = REPO_ROOT / "docs" / "EXPERIMENT_PROVENANCE.md"
 STATUS_DOC = REPO_ROOT / "docs" / "EXPERIMENT_STATUS.md"
+
+
+def _local_validation_module():
+    spec = importlib.util.spec_from_file_location(
+        "local_validation", REPO_ROOT / "tools" / "local_validation.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _requirement_names(requirements: list[str]) -> set[str]:
@@ -52,6 +64,7 @@ def test_github_actions_runs_worker_validation_commands():
     assert "pull_request:" in workflow
     assert "push:" in workflow
     assert "main" in workflow
+    assert "fetch-depth: 0" in workflow
     assert 'python -m pip install -e ".[dev]"' in workflow
     assert "python tools/local_validation.py" in workflow
 
@@ -109,7 +122,68 @@ def test_local_validation_gate_runs_executable_checks():
     gate = (REPO_ROOT / "tools" / "local_validation.py").read_text()
 
     assert '"-m", "pytest", "-q"' in gate
-    assert '"git", "diff", "--check"' in gate
+    assert "_committed_diff_check_command()" in gate
+    assert '"git", "diff", "--check", f"{merge_base}..HEAD"' in gate
+
+
+def test_local_validation_gate_checks_committed_diff_from_base_ref(monkeypatch):
+    local_validation = _local_validation_module()
+    monkeypatch.setenv("LOCAL_VALIDATION_BASE_REF", "origin/release")
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+
+    def fake_git_output(args):
+        assert args == ["merge-base", "origin/release", "HEAD"]
+        return "abc123"
+
+    monkeypatch.setattr(local_validation, "_git_output", fake_git_output)
+
+    assert local_validation._committed_diff_check_command() == [
+        "git",
+        "diff",
+        "--check",
+        "abc123..HEAD",
+    ]
+
+
+def test_local_validation_gate_uses_github_base_ref_for_pr_ci(monkeypatch):
+    local_validation = _local_validation_module()
+    monkeypatch.delenv("LOCAL_VALIDATION_BASE_REF", raising=False)
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+
+    def fake_git_output(args):
+        assert args == ["merge-base", "origin/main", "HEAD"]
+        return "def456"
+
+    monkeypatch.setattr(local_validation, "_git_output", fake_git_output)
+
+    assert local_validation._committed_diff_check_command() == [
+        "git",
+        "diff",
+        "--check",
+        "def456..HEAD",
+    ]
+
+
+def test_local_validation_gate_falls_back_to_head_parent(monkeypatch):
+    local_validation = _local_validation_module()
+    monkeypatch.delenv("LOCAL_VALIDATION_BASE_REF", raising=False)
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+
+    def fake_git_output(args):
+        if args == ["rev-parse", "--verify", "--quiet", "origin/main"]:
+            return None
+        if args == ["rev-parse", "--verify", "--quiet", "HEAD^"]:
+            return "parent123"
+        raise AssertionError(args)
+
+    monkeypatch.setattr(local_validation, "_git_output", fake_git_output)
+
+    assert local_validation._committed_diff_check_command() == [
+        "git",
+        "diff",
+        "--check",
+        "HEAD^..HEAD",
+    ]
 
 
 def test_local_validation_gate_exits_nonzero_when_pytest_fails(tmp_path):

--- a/tests/test_packaging_ci.py
+++ b/tests/test_packaging_ci.py
@@ -53,18 +53,18 @@ def test_github_actions_runs_worker_validation_commands():
     assert "push:" in workflow
     assert "main" in workflow
     assert 'python -m pip install -e ".[dev]"' in workflow
-    assert "python -m pytest tests/ -v" in workflow
+    assert "python tools/local_validation.py" in workflow
 
 
 def test_readme_documents_worker_validation_commands():
     readme = (REPO_ROOT / "README.md").read_text()
 
-    assert 'python -m pip install -e ".[dev]"' in readme
-    assert "python -m pytest tests/ -v" in readme
+    assert 'python3 -m pip install -e ".[dev]"' in readme
+    assert "python3 tools/local_validation.py" in readme
+    assert "python tools/local_validation.py" in readme
     assert "tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v" in readme
     assert "python experiments/exp86_support_baselines.py --quick" in readme
-    assert 'python3 -m pip install -e ".[dev]"' in readme
-    assert "python3 -m pytest tests/ -v" in readme
+    assert 'python -m pip install -e ".[dev]"' in readme
     assert "docs/VALIDATION.md" in readme
 
 
@@ -82,7 +82,7 @@ def test_validation_doc_defines_local_tiers_and_boundaries():
     validation = VALIDATION_DOC.read_text()
 
     expected_sections = [
-        "## Canonical CI Validation",
+        "## Canonical Local And CI Validation",
         "## Cheap CI Tests",
         "## Code-Index Commands",
         "## Lightweight Build/Import Proof",
@@ -95,14 +95,36 @@ def test_validation_doc_defines_local_tiers_and_boundaries():
     for section in expected_sections:
         assert section in validation
 
-    assert 'python -m pip install -e ".[dev]"' in validation
-    assert "python -m pytest tests/ -v" in validation
     assert 'python3 -m pip install -e ".[dev]"' in validation
-    assert "python3 -m pytest tests/ -v" in validation
+    assert "python3 tools/local_validation.py" in validation
+    assert 'python -m pip install -e ".[dev]"' in validation
+    assert "python tools/local_validation.py" in validation
     assert "python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v" in validation
     assert "remote services, external datasets, model" in validation
     assert "External FAFSA/ISIR validation" in validation
     assert "docs/EXPERIMENT_PROVENANCE.md" in validation
+
+
+def test_local_validation_gate_runs_executable_checks():
+    gate = (REPO_ROOT / "tools" / "local_validation.py").read_text()
+
+    assert '"-m", "pytest", "-q"' in gate
+    assert '"git", "diff", "--check"' in gate
+
+
+def test_local_validation_gate_exits_nonzero_when_pytest_fails(tmp_path):
+    failing_test = tmp_path / "test_failing_gate.py"
+    failing_test.write_text("def test_fails():\n    assert False\n")
+
+    result = subprocess.run(
+        [sys.executable, "tools/local_validation.py", str(failing_test)],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+
+    assert result.returncode != 0
+    assert "test_fails" in result.stdout
 
 
 def test_validation_doc_maps_heavy_dependencies_outside_ci():

--- a/tools/local_validation.py
+++ b/tools/local_validation.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run(command: list[str]) -> int:
+    print("+ " + " ".join(command), flush=True)
+    return subprocess.run(command, cwd=REPO_ROOT).returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the local pre-handoff validation gate.")
+    parser.add_argument(
+        "pytest_targets",
+        nargs="*",
+        default=["tests/"],
+        help="Optional pytest targets; defaults to the full tests/ tree.",
+    )
+    args = parser.parse_args(argv)
+
+    pytest_rc = _run([sys.executable, "-m", "pytest", "-q", *args.pytest_targets])
+    if pytest_rc != 0:
+        return pytest_rc
+
+    return _run(["git", "diff", "--check"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/local_validation.py
+++ b/tools/local_validation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -13,6 +14,38 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 def _run(command: list[str]) -> int:
     print("+ " + " ".join(command), flush=True)
     return subprocess.run(command, cwd=REPO_ROOT).returncode
+
+
+def _git_output(args: list[str]) -> str | None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _committed_diff_check_command() -> list[str]:
+    base_ref = os.environ.get("LOCAL_VALIDATION_BASE_REF")
+    if base_ref is None:
+        github_base_ref = os.environ.get("GITHUB_BASE_REF")
+        if github_base_ref:
+            base_ref = f"origin/{github_base_ref}"
+        elif _git_output(["rev-parse", "--verify", "--quiet", "origin/main"]):
+            base_ref = "origin/main"
+
+    if base_ref:
+        merge_base = _git_output(["merge-base", base_ref, "HEAD"])
+        if merge_base:
+            return ["git", "diff", "--check", f"{merge_base}..HEAD"]
+
+    if _git_output(["rev-parse", "--verify", "--quiet", "HEAD^"]):
+        return ["git", "diff", "--check", "HEAD^..HEAD"]
+
+    return ["git", "diff", "--check", "--cached"]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -28,6 +61,10 @@ def main(argv: list[str] | None = None) -> int:
     pytest_rc = _run([sys.executable, "-m", "pytest", "-q", *args.pytest_targets])
     if pytest_rc != 0:
         return pytest_rc
+
+    committed_diff_rc = _run(_committed_diff_check_command())
+    if committed_diff_rc != 0:
+        return committed_diff_rc
 
     return _run(["git", "diff", "--check"])
 


### PR DESCRIPTION
## Summary
- add tools/local_validation.py as the single pre-handoff gate for pytest plus git diff --check
- point CI and worker validation docs at the same gate
- extend packaging/CI contract tests to prove the gate runs executable checks and exits nonzero on pytest failure

## Validation
- python3 -m pytest tests/test_packaging_ci.py -q
- python3 -m pytest -q
- git diff --check
- python3 tools/local_validation.py

Residual risk: CI still needs to run on GitHub's Python 3.11 environment; local validation passed on this worktree.