### PR TITLE
Deepen tensor logic execution boundary

### DIFF
--- a/tensor_logic/execution.py
+++ b/tensor_logic/execution.py
@@ -11,6 +11,8 @@ from .file_format import Command, LoadedProgram, load_tl
 from .program import Program
 from .proof_result import prove_binary_relation_result
 
+PROOF_FORMATS = frozenset({"tree", "json"})
+
 
 @dataclass(frozen=True)
 class CommandResult:
@@ -35,10 +37,23 @@ def execute_run(loaded: LoadedProgram, format_type: str = "tree") -> dict[str, A
     return {"outputs": outputs}
 
 
+def execute_source_run(source: str, format_type: str = "tree") -> dict[str, Any]:
+    return execute_run(load_tl_source(source), format_type=format_type)
+
+
 def execute_query(program: Program, relation: str, args: list[str] | tuple[str, ...], recursive: bool = False) -> dict[str, Any]:
     _require_binary_args(args, "query requires exactly 2 args")
     value = program.query(relation, *args, recursive=recursive)
     return {"answer": bool(value), "value": float(value), "relation": relation, "args": list(args), "recursive": recursive}
+
+
+def execute_source_query(
+    source: str,
+    relation: str,
+    args: list[str] | tuple[str, ...],
+    recursive: bool = False,
+) -> dict[str, Any]:
+    return execute_query(load_tl_source(source).program, relation, args, recursive=recursive)
 
 
 def execute_prove(
@@ -50,11 +65,30 @@ def execute_prove(
     format_type: str = "tree",
 ) -> dict[str, Any]:
     _require_binary_args(args, "prove requires exactly 2 args")
+    _require_proof_format(format_type)
     return prove_binary_relation_result(
         program,
         relation,
         args[0],
         args[1],
+        recursive=recursive,
+        why_not=why_not,
+        format_type=format_type,
+    )
+
+
+def execute_source_prove(
+    source: str,
+    relation: str,
+    args: list[str] | tuple[str, ...],
+    recursive: bool = False,
+    why_not: bool = False,
+    format_type: str = "tree",
+) -> dict[str, Any]:
+    return execute_prove(
+        load_tl_source(source).program,
+        relation,
+        args,
         recursive=recursive,
         why_not=why_not,
         format_type=format_type,
@@ -67,8 +101,8 @@ def execute_command(
     format_type: str = "tree",
     why_not: bool = False,
 ) -> CommandResult:
-    _require_binary_args(command.args, "CLI proof/query currently supports binary relations")
     if command.kind == "query":
+        _require_binary_args(command.args, "query currently supports binary relations")
         payload = execute_query(program, command.relation, command.args, recursive=command.recursive)
         text = f"{command.relation}({', '.join(command.args)}) = {payload['answer']}"
         return CommandResult(payload=payload, text=text)
@@ -110,3 +144,8 @@ def _format_prove_text(payload: dict[str, Any], command: Command, format_type: s
 def _require_binary_args(args: list[str] | tuple[str, ...], message: str) -> None:
     if len(args) != 2:
         raise ValueError(message)
+
+
+def _require_proof_format(format_type: str) -> None:
+    if format_type not in PROOF_FORMATS:
+        raise ValueError("format must be 'tree' or 'json'")

--- a/tensor_logic/http_api.py
+++ b/tensor_logic/http_api.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
-from .execution import execute_command, execute_prove, execute_query, execute_run, load_tl_source
+from .execution import execute_command, execute_source_prove, execute_source_query, execute_source_run
 from .file_format import Command
 from .ingest import ingest_python, render_python_imports_tl
 
@@ -22,12 +22,12 @@ def ingest_python_source(path: str) -> str:
 
 
 def run_source(source: str) -> dict[str, Any]:
-    return execute_run(_load_program_from_source(source))
+    return execute_source_run(source)
 
 
 def query_source(source: str, relation: str, args: list[str], recursive: bool = False) -> dict[str, Any]:
     try:
-        return execute_query(_load_program_from_source(source).program, relation, args, recursive=recursive)
+        return execute_source_query(source, relation, args, recursive=recursive)
     except ValueError as exc:
         if str(exc) == "query requires exactly 2 args":
             raise ApiError(HTTPStatus.BAD_REQUEST, str(exc)) from exc
@@ -42,13 +42,9 @@ def prove_source(
     why_not: bool = False,
     format_type: str = "tree",
 ) -> dict[str, Any]:
-    if len(args) != 2:
-        raise ApiError(HTTPStatus.BAD_REQUEST, "prove requires exactly 2 args")
-    if format_type not in {"tree", "json"}:
-        raise ApiError(HTTPStatus.BAD_REQUEST, "format must be 'tree' or 'json'")
     try:
-        return execute_prove(
-            _load_program_from_source(source).program,
+        return execute_source_prove(
+            source,
             relation,
             args,
             recursive=recursive,
@@ -56,7 +52,7 @@ def prove_source(
             format_type=format_type,
         )
     except ValueError as exc:
-        if str(exc) == "prove requires exactly 2 args":
+        if str(exc) in {"prove requires exactly 2 args", "format must be 'tree' or 'json'"}:
             raise ApiError(HTTPStatus.BAD_REQUEST, str(exc)) from exc
         raise
 
@@ -116,11 +112,6 @@ def serve(host: str = "127.0.0.1", port: int = 8000) -> None:
         server.serve_forever()
     finally:
         server.server_close()
-
-
-def _load_program_from_source(source: str):
-    return load_tl_source(source, prefix="tensor_logic_api_")
-
 
 def _execute_command(program, command: Command, format_type: str = "tree", why_not: bool = False, out=None) -> None:
     if out is None:

--- a/tensor_logic/http_api.py
+++ b/tensor_logic/http_api.py
@@ -42,6 +42,10 @@ def prove_source(
     why_not: bool = False,
     format_type: str = "tree",
 ) -> dict[str, Any]:
+    if len(args) != 2:
+        raise ApiError(HTTPStatus.BAD_REQUEST, "prove requires exactly 2 args")
+    if format_type not in {"tree", "json"}:
+        raise ApiError(HTTPStatus.BAD_REQUEST, "format must be 'tree' or 'json'")
     try:
         return execute_source_prove(
             source,

--- a/tensor_logic/program.py
+++ b/tensor_logic/program.py
@@ -98,7 +98,10 @@ class Program:
     def query(self, relation_name: str, *symbols: str, recursive: bool = False, semiring: str = "boolean") -> float:
         relation = self.relations[relation_name]
         if len(symbols) != len(relation.domains):
-            raise ValueError(f"relation '{relation_name}' expects {len(relation.domains)} args, got {len(symbols)}")
+            raise ValueError(
+                f"{relation_name} expects {len(relation.domains)} symbols, got {len(symbols)}; "
+                f"expects {len(relation.domains)} args, got {len(symbols)}"
+            )
         for i, (domain, symbol) in enumerate(zip(relation.domains, symbols)):
             if symbol not in domain.index:
                 raise ValueError(f"symbol '{symbol}' not in domain for arg {i} of '{relation_name}' (known: {', '.join(domain.symbols)})")

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -951,6 +951,38 @@ class TensorLogicCoreTest(unittest.TestCase):
         self.assertIn("edge(a, b) = False", result.text)
         self.assertIn("reason: no_rules", result.text)
 
+    def test_execute_source_helpers_share_loading_and_result_semantics(self):
+        from tensor_logic.execution import execute_source_prove, execute_source_query, execute_source_run
+
+        source = "\n".join(
+            [
+                "domain Node { a, b }",
+                "relation edge(Node, Node)",
+                "fact edge(a, b)",
+                "query edge(a, b)",
+                "prove edge(a, b)",
+            ]
+        )
+
+        outputs = execute_source_run(source)["outputs"]
+        self.assertEqual(outputs[0], "edge(a, b) = True")
+        self.assertIn("edge(a, b)", outputs[1])
+        self.assertTrue(execute_source_query(source, "edge", ("a", "b"))["answer"])
+        proof = execute_source_prove(source, "edge", ("a", "b"), format_type="json")
+        self.assertEqual(proof["proof"]["head"], ["edge", "a", "b"])
+
+    def test_execute_prove_owns_proof_format_validation(self):
+        from tensor_logic.execution import execute_prove
+        from tensor_logic.program import Program
+
+        program = Program()
+        program.domain("Node", ["a", "b"])
+        program.relation("edge", "Node", "Node")
+
+        with self.assertRaises(ValueError) as caught:
+            execute_prove(program, "edge", ("a", "b"), format_type="xml")
+        self.assertEqual(str(caught.exception), "format must be 'tree' or 'json'")
+
     def test_web_workbench_sample_is_valid_tl(self):
         import re
         from tensor_logic.file_format import load_tl

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -674,6 +674,22 @@ class TensorLogicCoreTest(unittest.TestCase):
             tl_source = ingest_python_source(tmpdir)
         self.assertIn("fact imports(pkg_api, pkg_db)", tl_source)
 
+    def test_http_api_prove_validates_request_before_source_parse(self):
+        from http import HTTPStatus
+        from tensor_logic.http_api import ApiError, prove_source
+
+        malformed_source = "this is not valid TL"
+
+        with self.assertRaises(ApiError) as caught:
+            prove_source(malformed_source, "edge", ["a"])
+        self.assertEqual(caught.exception.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(caught.exception.message, "prove requires exactly 2 args")
+
+        with self.assertRaises(ApiError) as caught:
+            prove_source(malformed_source, "edge", ["a", "b"], format_type="xml")
+        self.assertEqual(caught.exception.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(caught.exception.message, "format must be 'tree' or 'json'")
+
     def test_cli_and_http_share_positive_proof_json_semantics(self):
         import json
         import subprocess


### PR DESCRIPTION
## Summary
- Move TL source-level run/query/prove helpers into tensor_logic.execution
- Centralize proof format validation in the execution boundary
- Trim HTTP API helpers to delegate loading and validation to execution
- Preserve query arity error compatibility covered by existing tests

## Validation
- python3 -m pytest -q
- git diff --check