### PR TITLE
Add query arity regression test

### DIFF
--- a/tensor_logic/language.py
+++ b/tensor_logic/language.py
@@ -162,7 +162,7 @@ class Relation:
 
     def value(self, *symbols: str, semiring: str = "boolean") -> float:
         tensor = self.eval(semiring=semiring)
-        coords = tuple(domain.id(symbol) for domain, symbol in zip(self.domains, symbols))
+        coords = self._coords_for_symbols(symbols)
         return float(tensor[coords].item())
 
     def fixpoint(
@@ -193,11 +193,21 @@ class Relation:
 
     def reachable(self, *symbols: str, semiring: str = "boolean", max_iters: int | None = None) -> float:
         tensor = self.fixpoint(semiring=semiring, max_iters=max_iters)
-        coords = tuple(domain.id(symbol) for domain, symbol in zip(self.domains, symbols))
+        coords = self._coords_for_symbols(symbols)
         return float(tensor[coords].item())
 
     def default_indices(self) -> tuple[str, ...]:
         return tuple(chr(ord("a") + i) for i in range(len(self.domains)))
+
+    def _coords_for_symbols(self, symbols: tuple[str, ...]) -> tuple[int, ...]:
+        if len(symbols) != len(self.domains):
+            raise ValueError(f"{self.name} expects {len(self.domains)} symbols, got {len(symbols)}")
+        coords = []
+        for i, (domain, symbol) in enumerate(zip(self.domains, symbols)):
+            if symbol not in domain.index:
+                raise ValueError(f"symbol '{symbol}' not in domain for arg {i} of '{self.name}' (known: {', '.join(domain.symbols)})")
+            coords.append(domain.id(symbol))
+        return tuple(coords)
 
 
 @dataclass(frozen=True)

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -244,6 +244,28 @@ class TensorLogicCoreTest(unittest.TestCase):
         with self.assertRaises(ValueError, msg="prove unknown symbol"):
             prove(program, "edge", "a", "z")
 
+    def test_query_rejects_wrong_arity_and_unknown_symbols(self):
+        program = Program()
+        program.domain("Node", ["a", "b"])
+        program.relation("edge", "Node", "Node")
+        program.fact("edge", "a", "b")
+
+        with self.assertRaisesRegex(ValueError, "edge expects 2 symbols, got 1"):
+            program.query("edge", "a")
+        with self.assertRaisesRegex(ValueError, "edge expects 2 symbols, got 3"):
+            program.query("edge", "a", "b", "extra")
+        with self.assertRaisesRegex(ValueError, "symbol 'z' not in domain"):
+            program.query("edge", "a", "z")
+
+    def test_recursive_query_rejects_wrong_arity(self):
+        program = Program()
+        program.domain("Node", ["a", "b"])
+        program.relation("edge", "Node", "Node")
+        program.fact("edge", "a", "b")
+
+        with self.assertRaisesRegex(ValueError, "edge expects 2 symbols, got 3"):
+            program.query("edge", "a", "b", "extra", recursive=True)
+
     def test_confidence_propagates(self):
         program = Program()
         program.domain("X", ["a", "b", "c"])


### PR DESCRIPTION
## Summary
- Add regression coverage for Program.query rejecting wrong arity and unknown symbols.
- Share relation symbol-to-coordinate validation between direct and recursive query paths.

## Validation
- python3 -m pytest -q
- git diff --check

## Residual risk
- Low; scoped to query-time validation in tensor_logic.language.Relation.