### PR TITLE
Add Program query arity regression test

### DIFF
--- a/tensor_logic/program.py
+++ b/tensor_logic/program.py
@@ -97,6 +97,11 @@ class Program:
 
     def query(self, relation_name: str, *symbols: str, recursive: bool = False, semiring: str = "boolean") -> float:
         relation = self.relations[relation_name]
+        if len(symbols) != len(relation.domains):
+            raise ValueError(f"relation '{relation_name}' expects {len(relation.domains)} args, got {len(symbols)}")
+        for i, (domain, symbol) in enumerate(zip(relation.domains, symbols)):
+            if symbol not in domain.index:
+                raise ValueError(f"symbol '{symbol}' not in domain for arg {i} of '{relation_name}' (known: {', '.join(domain.symbols)})")
         if recursive:
             return relation.reachable(*symbols, semiring=semiring)
         return relation.value(*symbols, semiring=semiring)

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -170,6 +170,15 @@ class TensorLogicCoreTest(unittest.TestCase):
         self.assertEqual(program.query("ancestor", "alice", "dave", recursive=True), 1.0)
         self.assertEqual(program.query("ancestor", "dave", "alice", recursive=True), 0.0)
 
+    def test_program_query_rejects_extra_symbols(self):
+        program = Program()
+        program.domain("Node", ["a", "b", "c"])
+        program.relation("edge", "Node", "Node")
+        program.fact("edge", "a", "b")
+
+        with self.assertRaisesRegex(ValueError, "expects 2 args, got 3"):
+            program.query("edge", "a", "b", "c")
+
     def test_tl_file_query_and_proof(self):
         loaded = load_tl("examples/code_dependencies.tl")
         self.assertEqual(loaded.program.query("depends_on", "worker", "models", recursive=True), 1.0)


### PR DESCRIPTION
## Summary
- Add a focused regression test proving Program.query rejects extra symbols instead of silently ignoring them.
- Validate Program.query arity and symbol membership before dispatching to direct or recursive relation lookup.

## Validation
- python3 -m pytest -q
- git diff --check

## Residual risk
- Direct Relation.value()/reachable() calls still have their existing lower-level behavior; this patch guards the public Program query interface requested by the work pack.