### PR TITLE
Consolidate synthetic scene helpers

### DIFF
--- a/experiments/exp79_lewm_tl.py
+++ b/experiments/exp79_lewm_tl.py
@@ -27,87 +27,33 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from tensor_logic import Domain, Relation
-from tensor_logic.research.utils import f1, apply_body, Schema
+from tensor_logic.research.synthetic_scene import (
+    CANVAS,
+    COLORS,
+    N_OBJ,
+    N_PAIRS,
+    OBJ_IDX,
+    OBJ_NAMES,
+    OBJ_SIZE,
+    PAIR_INDEX,
+    PAIRS,
+    RELATIONS,
+    build_spatial_tl_state as build_tl_state,
+    compute_ground_truth_spatial_derivations as compute_gt_derived,
+    compute_pairwise_spatial_relations as compute_relations,
+    generate_colored_object_sequence as generate_sequence,
+    generate_labeled_scene_frames as generate_labeled_frames,
+    remove_object_facts as remove_object,
+)
+from tensor_logic.research.utils import f1, Schema
 
 torch.manual_seed(42)
 np.random.seed(42)
 
 # ── Constants ──────────────────────────────────────────────────────────────
-CANVAS = 64
-OBJ_SIZE = 10
-N_OBJ = 3
-OBJ_NAMES = ["R", "G", "B"]
-COLORS = [(220, 50, 50), (50, 200, 50), (50, 50, 220)]
-RELATIONS = ["above", "left_of", "touching", "occluded"]
 JEPA_SCHEMA = Schema("jepa", {r: ("obj", "obj") for r in RELATIONS})
-PAIRS = [(a, b) for a in OBJ_NAMES for b in OBJ_NAMES if a != b]
-PAIR_INDEX = {p: i for i, p in enumerate(PAIRS)}
-OBJ_IDX = {n: i for i, n in enumerate(OBJ_NAMES)}
 LATENT_DIM = 64
-N_PAIRS = 6
 DATA_DIR = os.path.join(os.path.dirname(__file__), "exp79_data")
-
-# ── 1. Data Generation ────────────────────────────────────────────────────
-
-def generate_sequence(n_frames=8, rng=None):
-    """Returns frames (T,3,H,W) float32 in [0,1], positions (T,N,2) float64."""
-    if rng is None:
-        rng = np.random.default_rng()
-    half = OBJ_SIZE // 2
-    pos = rng.integers(half + 4, CANVAS - half - 4, size=(N_OBJ, 2)).astype(float)
-    vel = rng.uniform(-3.0, 3.0, size=(N_OBJ, 2))
-
-    frames_np, pos_hist = [], []
-    for _ in range(n_frames):
-        pos += vel
-        for i in range(N_OBJ):
-            for d in range(2):
-                if pos[i, d] < half + 1:
-                    pos[i, d] = half + 1.0
-                    vel[i, d] = abs(vel[i, d])
-                elif pos[i, d] > CANVAS - half - 1:
-                    pos[i, d] = float(CANVAS - half - 1)
-                    vel[i, d] = -abs(vel[i, d])
-        canvas = np.zeros((CANVAS, CANVAS, 3), dtype=np.uint8)
-        for i, (color, p) in enumerate(zip(COLORS, pos)):
-            x, y = int(round(p[0])), int(round(p[1]))
-            canvas[max(0, y - half):min(CANVAS, y + half),
-                   max(0, x - half):min(CANVAS, x + half)] = color
-        frames_np.append(canvas.copy())
-        pos_hist.append(pos.copy())
-
-    frames = torch.from_numpy(np.stack(frames_np)).permute(0, 3, 1, 2).float() / 255.0
-    return frames, np.array(pos_hist)
-
-
-def compute_relations(pos):
-    """pos: (N_OBJ, 2) float array. Returns {(rel, a, b): bool} for all pairs."""
-    rels = {}
-    half = OBJ_SIZE // 2
-    for i, a in enumerate(OBJ_NAMES):
-        for j, b in enumerate(OBJ_NAMES):
-            if i == j:
-                continue
-            pi, pj = pos[i], pos[j]
-            rels[("above", a, b)] = bool(pi[1] < pj[1])
-            rels[("left_of", a, b)] = bool(pi[0] < pj[0])
-            gap_x = abs(pi[0] - pj[0]) - OBJ_SIZE
-            gap_y = abs(pi[1] - pj[1]) - OBJ_SIZE
-            rels[("touching", a, b)] = bool(max(gap_x, gap_y) < 2)
-            bbox = abs(pi[0] - pj[0]) < OBJ_SIZE and abs(pi[1] - pj[1]) < OBJ_SIZE
-            rels[("occluded", a, b)] = bool(bbox and i > j)
-    return rels
-
-
-def generate_labeled_frames(n=500, seed=99):
-    """Returns list of (frame (3,H,W), pos (N,2)) tuples."""
-    rng = np.random.default_rng(seed)
-    out = []
-    for _ in range(n):
-        frames, pos_hist = generate_sequence(n_frames=1, rng=rng)
-        out.append((frames[0], pos_hist[0]))
-    return out
 
 
 # ── 2. JEPA Model ─────────────────────────────────────────────────────────
@@ -325,80 +271,6 @@ def train_probe(encoder, labeled_frames, device, n_epochs=100, lr=1e-3, batch_si
 
     torch.save(probe.state_dict(), os.path.join(DATA_DIR, "probe.pt"))
     return probe, val_acc
-
-
-# ── 5. TL Wiring + Fixpoint ───────────────────────────────────────────────
-
-_DOMAIN = Domain(OBJ_NAMES)
-
-
-def build_tl_state(fact_dict):
-    """fact_dict: {(rel_name, a, b): bool}. Returns dict of derived tensors."""
-    base = {r: torch.zeros(N_OBJ, N_OBJ) for r in RELATIONS}
-    for (rel_name, a, b), val in fact_dict.items():
-        if val and rel_name in base:
-            base[rel_name][OBJ_IDX[a], OBJ_IDX[b]] = 1.0
-
-    # blocked_path[X,Z] = ∃Y≠X,Z: touching(X,Y) ∧ above(Y,Z)
-    blocked_path = apply_body(["touching", "above"], base)
-    blocked_path.fill_diagonal_(0)  # X cannot block path to itself
-
-    # same_side[X,Z] = ∃Y: left_of(X,Y) ∧ left_of(Y,Z)
-    same_side = apply_body(["left_of", "left_of"], base)
-
-    # clear_above[X] = ¬∃Y: above(Y,X)  (1-ary)
-    above_t = base["above"]
-    clear_above = (1.0 - above_t.max(dim=0)[0])
-
-    return {
-        **base,
-        "blocked_path": blocked_path,
-        "same_side": same_side,
-        "clear_above": clear_above,
-    }
-
-
-def remove_object(fact_dict, obj):
-    """Return copy of fact_dict with all facts where obj appears removed."""
-    return {k: v for k, v in fact_dict.items() if k[1] != obj and k[2] != obj}
-
-
-def compute_gt_derived(pos, exclude_obj=None):
-    """Ground-truth derived relations from raw geometry. Returns tensors."""
-    n = len(OBJ_NAMES)
-    blocked = torch.zeros(n, n)
-    same = torch.zeros(n, n)
-    clear = torch.ones(n)
-
-    active = [i for i, nm in enumerate(OBJ_NAMES) if nm != exclude_obj]
-
-    def touching(pi, pj):
-        return max(abs(pi[0] - pj[0]) - OBJ_SIZE, abs(pi[1] - pj[1]) - OBJ_SIZE) < 2
-
-    def above(pi, pj):
-        return pi[1] < pj[1]
-
-    def left_of(pi, pj):
-        return pi[0] < pj[0]
-
-    for xi in active:
-        for zi in active:
-            if xi == zi:
-                continue
-            for yi in active:
-                if yi == xi or yi == zi:
-                    continue
-                if touching(pos[xi], pos[yi]) and above(pos[yi], pos[zi]):
-                    blocked[xi, zi] = 1.0
-                if left_of(pos[xi], pos[yi]) and left_of(pos[yi], pos[zi]):
-                    same[xi, zi] = 1.0
-        for yi in active:
-            if yi == xi:
-                continue
-            if above(pos[yi], pos[xi]):
-                clear[xi] = 0.0
-
-    return {"blocked_path": blocked, "same_side": same, "clear_above": clear}
 
 
 # ── 6. Evaluation ─────────────────────────────────────────────────────────

--- a/experiments/exp83_slot_attention.py
+++ b/experiments/exp83_slot_attention.py
@@ -27,102 +27,38 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from tensor_logic import Domain, Relation
-from tensor_logic.research.utils import f1, apply_body, Schema
+from tensor_logic.research.synthetic_scene import (
+    CANVAS,
+    COLORS,
+    N_OBJ,
+    N_PAIRS,
+    OBJ_IDX,
+    OBJ_NAMES,
+    OBJ_SIZE,
+    PAIR_INDEX,
+    PAIRS,
+    RELATIONS,
+    build_spatial_tl_state as build_tl_state,
+    compute_ground_truth_spatial_derivations as compute_gt_derived,
+    compute_pairwise_spatial_relations as compute_relations,
+    generate_colored_object_sequence as generate_sequence,
+    generate_labeled_scene_frames as generate_labeled_frames,
+    remove_object_facts as remove_object,
+)
 
 torch.manual_seed(42)
 np.random.seed(42)
 
 # ── Constants ──────────────────────────────────────────────────────────────
-CANVAS = 64
-OBJ_SIZE = 10
-N_OBJ = 3
-OBJ_NAMES = ["R", "G", "B"]
-COLORS = [(220, 50, 50), (50, 200, 50), (50, 50, 220)]
-RELATIONS = ["above", "left_of", "touching", "occluded"]
-JEPA_SCHEMA = Schema("jepa", {r: ("obj", "obj") for r in RELATIONS})
-PAIRS = [(a, b) for a in OBJ_NAMES for b in OBJ_NAMES if a != b]
-PAIR_INDEX = {p: i for i, p in enumerate(PAIRS)}
-OBJ_IDX = {n: i for i, n in enumerate(OBJ_NAMES)}
 LATENT_DIM = 64
-N_PAIRS = 6
 DATA_DIR = os.path.join(os.path.dirname(__file__), "exp83_slot_data")
-
-# ── 1. Data Generation ────────────────────────────────────────────────────
-
-def generate_sequence(n_frames=8, rng=None):
-    """Returns frames (T,3,H,W) float32 in [0,1], positions (T,N,2) float64."""
-    if rng is None:
-        rng = np.random.default_rng()
-    half = OBJ_SIZE // 2
-    pos = rng.integers(half + 4, CANVAS - half - 4, size=(N_OBJ, 2)).astype(float)
-    vel = rng.uniform(-3.0, 3.0, size=(N_OBJ, 2))
-
-    frames_np, pos_hist = [], []
-    for _ in range(n_frames):
-        pos += vel
-        for i in range(N_OBJ):
-            for d in range(2):
-                if pos[i, d] < half + 1:
-                    pos[i, d] = half + 1.0
-                    vel[i, d] = abs(vel[i, d])
-                elif pos[i, d] > CANVAS - half - 1:
-                    pos[i, d] = float(CANVAS - half - 1)
-                    vel[i, d] = -abs(vel[i, d])
-        canvas = np.zeros((CANVAS, CANVAS, 3), dtype=np.uint8)
-        for i, (color, p) in enumerate(zip(COLORS, pos)):
-            x, y = int(round(p[0])), int(round(p[1]))
-            canvas[max(0, y - half):min(CANVAS, y + half),
-                   max(0, x - half):min(CANVAS, x + half)] = color
-        frames_np.append(canvas.copy())
-        pos_hist.append(pos.copy())
-
-    frames = torch.from_numpy(np.stack(frames_np)).permute(0, 3, 1, 2).float() / 255.0
-    return frames, np.array(pos_hist)
-
-
-def compute_relations(pos):
-    """pos: (N_OBJ, 2) float array. Returns {(rel, a, b): bool} for all pairs."""
-    rels = {}
-    half = OBJ_SIZE // 2
-    for i, a in enumerate(OBJ_NAMES):
-        for j, b in enumerate(OBJ_NAMES):
-            if i == j:
-                continue
-            pi, pj = pos[i], pos[j]
-            rels[("above", a, b)] = bool(pi[1] < pj[1])
-            rels[("left_of", a, b)] = bool(pi[0] < pj[0])
-            gap_x = abs(pi[0] - pj[0]) - OBJ_SIZE
-            gap_y = abs(pi[1] - pj[1]) - OBJ_SIZE
-            rels[("touching", a, b)] = bool(max(gap_x, gap_y) < 2)
-            bbox = abs(pi[0] - pj[0]) < OBJ_SIZE and abs(pi[1] - pj[1]) < OBJ_SIZE
-            rels[("occluded", a, b)] = bool(bbox and i > j)
-    return rels
-
-
-def generate_labeled_frames(n=500, seed=99):
-    """Returns list of (frame (3,H,W), pos (N,2)) tuples."""
-    rng = np.random.default_rng(seed)
-    out = []
-    for _ in range(n):
-        frames, pos_hist = generate_sequence(n_frames=1, rng=rng)
-        out.append((frames[0], pos_hist[0]))
-    return out
 
 
 from tensor_logic.research.slot_attention import SlotAttention, VisualEncoder
 from scipy.optimize import linear_sum_assignment
 
 # ── Constants ──────────────────────────────────────────────────────────────
-CANVAS = 64
-OBJ_SIZE = 10
-N_OBJ = 3
 N_SLOTS = 4
-OBJ_NAMES = ["R", "G", "B"]
-COLORS = [(220, 50, 50), (50, 200, 50), (50, 50, 220)]
-RELATIONS = ["above", "left_of", "touching", "occluded"]
-LATENT_DIM = 64
-DATA_DIR = os.path.join(os.path.dirname(__file__), "exp83_slot_data")
 
 # ── 2. Slot Models ────────────────────────────────────────────────────────
 
@@ -257,80 +193,6 @@ def eval_slot_pipeline(encoder, slot_attn, color_probe, rel_probe, val_data, dev
                     metrics[f"{rel}_acc"].append(float(preds[ri] == float(rels_gt[(rel, a, b_obj)])))
                     
     return {k: sum(v)/len(v) for k, v in metrics.items()}
-
-
-# ── 5. TL Wiring + Fixpoint ───────────────────────────────────────────────
-
-_DOMAIN = Domain(OBJ_NAMES)
-
-
-def build_tl_state(fact_dict):
-    """fact_dict: {(rel_name, a, b): bool}. Returns dict of derived tensors."""
-    base = {r: torch.zeros(N_OBJ, N_OBJ) for r in RELATIONS}
-    for (rel_name, a, b), val in fact_dict.items():
-        if val and rel_name in base:
-            base[rel_name][OBJ_IDX[a], OBJ_IDX[b]] = 1.0
-
-    # blocked_path[X,Z] = ∃Y≠X,Z: touching(X,Y) ∧ above(Y,Z)
-    blocked_path = apply_body(["touching", "above"], base)
-    blocked_path.fill_diagonal_(0)  # X cannot block path to itself
-    
-    # same_side[X,Z] = ∃Y: left_of(X,Y) ∧ left_of(Y,Z)
-    same_side = apply_body(["left_of", "left_of"], base)
-    
-    # clear_above[X] = ¬∃Y: above(Y,X)  (1-ary)
-    above_t = base["above"]
-    clear_above = (1.0 - above_t.max(dim=0)[0])
-
-    return {
-        **base,
-        "blocked_path": blocked_path,
-        "same_side": same_side,
-        "clear_above": clear_above,
-    }
-
-
-def remove_object(fact_dict, obj):
-    """Return copy of fact_dict with all facts where obj appears removed."""
-    return {k: v for k, v in fact_dict.items() if k[1] != obj and k[2] != obj}
-
-
-def compute_gt_derived(pos, exclude_obj=None):
-    """Ground-truth derived relations from raw geometry. Returns tensors."""
-    n = len(OBJ_NAMES)
-    blocked = torch.zeros(n, n)
-    same = torch.zeros(n, n)
-    clear = torch.ones(n)
-
-    active = [i for i, nm in enumerate(OBJ_NAMES) if nm != exclude_obj]
-
-    def touching(pi, pj):
-        return max(abs(pi[0] - pj[0]) - OBJ_SIZE, abs(pi[1] - pj[1]) - OBJ_SIZE) < 2
-
-    def above(pi, pj):
-        return pi[1] < pj[1]
-
-    def left_of(pi, pj):
-        return pi[0] < pj[0]
-
-    for xi in active:
-        for zi in active:
-            if xi == zi:
-                continue
-            for yi in active:
-                if yi == xi or yi == zi:
-                    continue
-                if touching(pos[xi], pos[yi]) and above(pos[yi], pos[zi]):
-                    blocked[xi, zi] = 1.0
-                if left_of(pos[xi], pos[yi]) and left_of(pos[yi], pos[zi]):
-                    same[xi, zi] = 1.0
-        for yi in active:
-            if yi == xi:
-                continue
-            if above(pos[yi], pos[xi]):
-                clear[xi] = 0.0
-
-    return {"blocked_path": blocked, "same_side": same, "clear_above": clear}
 
 
 # ── 6. Evaluation ─────────────────────────────────────────────────────────

--- a/tensor_logic/research/synthetic_scene.py
+++ b/tensor_logic/research/synthetic_scene.py
@@ -1,0 +1,139 @@
+import numpy as np
+import torch
+
+from tensor_logic.research.utils import apply_body
+
+
+CANVAS = 64
+OBJ_SIZE = 10
+OBJ_NAMES = ["R", "G", "B"]
+COLORS = [(220, 50, 50), (50, 200, 50), (50, 50, 220)]
+RELATIONS = ["above", "left_of", "touching", "occluded"]
+N_OBJ = len(OBJ_NAMES)
+PAIRS = [(a, b) for a in OBJ_NAMES for b in OBJ_NAMES if a != b]
+PAIR_INDEX = {p: i for i, p in enumerate(PAIRS)}
+OBJ_IDX = {n: i for i, n in enumerate(OBJ_NAMES)}
+N_PAIRS = len(PAIRS)
+
+
+def generate_colored_object_sequence(n_frames=8, rng=None):
+    """Return frames and positions for the shared colored-object scene."""
+    if rng is None:
+        rng = np.random.default_rng()
+    half = OBJ_SIZE // 2
+    pos = rng.integers(half + 4, CANVAS - half - 4, size=(N_OBJ, 2)).astype(float)
+    vel = rng.uniform(-3.0, 3.0, size=(N_OBJ, 2))
+
+    frames_np, pos_hist = [], []
+    for _ in range(n_frames):
+        pos += vel
+        for i in range(N_OBJ):
+            for d in range(2):
+                if pos[i, d] < half + 1:
+                    pos[i, d] = half + 1.0
+                    vel[i, d] = abs(vel[i, d])
+                elif pos[i, d] > CANVAS - half - 1:
+                    pos[i, d] = float(CANVAS - half - 1)
+                    vel[i, d] = -abs(vel[i, d])
+        canvas = np.zeros((CANVAS, CANVAS, 3), dtype=np.uint8)
+        for color, p in zip(COLORS, pos):
+            x, y = int(round(p[0])), int(round(p[1]))
+            canvas[
+                max(0, y - half) : min(CANVAS, y + half),
+                max(0, x - half) : min(CANVAS, x + half),
+            ] = color
+        frames_np.append(canvas.copy())
+        pos_hist.append(pos.copy())
+
+    frames = torch.from_numpy(np.stack(frames_np)).permute(0, 3, 1, 2).float() / 255.0
+    return frames, np.array(pos_hist)
+
+
+def compute_pairwise_spatial_relations(pos):
+    """Return all pairwise colored-object spatial facts for a scene."""
+    rels = {}
+    for i, a in enumerate(OBJ_NAMES):
+        for j, b in enumerate(OBJ_NAMES):
+            if i == j:
+                continue
+            pi, pj = pos[i], pos[j]
+            rels[("above", a, b)] = bool(pi[1] < pj[1])
+            rels[("left_of", a, b)] = bool(pi[0] < pj[0])
+            gap_x = abs(pi[0] - pj[0]) - OBJ_SIZE
+            gap_y = abs(pi[1] - pj[1]) - OBJ_SIZE
+            rels[("touching", a, b)] = bool(max(gap_x, gap_y) < 2)
+            bbox = abs(pi[0] - pj[0]) < OBJ_SIZE and abs(pi[1] - pj[1]) < OBJ_SIZE
+            rels[("occluded", a, b)] = bool(bbox and i > j)
+    return rels
+
+
+def generate_labeled_scene_frames(n=500, seed=99):
+    """Return a list of single-frame colored-object scenes with positions."""
+    rng = np.random.default_rng(seed)
+    out = []
+    for _ in range(n):
+        frames, pos_hist = generate_colored_object_sequence(n_frames=1, rng=rng)
+        out.append((frames[0], pos_hist[0]))
+    return out
+
+
+def build_spatial_tl_state(fact_dict):
+    """Build base and derived TL tensors from pairwise spatial facts."""
+    base = {r: torch.zeros(N_OBJ, N_OBJ) for r in RELATIONS}
+    for (rel_name, a, b), val in fact_dict.items():
+        if val and rel_name in base:
+            base[rel_name][OBJ_IDX[a], OBJ_IDX[b]] = 1.0
+
+    blocked_path = apply_body(["touching", "above"], base)
+    blocked_path.fill_diagonal_(0)
+    same_side = apply_body(["left_of", "left_of"], base)
+    clear_above = 1.0 - base["above"].max(dim=0)[0]
+
+    return {
+        **base,
+        "blocked_path": blocked_path,
+        "same_side": same_side,
+        "clear_above": clear_above,
+    }
+
+
+def remove_object_facts(fact_dict, obj):
+    """Return facts with every relation touching obj removed."""
+    return {k: v for k, v in fact_dict.items() if k[1] != obj and k[2] != obj}
+
+
+def compute_ground_truth_spatial_derivations(pos, exclude_obj=None):
+    """Compute derived spatial relations directly from geometry."""
+    blocked = torch.zeros(N_OBJ, N_OBJ)
+    same = torch.zeros(N_OBJ, N_OBJ)
+    clear = torch.ones(N_OBJ)
+    active = [i for i, nm in enumerate(OBJ_NAMES) if nm != exclude_obj]
+
+    for xi in active:
+        for zi in active:
+            if xi == zi:
+                continue
+            for yi in active:
+                if yi == xi or yi == zi:
+                    continue
+                if _touching(pos[xi], pos[yi]) and _above(pos[yi], pos[zi]):
+                    blocked[xi, zi] = 1.0
+                if _left_of(pos[xi], pos[yi]) and _left_of(pos[yi], pos[zi]):
+                    same[xi, zi] = 1.0
+        for yi in active:
+            if yi != xi and _above(pos[yi], pos[xi]):
+                clear[xi] = 0.0
+
+    return {"blocked_path": blocked, "same_side": same, "clear_above": clear}
+
+
+def _touching(pi, pj):
+    return max(abs(pi[0] - pj[0]) - OBJ_SIZE, abs(pi[1] - pj[1]) - OBJ_SIZE) < 2
+
+
+def _above(pi, pj):
+    return pi[1] < pj[1]
+
+
+def _left_of(pi, pj):
+    return pi[0] < pj[0]

--- a/tests/test_synthetic_scene_helpers.py
+++ b/tests/test_synthetic_scene_helpers.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tensor_logic.research import synthetic_scene as scene
+from experiments import exp79_lewm_tl, exp83_slot_attention
+
+
+def test_experiments_use_canonical_spatial_scene_helpers():
+    assert exp79_lewm_tl.generate_sequence is scene.generate_colored_object_sequence
+    assert exp83_slot_attention.generate_sequence is scene.generate_colored_object_sequence
+    assert exp79_lewm_tl.compute_relations is scene.compute_pairwise_spatial_relations
+    assert exp83_slot_attention.compute_relations is scene.compute_pairwise_spatial_relations
+    assert exp79_lewm_tl.build_tl_state is scene.build_spatial_tl_state
+    assert exp83_slot_attention.build_tl_state is scene.build_spatial_tl_state
+    assert exp79_lewm_tl.remove_object is scene.remove_object_facts
+    assert exp83_slot_attention.remove_object is scene.remove_object_facts
+    assert exp79_lewm_tl.compute_gt_derived is scene.compute_ground_truth_spatial_derivations
+    assert exp83_slot_attention.compute_gt_derived is scene.compute_ground_truth_spatial_derivations
+
+
+def test_canonical_pairwise_spatial_relations_cover_all_object_pairs():
+    pos = np.array([[10.0, 10.0], [32.0, 54.0], [20.0, 10.0]])
+    rels = scene.compute_pairwise_spatial_relations(pos)
+
+    assert len(rels) == len(scene.RELATIONS) * len(scene.PAIRS)
+    assert rels[("above", "R", "G")]
+    assert rels[("above", "B", "G")]
+    assert not rels[("above", "G", "R")]
+    assert rels[("left_of", "R", "G")]
+    assert not rels[("left_of", "G", "R")]
+
+
+def test_canonical_spatial_tl_retraction_matches_geometry():
+    pos = np.array([[10.0, 10.0], [32.0, 54.0], [20.0, 10.0]])
+    facts = scene.compute_pairwise_spatial_relations(pos)
+    facts_no_b = scene.remove_object_facts(facts, "B")
+
+    state_no_b = scene.build_spatial_tl_state(facts_no_b)
+    gt_no_b = scene.compute_ground_truth_spatial_derivations(pos, exclude_obj="B")
+
+    assert torch.equal(state_no_b["blocked_path"].round(), gt_no_b["blocked_path"])
+    assert torch.equal(state_no_b["same_side"].round(), gt_no_b["same_side"])
+    assert torch.equal(state_no_b["clear_above"].round(), gt_no_b["clear_above"])


### PR DESCRIPTION
## Summary
- Extract shared colored-object scene generation, pairwise spatial facts, TL derived-state construction, and object-fact retraction into tensor_logic.research.synthetic_scene.
- Route exp79 and exp83 through the canonical helper while preserving their old function names for existing scripts/tests.
- Add tests that prove both experiment call paths use the canonical implementation and validate the retraction rule behavior.

## Validation
- PASS: python3 -m pytest tests/test_synthetic_scene_helpers.py tests/test_exp79.py -q
- PASS: git diff --check
- FAIL: python3 -m pytest -q
  - Existing unrelated failures in tests/test_tensor_logic_core.py::TensorLogicCoreTest::test_query_rejects_wrong_arity_and_unknown_symbols and ::test_recursive_query_rejects_wrong_arity.
  - The implementation raises "relation 'edge' expects 2 args, got N" while those assertions expect "edge expects 2 symbols, got N".

## Residual Risk
- Full-suite failure is outside this duplicate-helper surface and remains unresolved in this PR.