### PR TITLE
Separate fixture artifacts from runtime outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ make_post_charts.py
 chart*.png
 /.cocoindex_code/
 tools/index.json
+runtime_outputs/
 dist/
 build/
 *.egg-info/
-

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,9 +67,10 @@ files.
 ## Experiment Map
 
 - `demos/`: small runnable demonstrations of a single idea.
-- `experiments/`: historical and active experiment scripts. Many scripts write
-  result JSON by default, so use explicit temporary `--output` paths when
-  validating unless the work order owns those artifacts.
+- `experiments/`: historical and active experiment scripts. Active result
+  writers default to ignored `runtime_outputs/experiments/` paths; pass an
+  explicit `--out`, `--output`, or `--output-dir` only when intentionally
+  refreshing committed `experiments/*_data/` evidence fixtures.
 - `phase_training/`: embodied-agent and phase-training experiments.
 - `notes/`: long-form research notes, memos, transcript material.
 - `web_workbench/`: local web workbench that exercises package behavior through
@@ -111,9 +112,9 @@ Use `docs/VALIDATION.md` as the source of truth for validation tiers.
   `python3 -m pytest tests/test_packaging_ci.py tests/test_code_index.py -v`.
 - **Support/stability fast path**:
   `python3 -m pytest tests/test_exp84_support_data.py tests/test_exp85_support_tl.py -v`.
-- **CLI smoke without repo mutation**: pass explicit temp output paths to
-  experiment scripts that otherwise write under tracked `experiments/*_data/`
-  directories.
+- **CLI smoke without repo mutation**: use script defaults or explicit temp
+  output paths; committed `experiments/*_data/` directories are fixture targets,
+  not default runtime output targets.
 
 ## Maintainer Notes For Agents
 

--- a/docs/EXPERIMENT_PROVENANCE.md
+++ b/docs/EXPERIMENT_PROVENANCE.md
@@ -37,6 +37,17 @@ If an experiment writes weights, adapters, large outputs, or remote artifacts,
 do not commit those binaries. Commit `results.json` and a pointer file such as
 `ADAPTER.md` or `PROVENANCE.md` instead.
 
+## Runtime Outputs Versus Fixtures
+
+Default local experiment runs write under ignored `runtime_outputs/experiments/`
+paths. Checked-in `experiments/*_data/` directories are deterministic evidence
+fixtures and should only be refreshed intentionally by passing an explicit
+`--out`, `--output`, or `--output-dir` path into the fixture directory.
+
+When refreshing a fixture, preserve the previous evidence unless it is
+explicitly obsolete, and document the command, commit, dependency context, and
+claim boundary in this file or the relevant experiment note.
+
 ## Current Result Artifact Index
 
 This is a repo-local pointer index, not a full metric table. Read the linked

--- a/experiments/exp60a_kinship_traces.py
+++ b/experiments/exp60a_kinship_traces.py
@@ -36,6 +36,12 @@ Sweep: NAMES = 12 people, GRAPHS = 1000 train + 200 eval, 4 query types
 import json
 import random
 from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from experiments.runtime_paths import experiment_output_dir
 
 NAMES = [
     "alice", "bob", "carol", "dave", "eve", "frank",
@@ -243,16 +249,19 @@ def main():
     ap.add_argument("--hard", action="store_true",
                     help="Generate harder eval set: 25-35 person graphs, "
                          "hops 6-10, distractor relations.")
+    default_out_dir = experiment_output_dir("exp60a_kinship_traces")
     ap.add_argument("--out", default=None,
                     help="Output filename (default: train+eval for normal, "
                          "eval_hard.jsonl for --hard).")
+    ap.add_argument("--out-dir", type=Path, default=default_out_dir,
+                    help="Output directory for generated traces.")
     ap.add_argument("--n", type=int, default=200,
                     help="Number of traces (only used with --hard).")
     args = ap.parse_args()
 
     rng = random.Random(42 if not args.hard else 1337)
-    out_dir = Path(__file__).parent / "exp60_data"
-    out_dir.mkdir(exist_ok=True)
+    out_dir = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     if args.hard:
         out_path = out_dir / (args.out or "eval_hard.jsonl")

--- a/experiments/exp60d_sft.py
+++ b/experiments/exp60d_sft.py
@@ -34,6 +34,12 @@ import json
 import re
 from pathlib import Path
 from collections import defaultdict
+import sys
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from experiments.runtime_paths import experiment_output_dir
 
 HERE = Path(__file__).parent
 DATA = HERE / "exp60_data"
@@ -339,7 +345,7 @@ def main():
     ap.add_argument("--model", default="Qwen/Qwen2.5-0.5B-Instruct")
     ap.add_argument("--epochs", type=int, default=1)
     ap.add_argument("--lr", type=float, default=2e-4)
-    ap.add_argument("--out", default=str(HERE / "exp60_data" / "lora_adapter"))
+    ap.add_argument("--out", default=str(experiment_output_dir("exp60d_sft") / "lora_adapter"))
     ap.add_argument("--skip-train", action="store_true",
                     help="Skip training; eval base LM only (condition A).")
     ap.add_argument("--eval-only", action="store_true",

--- a/experiments/exp76a_rule_traces.py
+++ b/experiments/exp76a_rule_traces.py
@@ -39,6 +39,12 @@ evaluate_rule.
 import json
 import random
 from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from experiments.runtime_paths import experiment_output_dir
 
 NAMES = [
     "alice", "bob", "carol", "dave", "eve", "frank", "grace", "henry",
@@ -194,8 +200,14 @@ def make_trace(rng, rule_type, want_positive=None):
 
 def main():
     rng = random.Random(7)
-    out_dir = Path(__file__).parent / "exp76_data"
-    out_dir.mkdir(exist_ok=True)
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-dir", type=Path, default=experiment_output_dir("exp76a_rule_traces"),
+                    help="Output directory for generated train/eval traces.")
+    args = ap.parse_args()
+
+    out_dir = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     rules = list(RULE_BODIES.keys())  # 4 rule types
     splits = [("train", 2000), ("eval", 400)]

--- a/experiments/exp76b_hard_eval.py
+++ b/experiments/exp76b_hard_eval.py
@@ -14,7 +14,12 @@ a half-hard variant — names+graph only, original templates — for ablation).
 import json
 import random
 from pathlib import Path
+import sys
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from experiments.runtime_paths import experiment_output_dir
 from exp76a_rule_traces import (
     RULE_BODIES,
     derive_siblings,
@@ -102,8 +107,16 @@ def make_hard_trace(rng, rule_type, want_positive):
 
 
 def main():
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", type=Path, default=experiment_output_dir("exp76b_hard_eval") / "eval_hard.jsonl",
+                    help="Output JSONL path for generated hard eval traces.")
+    args = ap.parse_args()
+
     rng = random.Random(76)
-    out_path = Path(__file__).parent / "exp76_data" / "eval_hard.jsonl"
+    out_path = args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     rules = list(RULE_BODIES.keys())
     n = 200
     rule_counts = {}

--- a/experiments/exp76c_paraphrase_train.py
+++ b/experiments/exp76c_paraphrase_train.py
@@ -19,7 +19,12 @@ from a 5-paraphrase pool).
 import json
 import random
 from pathlib import Path
+import sys
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from experiments.runtime_paths import experiment_output_dir
 from exp76a_rule_traces import (
     NAMES,
     RULE_BODIES,
@@ -96,8 +101,16 @@ def make_paraphrased_trace(rng, rule_type, want_positive):
 
 
 def main():
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", type=Path, default=experiment_output_dir("exp76c_paraphrase_train") / "train_paraphrased.jsonl",
+                    help="Output JSONL path for generated paraphrased train traces.")
+    args = ap.parse_args()
+
     rng = random.Random(76)
-    out_path = Path(__file__).parent / "exp76_data" / "train_paraphrased.jsonl"
+    out_path = args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     rules = list(RULE_BODIES.keys())
     n = 2000
     rule_counts = {}

--- a/experiments/exp78_rule_induction.py
+++ b/experiments/exp78_rule_induction.py
@@ -23,8 +23,12 @@ Metrics per target:
 """
 import argparse
 import json
+import sys
 import time
 from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import torch
 
@@ -38,8 +42,10 @@ from tensor_logic.research.utils import (
     sample_examples,
     semantic_equiv,
 )
+from experiments.runtime_paths import result_path
 
 HERE = Path(__file__).parent
+EXPERIMENT_NAME = "exp78_rule_induction"
 
 
 # ---------- LM pruner (v2) ----------
@@ -199,7 +205,7 @@ def eval_split(name: str, targets: list, schema_for_world, n_pos: int = 20,
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--out", default=str(HERE / "exp78_data" / "results.json"))
+    ap.add_argument("--out", default=str(result_path(EXPERIMENT_NAME)))
     ap.add_argument("--n-pos", type=int, default=20)
     ap.add_argument("--n-neg", type=int, default=20)
     ap.add_argument("--n-entities", type=int, default=8)

--- a/experiments/exp79_lewm_tl.py
+++ b/experiments/exp79_lewm_tl.py
@@ -45,6 +45,7 @@ from tensor_logic.research.synthetic_scene import (
     generate_labeled_scene_frames as generate_labeled_frames,
     remove_object_facts as remove_object,
 )
+from experiments.runtime_paths import experiment_output_dir
 from tensor_logic.research.utils import f1, Schema
 
 torch.manual_seed(42)
@@ -53,7 +54,8 @@ np.random.seed(42)
 # ── Constants ──────────────────────────────────────────────────────────────
 JEPA_SCHEMA = Schema("jepa", {r: ("obj", "obj") for r in RELATIONS})
 LATENT_DIM = 64
-DATA_DIR = os.path.join(os.path.dirname(__file__), "exp79_data")
+FIXTURE_DATA_DIR = os.path.join(os.path.dirname(__file__), "exp79_data")
+DATA_DIR = str(experiment_output_dir("exp79_lewm_tl"))
 
 
 # ── 2. JEPA Model ─────────────────────────────────────────────────────────
@@ -398,10 +400,15 @@ def compute_complexity_scaling(val_acc, val_frames, probe, encoder, device):
 # ── Main ──────────────────────────────────────────────────────────────────
 
 def main():
+    global DATA_DIR
+
     parser = argparse.ArgumentParser(description="exp79: LeWM + TL relational layer")
     parser.add_argument("--skip-train", action="store_true",
                         help="Load saved encoder.pt and probe.pt instead of retraining")
+    parser.add_argument("--output-dir", default=DATA_DIR,
+                        help=f"Directory for runtime outputs; use {FIXTURE_DATA_DIR} only when intentionally refreshing fixtures.")
     args = parser.parse_args()
+    DATA_DIR = args.output_dir
 
     device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
     print(f"Device: {device}")

--- a/experiments/exp83_slot_attention.py
+++ b/experiments/exp83_slot_attention.py
@@ -45,13 +45,15 @@ from tensor_logic.research.synthetic_scene import (
     generate_labeled_scene_frames as generate_labeled_frames,
     remove_object_facts as remove_object,
 )
+from experiments.runtime_paths import experiment_output_dir
 
 torch.manual_seed(42)
 np.random.seed(42)
 
 # ── Constants ──────────────────────────────────────────────────────────────
 LATENT_DIM = 64
-DATA_DIR = os.path.join(os.path.dirname(__file__), "exp83_slot_data")
+FIXTURE_DATA_DIR = os.path.join(os.path.dirname(__file__), "exp83_slot_data")
+DATA_DIR = str(experiment_output_dir("exp83_slot_attention"))
 
 
 from tensor_logic.research.slot_attention import SlotAttention, VisualEncoder
@@ -327,10 +329,15 @@ def compute_complexity_scaling(val_metrics, val_frames, encoder, slot_attn, colo
 # ── Main ──────────────────────────────────────────────────────────────────
 
 def main():
+    global DATA_DIR
+
     parser = argparse.ArgumentParser(description="exp83: Slot Attention + TL relational layer")
     parser.add_argument("--skip-train", action="store_true",
                         help="Skip training (not supported in this PoC yet)")
+    parser.add_argument("--output-dir", default=DATA_DIR,
+                        help=f"Directory for runtime outputs; use {FIXTURE_DATA_DIR} only when intentionally refreshing fixtures.")
     args = parser.parse_args()
+    DATA_DIR = args.output_dir
 
     device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
     print(f"Device: {device}")

--- a/experiments/exp87_support_eval.py
+++ b/experiments/exp87_support_eval.py
@@ -24,9 +24,11 @@ from experiments.exp86_support_baselines import (
     tensorize_scenes,
     train_model,
 )
+from experiments.runtime_paths import portable_path, result_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp87_support_data")
+EXPERIMENT_NAME = "exp87_support_eval"
 OOD_GATE_SPLITS = ("larger_ood", "deeper_ood")
 
 
@@ -334,14 +336,6 @@ def _build_gates(tl: dict[str, object], baselines: dict[str, dict[str, object]])
     }
 
 
-def _portable_path(path: Path) -> str:
-    resolved = path.resolve()
-    try:
-        return str(resolved.relative_to(Path.cwd().resolve()))
-    except ValueError:
-        return str(resolved)
-
-
 def run_evaluation(config: EvalConfig, output_path: Path | None = None) -> dict[str, object]:
     train, eval_splits = make_splits(config)
     split_summaries = {"train": _split_summary(train)}
@@ -388,9 +382,9 @@ def run_evaluation(config: EvalConfig, output_path: Path | None = None) -> dict[
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = result_path(EXPERIMENT_NAME, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    results["results_path"] = _portable_path(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp88_support_noisy_relations.py
+++ b/experiments/exp88_support_noisy_relations.py
@@ -21,9 +21,11 @@ if __package__ in {None, ""}:
 
 from experiments.exp85_support_tl import PrimitiveRelations, SupportTolerance, extract_primitives, infer_stability
 from experiments.exp87_support_eval import EvalConfig, make_splits
+from experiments.runtime_paths import portable_path, result_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp88_support_noisy_relations_data")
+EXPERIMENT_NAME = "exp88_support_noisy_relations"
 BINARY_RELATIONS = ("touching", "above", "horiz_overlap")
 GEOMETRY_MODES = {
     "x_only": ("x",),
@@ -379,12 +381,9 @@ def run_noise_evaluation(config: NoiseConfig, output_path: Path | None = None) -
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = result_path(EXPERIMENT_NAME, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp89_support_primitive_confidence.py
+++ b/experiments/exp89_support_primitive_confidence.py
@@ -22,9 +22,11 @@ if __package__ in {None, ""}:
 from experiments.exp85_support_tl import SupportTolerance, infer_stability
 from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp88_support_noisy_relations import perturb_objects
+from experiments.runtime_paths import portable_path, result_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp89_support_primitive_confidence_data")
+EXPERIMENT_NAME = "exp89_support_primitive_confidence"
 GEOMETRY_MODES = {
     "x_only": ("x",),
     "y_only": ("y",),
@@ -413,12 +415,9 @@ def run_confidence_evaluation(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = result_path(EXPERIMENT_NAME, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp90_support_repair_sweep.py
+++ b/experiments/exp90_support_repair_sweep.py
@@ -23,9 +23,11 @@ from experiments.exp85_support_tl import SupportTolerance, infer_stability
 from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp88_support_noisy_relations import perturb_objects
 from experiments.exp89_support_primitive_confidence import prediction_confidences
+from experiments.runtime_paths import portable_path, result_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp90_support_repair_sweep_data")
+EXPERIMENT_NAME = "exp90_support_repair_sweep"
 GEOMETRY_MODES = {
     "x_only": ("x",),
     "y_only": ("y",),
@@ -643,12 +645,9 @@ def run_repair_evaluation(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = result_path(EXPERIMENT_NAME, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp91_interval_support_uncertainty.py
+++ b/experiments/exp91_interval_support_uncertainty.py
@@ -22,9 +22,11 @@ from experiments.exp85_support_tl import SupportTolerance, infer_stability
 from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp88_support_noisy_relations import perturb_objects
 from experiments.exp89_support_primitive_confidence import prediction_confidences
+from experiments.runtime_paths import portable_path, result_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp91_interval_support_uncertainty_data")
+EXPERIMENT_NAME = "exp91_interval_support_uncertainty"
 GEOMETRY_MODES = {
     "x_only": ("x",),
     "y_only": ("y",),
@@ -491,12 +493,9 @@ def run_interval_evaluation(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = result_path(EXPERIMENT_NAME, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp92_pixel_abstain_recover.py
+++ b/experiments/exp92_pixel_abstain_recover.py
@@ -28,9 +28,11 @@ from experiments.exp87_support_eval import EvalConfig, make_splits
 from experiments.exp89_support_primitive_confidence import prediction_confidences
 from experiments.exp90_support_repair_sweep import repair_objects
 from experiments.exp91_interval_support_uncertainty import possible_stability
+from experiments.runtime_paths import portable_path, result_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp92_pixel_abstain_recover_data")
+EXPERIMENT_NAME = "exp92_pixel_abstain_recover"
 LOCALIZATION_MODES = {
     "x_only": ("x",),
     "y_only": ("y",),
@@ -540,12 +542,9 @@ def run_pixel_benchmark(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = result_path(EXPERIMENT_NAME, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp93_detector_calibration_stress.py
+++ b/experiments/exp93_detector_calibration_stress.py
@@ -30,9 +30,11 @@ from experiments.exp92_pixel_abstain_recover import (
     detect_object_table,
     render_scene,
 )
+from experiments.runtime_paths import portable_path, result_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp93_detector_calibration_stress_data")
+EXPERIMENT_NAME = "exp93_detector_calibration_stress"
 LOCALIZATION_MODES = {
     "x_only": ("x",),
     "y_only": ("y",),
@@ -626,12 +628,9 @@ def run_detector_stress(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = result_path(EXPERIMENT_NAME, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp94_object_hypothesis_layer.py
+++ b/experiments/exp94_object_hypothesis_layer.py
@@ -33,9 +33,11 @@ from experiments.exp93_detector_calibration_stress import (
     _seed_for,
     apply_detector_stress,
 )
+from experiments.runtime_paths import portable_path, result_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp94_object_hypothesis_layer_data")
+EXPERIMENT_NAME = "exp94_object_hypothesis_layer"
 STRUCTURAL_FAILURE_MODES = tuple(mode for mode in FAILURE_MODES if mode != "coordinate")
 
 
@@ -531,12 +533,9 @@ def run_object_hypothesis_layer(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = result_path(EXPERIMENT_NAME, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/exp95_scored_object_hypotheses.py
+++ b/experiments/exp95_scored_object_hypotheses.py
@@ -39,9 +39,11 @@ from experiments.exp94_object_hypothesis_layer import (
     ObjectHypothesisConfig,
     evaluate_object_hypothesis_scene,
 )
+from experiments.runtime_paths import portable_path, result_path
 
 
 RESULT_DIR = Path(__file__).with_name("exp95_scored_object_hypotheses_data")
+EXPERIMENT_NAME = "exp95_scored_object_hypotheses"
 STRUCTURAL_FAILURE_MODES = tuple(mode for mode in FAILURE_MODES if mode != "coordinate")
 
 
@@ -749,12 +751,9 @@ def run_scored_object_hypotheses(
     }
 
     if output_path is None:
-        output_path = RESULT_DIR / ("results_quick.json" if config.quick else "results.json")
+        output_path = result_path(EXPERIMENT_NAME, quick=config.quick)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        results["results_path"] = str(output_path.resolve().relative_to(Path.cwd().resolve()))
-    except ValueError:
-        results["results_path"] = str(output_path)
+    results["results_path"] = portable_path(output_path)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return results
 

--- a/experiments/runtime_paths.py
+++ b/experiments/runtime_paths.py
@@ -1,0 +1,26 @@
+"""Local runtime output paths for experiment scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_OUTPUT_ROOT = REPO_ROOT / "runtime_outputs" / "experiments"
+
+
+def experiment_output_dir(experiment_name: str) -> Path:
+    return RUNTIME_OUTPUT_ROOT / experiment_name
+
+
+def result_path(experiment_name: str, quick: bool = False) -> Path:
+    filename = "results_quick.json" if quick else "results.json"
+    return experiment_output_dir(experiment_name) / filename
+
+
+def portable_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)

--- a/tests/test_runtime_output_paths.py
+++ b/tests/test_runtime_output_paths.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+import subprocess
+
+import experiments.exp78_rule_induction as exp78
+import experiments.exp79_lewm_tl as exp79
+import experiments.exp87_support_eval as exp87
+import experiments.exp88_support_noisy_relations as exp88
+import experiments.exp89_support_primitive_confidence as exp89
+import experiments.exp90_support_repair_sweep as exp90
+import experiments.exp91_interval_support_uncertainty as exp91
+import experiments.exp92_pixel_abstain_recover as exp92
+import experiments.exp93_detector_calibration_stress as exp93
+import experiments.exp94_object_hypothesis_layer as exp94
+import experiments.exp95_scored_object_hypotheses as exp95
+from experiments.runtime_paths import RUNTIME_OUTPUT_ROOT, result_path
+
+
+def test_runtime_output_root_is_git_ignored():
+    candidate = RUNTIME_OUTPUT_ROOT / "example" / "results.json"
+
+    completed = subprocess.run(
+        ["git", "check-ignore", str(candidate)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "runtime_outputs/" in completed.stdout
+
+
+def test_default_runtime_paths_do_not_target_tracked_fixtures():
+    experiment_names = [
+        exp78.EXPERIMENT_NAME,
+        exp87.EXPERIMENT_NAME,
+        exp88.EXPERIMENT_NAME,
+        exp89.EXPERIMENT_NAME,
+        exp90.EXPERIMENT_NAME,
+        exp91.EXPERIMENT_NAME,
+        exp92.EXPERIMENT_NAME,
+        exp93.EXPERIMENT_NAME,
+        exp94.EXPERIMENT_NAME,
+        exp95.EXPERIMENT_NAME,
+    ]
+
+    for experiment_name in experiment_names:
+        for quick in (False, True):
+            path = result_path(experiment_name, quick=quick)
+            assert path.is_relative_to(RUNTIME_OUTPUT_ROOT)
+            assert "_data" not in path.parts
+
+
+def test_training_experiment_output_dirs_default_to_runtime_tree():
+    for output_dir in (Path(exp79.DATA_DIR),):
+        assert output_dir.is_relative_to(RUNTIME_OUTPUT_ROOT)
+        assert "_data" not in output_dir.parts
+
+    exp83_source = Path("experiments/exp83_slot_attention.py").read_text(encoding="utf-8")
+    assert 'DATA_DIR = str(experiment_output_dir("exp83_slot_attention"))' in exp83_source
+
+
+def test_data_generators_default_to_runtime_tree():
+    default_markers = {
+        "experiments/exp60a_kinship_traces.py": 'experiment_output_dir("exp60a_kinship_traces")',
+        "experiments/exp60d_sft.py": 'experiment_output_dir("exp60d_sft")',
+        "experiments/exp76a_rule_traces.py": 'experiment_output_dir("exp76a_rule_traces")',
+        "experiments/exp76b_hard_eval.py": 'experiment_output_dir("exp76b_hard_eval")',
+        "experiments/exp76c_paraphrase_train.py": 'experiment_output_dir("exp76c_paraphrase_train")',
+    }
+
+    for script, marker in default_markers.items():
+        assert marker in Path(script).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add shared ignored runtime output paths under runtime_outputs/experiments.
- Move experiment and data-generator defaults away from committed experiments/*_data fixtures while preserving explicit fixture refresh flags.
- Document the runtime-vs-fixture boundary and add regression tests for ignored defaults.

## Validation
- python3 -m pytest -q
- git diff --check
- python3 experiments/exp60a_kinship_traces.py --hard --n 1