### PR TITLE
Separate experiment fixtures from runtime outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ make_post_charts.py
 chart*.png
 /.cocoindex_code/
 tools/index.json
+/.runtime/
 dist/
 build/
 *.egg-info/
-

--- a/docs/EXPERIMENT_PROVENANCE.md
+++ b/docs/EXPERIMENT_PROVENANCE.md
@@ -37,6 +37,11 @@ If an experiment writes weights, adapters, large outputs, or remote artifacts,
 do not commit those binaries. Commit `results.json` and a pointer file such as
 `ADAPTER.md` or `PROVENANCE.md` instead.
 
+Default local reruns should write to ignored `.runtime/experiments/` paths.
+Committed `experiments/*_data/results*.json` files are fixtures/evidence and
+should only be refreshed with an explicit output path plus an experiment-log
+entry or provenance note.
+
 ## Current Result Artifact Index
 
 This is a repo-local pointer index, not a full metric table. Read the linked

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -173,10 +173,11 @@ was not refreshed.
 ## Expected Artifacts
 
 Cheap CI proofs should leave no durable artifact except the gitignored
-`tools/index.json` when the code-index command rebuilds it.
+`tools/index.json` when the code-index command rebuilds it, or ignored
+`.runtime/` files when a script default writes local runtime output.
 
-Experiment runs may intentionally write artifacts under experiment-specific
-directories, for example:
+Committed experiment fixtures live under experiment-specific directories, for
+example:
 
 - `experiments/exp78_data/results.json`
 - `experiments/exp79_data/results.json`
@@ -185,4 +186,6 @@ directories, for example:
 - `experiments/exp83_slot_data/complexity_curve.png`
 
 Do not create, refresh, or commit experiment artifacts as part of default
-validation unless the issue explicitly owns those outputs.
+validation unless the issue explicitly owns those outputs. Prefer script
+defaults or explicit temporary `--output` paths for validation; pass an
+`experiments/*_data/` path only when intentionally refreshing evidence.

--- a/experiments/exp87_support_eval.py
+++ b/experiments/exp87_support_eval.py
@@ -24,6 +24,7 @@ from experiments.exp86_support_baselines import (
     tensorize_scenes,
     train_model,
 )
+from experiments.runtime_paths import default_runtime_result_path, portable_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp87_support_data")
@@ -335,11 +336,7 @@ def _build_gates(tl: dict[str, object], baselines: dict[str, dict[str, object]])
 
 
 def _portable_path(path: Path) -> str:
-    resolved = path.resolve()
-    try:
-        return str(resolved.relative_to(Path.cwd().resolve()))
-    except ValueError:
-        return str(resolved)
+    return portable_path(path)
 
 
 def run_evaluation(config: EvalConfig, output_path: Path | None = None) -> dict[str, object]:
@@ -388,7 +385,7 @@ def run_evaluation(config: EvalConfig, output_path: Path | None = None) -> dict[
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = default_runtime_result_path(RESULT_DIR, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     results["results_path"] = _portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/experiments/exp88_support_noisy_relations.py
+++ b/experiments/exp88_support_noisy_relations.py
@@ -21,6 +21,7 @@ if __package__ in {None, ""}:
 
 from experiments.exp85_support_tl import PrimitiveRelations, SupportTolerance, extract_primitives, infer_stability
 from experiments.exp87_support_eval import EvalConfig, make_splits
+from experiments.runtime_paths import default_runtime_result_path, portable_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp88_support_noisy_relations_data")
@@ -379,12 +380,9 @@ def run_noise_evaluation(config: NoiseConfig, output_path: Path | None = None) -
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = default_runtime_result_path(RESULT_DIR, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp89_support_primitive_confidence.py
+++ b/experiments/exp89_support_primitive_confidence.py
@@ -22,6 +22,7 @@ if __package__ in {None, ""}:
 from experiments.exp85_support_tl import SupportTolerance, infer_stability
 from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp88_support_noisy_relations import perturb_objects
+from experiments.runtime_paths import default_runtime_result_path, portable_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp89_support_primitive_confidence_data")
@@ -413,12 +414,9 @@ def run_confidence_evaluation(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = default_runtime_result_path(RESULT_DIR, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp90_support_repair_sweep.py
+++ b/experiments/exp90_support_repair_sweep.py
@@ -23,6 +23,7 @@ from experiments.exp85_support_tl import SupportTolerance, infer_stability
 from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp88_support_noisy_relations import perturb_objects
 from experiments.exp89_support_primitive_confidence import prediction_confidences
+from experiments.runtime_paths import default_runtime_result_path, portable_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp90_support_repair_sweep_data")
@@ -643,12 +644,9 @@ def run_repair_evaluation(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = default_runtime_result_path(RESULT_DIR, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp91_interval_support_uncertainty.py
+++ b/experiments/exp91_interval_support_uncertainty.py
@@ -22,6 +22,7 @@ from experiments.exp85_support_tl import SupportTolerance, infer_stability
 from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp88_support_noisy_relations import perturb_objects
 from experiments.exp89_support_primitive_confidence import prediction_confidences
+from experiments.runtime_paths import default_runtime_result_path, portable_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp91_interval_support_uncertainty_data")
@@ -491,12 +492,9 @@ def run_interval_evaluation(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = default_runtime_result_path(RESULT_DIR, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp92_pixel_abstain_recover.py
+++ b/experiments/exp92_pixel_abstain_recover.py
@@ -28,6 +28,7 @@ from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp89_support_primitive_confidence import prediction_confidences
 from experiments.exp90_support_repair_sweep import repair_objects
 from experiments.exp91_interval_support_uncertainty import possible_stability
+from experiments.runtime_paths import default_runtime_result_path, portable_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp92_pixel_abstain_recover_data")
@@ -540,12 +541,9 @@ def run_pixel_benchmark(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = default_runtime_result_path(RESULT_DIR, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp93_detector_calibration_stress.py
+++ b/experiments/exp93_detector_calibration_stress.py
@@ -25,6 +25,7 @@ from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp89_support_primitive_confidence import prediction_confidences
 from experiments.exp90_support_repair_sweep import repair_objects
 from experiments.exp91_interval_support_uncertainty import possible_stability
+from experiments.runtime_paths import default_runtime_result_path, portable_path
 from experiments.exp92_pixel_abstain_recover import (
     DetectedTable,
     detect_object_table,
@@ -626,12 +627,9 @@ def run_detector_stress(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = default_runtime_result_path(RESULT_DIR, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp94_object_hypothesis_layer.py
+++ b/experiments/exp94_object_hypothesis_layer.py
@@ -23,6 +23,7 @@ from experiments.exp85_support_tl import SupportTolerance, infer_stability
 from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp90_support_repair_sweep import repair_objects
 from experiments.exp91_interval_support_uncertainty import possible_stability
+from experiments.runtime_paths import default_runtime_result_path, portable_path
 from experiments.exp92_pixel_abstain_recover import detect_object_table, render_scene
 from experiments.exp93_detector_calibration_stress import (
     FAILURE_MODES,
@@ -531,12 +532,9 @@ def run_object_hypothesis_layer(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = default_runtime_result_path(RESULT_DIR, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp95_scored_object_hypotheses.py
+++ b/experiments/exp95_scored_object_hypotheses.py
@@ -24,6 +24,7 @@ from experiments.exp85_support_tl import SupportTolerance, infer_stability
 from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp90_support_repair_sweep import repair_objects
 from experiments.exp91_interval_support_uncertainty import possible_stability
+from experiments.runtime_paths import default_runtime_result_path, portable_path
 from experiments.exp92_pixel_abstain_recover import detect_object_table, render_scene
 from experiments.exp93_detector_calibration_stress import (
     FAILURE_MODES,
@@ -749,12 +750,9 @@ def run_scored_object_hypotheses(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = default_runtime_result_path(RESULT_DIR, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/runtime_paths.py
+++ b/experiments/runtime_paths.py
@@ -1,0 +1,27 @@
+"""Runtime output paths for experiment scripts.
+
+Committed ``experiments/*_data`` files are evidence fixtures. Default script
+runs should write to ignored local state unless the caller passes an explicit
+output path to refresh a fixture intentionally.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_EXPERIMENTS_DIR = REPO_ROOT / ".runtime" / "experiments"
+
+
+def default_runtime_result_path(result_dir: Path, *, quick: bool) -> Path:
+    filename = "results_quick.json" if quick else "results.json"
+    return RUNTIME_EXPERIMENTS_DIR / result_dir.name / filename
+
+
+def portable_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(resolved)

--- a/tests/test_runtime_outputs.py
+++ b/tests/test_runtime_outputs.py
@@ -1,0 +1,48 @@
+import ast
+from pathlib import Path
+
+from experiments.runtime_paths import default_runtime_result_path
+
+
+SUPPORT_RESULT_SCRIPTS = [
+    Path("experiments/exp87_support_eval.py"),
+    Path("experiments/exp88_support_noisy_relations.py"),
+    Path("experiments/exp89_support_primitive_confidence.py"),
+    Path("experiments/exp90_support_repair_sweep.py"),
+    Path("experiments/exp91_interval_support_uncertainty.py"),
+    Path("experiments/exp92_pixel_abstain_recover.py"),
+    Path("experiments/exp93_detector_calibration_stress.py"),
+    Path("experiments/exp94_object_hypothesis_layer.py"),
+    Path("experiments/exp95_scored_object_hypotheses.py"),
+]
+
+
+def _assigns_default_runtime_path(script: Path) -> bool:
+    tree = ast.parse(script.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "output_path" for target in node.targets):
+            continue
+        value = node.value
+        if isinstance(value, ast.Call) and isinstance(value.func, ast.Name):
+            if value.func.id == "default_runtime_result_path":
+                return True
+    return False
+
+
+def test_default_runtime_result_path_stays_out_of_fixture_dirs():
+    fixture_dir = Path("experiments/exp87_support_data")
+
+    assert default_runtime_result_path(fixture_dir, quick=False) == Path(
+        ".runtime/experiments/exp87_support_data/results.json"
+    ).resolve()
+    assert default_runtime_result_path(fixture_dir, quick=True) == Path(
+        ".runtime/experiments/exp87_support_data/results_quick.json"
+    ).resolve()
+
+
+def test_support_experiment_defaults_use_ignored_runtime_paths():
+    missing = [str(script) for script in SUPPORT_RESULT_SCRIPTS if not _assigns_default_runtime_path(script)]
+
+    assert missing == []


### PR DESCRIPTION
## Summary
- Add a shared runtime output path helper that sends default support experiment results to ignored .runtime/experiments paths.
- Keep explicit output paths available for intentional fixture refreshes.
- Document fixture/runtime separation and add a regression test for support experiment defaults.

## Validation
- python3 -m pytest -q
- git diff --check

## Work pack
WP-172: Separate fixtures from runtime outputs