### PR TITLE
Add CLI smoke contract

### DIFF
--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -83,6 +83,16 @@ python3 -m pip install -e ".[dev]"
 python3 -c "import tensor_logic; from tensor_logic import Program; print('tensor_logic import ok')"
 ```
 
+## CLI Smoke Contract
+
+Use this proof when the `python -m tensor_logic` entrypoint or `.tl` file loading
+failure behavior changes. It runs without remote services, secrets, durable
+experiment artifacts, or model downloads:
+
+```bash
+python3 -m pytest tests/test_cli_smoke.py -q
+```
+
 ## Demo Smoke Commands
 
 Demos are useful after changes to examples, tensor-language ergonomics, or

--- a/tensor_logic/__main__.py
+++ b/tensor_logic/__main__.py
@@ -74,7 +74,11 @@ def main(argv: list[str] | None = None) -> int:
         serve(args.host, args.port)
         return 0
 
-    loaded = load_tl(args.file)
+    try:
+        loaded = load_tl(args.file)
+    except (OSError, ValueError) as exc:
+        print(f"tensor-logic: error: {exc}", file=sys.stderr)
+        return 1
 
     if args.cmd == "run":
         for command in loaded.commands:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_tensor_logic_cli_run_smoke(tmp_path):
+    source = tmp_path / "smoke.tl"
+    source.write_text(
+        "\n".join(
+            [
+                "domain Node { a b }",
+                "relation edge(Node, Node)",
+                "fact edge(a, b)",
+                "query edge(a, b)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tensor_logic", "run", str(source)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "edge(a, b) = True" in result.stdout
+
+
+def test_tensor_logic_cli_bad_input_reports_clear_failure(tmp_path):
+    source = tmp_path / "bad.tl"
+    source.write_text("not valid tl\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tensor_logic", "run", str(source)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "tensor-logic: error:" in result.stderr
+    assert "unrecognized statement" in result.stderr
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary
- add a subprocess smoke contract for `python -m tensor_logic run`
- report malformed .tl load failures as concise CLI errors instead of tracebacks
- document the cheap CLI smoke validation command

## Validation
- `python3 -m pytest tests/test_cli_smoke.py -q`
- `python3 -m pytest -q`
- `git diff --check`