### PR TITLE
WP-141: Add CLI smoke contract

### DIFF
--- a/tensor_logic/__main__.py
+++ b/tensor_logic/__main__.py
@@ -50,44 +50,48 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    if args.cmd == "ingest-python":
-        text = render_python_imports_tl(ingest_python(args.path))
-        if args.output:
-            with open(args.output, "w", encoding="utf-8") as f:
-                f.write(text)
-        else:
-            print(text)
-        return 0
-
-    if args.cmd == "repl":
-        _run_repl()
-        return 0
-    if args.cmd == "repo-graph":
-        if args.interactive:
-            repo_graph_repl(args.file)
+    try:
+        if args.cmd == "ingest-python":
+            text = render_python_imports_tl(ingest_python(args.path))
+            if args.output:
+                with open(args.output, "w", encoding="utf-8") as f:
+                    f.write(text)
+            else:
+                print(text)
             return 0
-        if (args.src is None) != (args.dst is None):
-            parser.error("--src and --dst must be provided together")
-        print(dependency_report(args.file, module=args.module, src=args.src, dst=args.dst))
-        return 0
-    if args.cmd == "serve":
-        serve(args.host, args.port)
-        return 0
 
-    loaded = load_tl(args.file)
+        if args.cmd == "repl":
+            _run_repl()
+            return 0
+        if args.cmd == "repo-graph":
+            if args.interactive:
+                repo_graph_repl(args.file)
+                return 0
+            if (args.src is None) != (args.dst is None):
+                parser.error("--src and --dst must be provided together")
+            print(dependency_report(args.file, module=args.module, src=args.src, dst=args.dst))
+            return 0
+        if args.cmd == "serve":
+            serve(args.host, args.port)
+            return 0
 
-    if args.cmd == "run":
-        for command in loaded.commands:
-            _execute_command(loaded.program, command, "tree")
-        return 0
-    if args.cmd == "query":
-        _execute_command(loaded.program, Command("query", args.relation, tuple(args.args), args.recursive), "tree")
-        return 0
-    if args.cmd == "prove":
-        format_type = getattr(args, "format", "tree")
-        why_not = getattr(args, "why_not", False)
-        _execute_command(loaded.program, Command("prove", args.relation, tuple(args.args), args.recursive), format_type, why_not=why_not)
-        return 0
+        loaded = load_tl(args.file)
+
+        if args.cmd == "run":
+            for command in loaded.commands:
+                _execute_command(loaded.program, command, "tree")
+            return 0
+        if args.cmd == "query":
+            _execute_command(loaded.program, Command("query", args.relation, tuple(args.args), args.recursive), "tree")
+            return 0
+        if args.cmd == "prove":
+            format_type = getattr(args, "format", "tree")
+            why_not = getattr(args, "why_not", False)
+            _execute_command(loaded.program, Command("prove", args.relation, tuple(args.args), args.recursive), format_type, why_not=why_not)
+            return 0
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
     return 1
 
 

--- a/tests/test_cli_smoke_contract.py
+++ b/tests/test_cli_smoke_contract.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_tensor_logic_cli_help_smoke_runs_without_secrets():
+    result = subprocess.run(
+        [sys.executable, "-m", "tensor_logic", "--help"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "usage: tensor-logic" in result.stdout
+    assert "{run,query,prove,ingest-python,repl,repo-graph,serve}" in result.stdout
+
+
+def test_tensor_logic_cli_query_smoke_parses_and_executes_temp_tl(tmp_path):
+    tl_file = tmp_path / "smoke.tl"
+    tl_file.write_text(
+        "\n".join(
+            [
+                "domain Node { a, b }",
+                "relation edge(Node, Node)",
+                "fact edge(a, b)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tensor_logic", "query", str(tl_file), "edge", "a", "b"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "edge(a, b) = True"
+
+
+def test_tensor_logic_cli_bad_input_returns_clear_nonzero_failure(tmp_path):
+    missing_file = tmp_path / "missing.tl"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tensor_logic", "run", str(missing_file)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Error:" in result.stderr
+    assert str(missing_file) in result.stderr
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary
- add pytest smoke coverage for the tensor_logic CLI help, temp-file query path, and missing-file failure reporting
- report operational CLI ValueError/OSError failures as clear nonzero `Error:` messages instead of tracebacks

## Validation
- `python3 -m pytest tests/test_cli_smoke_contract.py -q` -> 3 passed
- `python3 -m pytest -q` -> 216 passed
- `git diff --check` -> passed

## Residual Risk
- The smoke contract covers the existing `python -m tensor_logic` entrypoint, not an installed console script because this package does not declare one today.