### PR TITLE
WP-197: Harden TL command flag parsing

### DIFF
--- a/tensor_logic/file_format.py
+++ b/tensor_logic/file_format.py
@@ -71,7 +71,7 @@ def _parse_line(program: Program, line: str, path: str = "", lineno: int = 0) ->
         program.rule(match.group("rule"))
         return None
     if match := QUERY_RE.match(line):
-        flags = set(_split_items(match.group("flags").strip()))
+        flags = _parse_command_flags(match.group("flags").strip())
         return Command(
             match.group("kind"),
             match.group("rel"),
@@ -80,6 +80,16 @@ def _parse_line(program: Program, line: str, path: str = "", lineno: int = 0) ->
         )
     keywords = "domain, relation, fact, rule, query, prove"
     raise ValueError(f"unrecognized statement: {line!r} (expected one of: {keywords})")
+
+
+def _parse_command_flags(text: str) -> set[str]:
+    flags = set(_split_items(text))
+    unknown = flags - {"recursive"}
+    if unknown:
+        allowed = "recursive"
+        found = ", ".join(sorted(unknown))
+        raise ValueError(f"unknown command flag(s): {found} (allowed: {allowed})")
+    return flags
 
 
 def _logical_lines(path: str):

--- a/tests/test_tensor_logic_core.py
+++ b/tests/test_tensor_logic_core.py
@@ -187,6 +187,29 @@ class TensorLogicCoreTest(unittest.TestCase):
         self.assertEqual(proof.head, ("depends_on", "worker", "models"))
         self.assertGreater(len(proof.body), 0)
 
+    def test_tl_file_rejects_unknown_command_flag(self):
+        import tempfile
+        from pathlib import Path
+
+        source = "\n".join(
+            [
+                "domain Node { a b c }",
+                "relation edge(Node, Node)",
+                "relation path(Node, Node)",
+                "fact edge(a, b)",
+                "fact edge(b, c)",
+                "rule path(x,y) := edge(x,y).step()",
+                "rule path(x,y) := edge(x,z) * path(z,y).step()",
+                "query path(a, c) recursvie",
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "bad_flag.tl"
+            path.write_text(source, encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "unknown command flag\\(s\\): recursvie"):
+                load_tl(str(path))
+
     def test_rule_aware_proof_with_witness(self):
         loaded = load_tl("examples/personal_memory.tl")
         proof = prove(loaded.program, "should_follow_up", "ryan", "tensor_demo")


### PR DESCRIPTION
## Summary
- Reject unknown .tl query/prove command flags instead of silently ignoring them
- Add a negative parser test for a misspelled recursive flag

## Validation
- python3 -m pytest -q
- git diff --check

## Residual risk
- Low; behavior change is limited to malformed .tl command flags. Valid existing recursive command syntax remains unchanged.