### PR TITLE
Reject malformed TL comma lists

### DIFF
--- a/tensor_logic/file_format.py
+++ b/tensor_logic/file_format.py
@@ -105,4 +105,8 @@ def _logical_lines(path: str):
 def _split_items(text: str) -> list[str]:
     if not text:
         return []
+    if "," in text:
+        chunks = text.split(",")
+        if any(not chunk.strip() for chunk in chunks):
+            raise ValueError(f"empty item in list: {text!r}")
     return [item.strip() for item in re.split(r"[,\s]+", text) if item.strip()]

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -489,6 +489,18 @@ class TensorLogicCoreTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 load_tl(a_path)
 
+    def test_tl_file_rejects_empty_comma_items(self):
+        import tempfile, os
+        from tensor_logic.file_format import load_tl
+        with tempfile.NamedTemporaryFile("w", suffix=".tl", delete=False, encoding="utf-8") as f:
+            f.write("domain Node { a,, b }\n")
+            path = f.name
+        try:
+            with self.assertRaisesRegex(ValueError, r"empty item in list"):
+                load_tl(path)
+        finally:
+            os.unlink(path)
+
     def test_proof_json_roundtrip(self):
         from tensor_logic import format_proof_result
         from tensor_logic.proofs import Proof


### PR DESCRIPTION
## Summary
- Reject empty comma-separated items in .tl parser lists instead of silently dropping them
- Add a negative loader test for malformed domain input

## Validation
- python3 -m pytest -q
- git diff --check